### PR TITLE
update gitignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,7 +2,6 @@
 ^\.Rproj\.user$
 ^_pkgdown\.yml$
 ^pkgdown$
-^doc$
 ^docs$
 ^LICENSE$
 ^LICENSES_THIRD_PARTY$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,6 +2,7 @@
 ^\.Rproj\.user$
 ^_pkgdown\.yml$
 ^pkgdown$
+^doc$
 ^docs$
 ^LICENSE$
 ^LICENSES_THIRD_PARTY$

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .Rhistory
 .RData
 .Ruserdata
-^tests/testthat/_snaps$
+docs
+doc

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
-docs
-doc
+docs/


### PR DESCRIPTION
- we should keep snapshot testing results.
- ignore `doc` or `docs` to avoid people accidentally upload `pkgdown` results from local.