### PR TITLE
bug fix #29: resolve non-binding probability = NULL

### DIFF
--- a/R/gs_design_combo.R
+++ b/R/gs_design_combo.R
@@ -158,6 +158,16 @@ gs_design_combo <- function(enrollRates = tibble(Stratum = "All",
   theta_fh <- utility$theta
   corr_fh  <- utility$corr
   
+  # --------------------------------------------- #
+  #     check design type                         #
+  # --------------------------------------------- #
+  K <- length(info)
+  if(identical(lower, gs_b) & (!is.list(lpar))){
+    two_sided <- ifelse(identical(lpar, rep(-Inf, K)), FALSE, TRUE)
+  }else{
+    two_sided <- TRUE
+  }
+  
   # Information Fraction
   if(n_analysis == 1){
     min_info_frac <- 1
@@ -214,15 +224,11 @@ gs_design_combo <- function(enrollRates = tibble(Stratum = "All",
   
   # Probability Cross Boundary under Null
   prob_null <- gs_prob_combo(upper_bound = bound$upper,
-                             lower_bound = if(binding){bound$lower}else{rep(-Inf, nrow(bound))},
+                             lower_bound = if(two_sided){bound$lower}else{rep(-Inf, nrow(bound))},
                              analysis = info_fh$Analysis,
                              theta = rep(0, nrow(info_fh)),
                              corr = corr_fh,
                              algorithm = algorithm, ...)
-  
-  # if(binding == FALSE){
-  #   prob_null$Probability[prob_null$Bound == "Lower"] <- NA
-  # }
   
   prob$Probability_Null <- prob_null$Probability
   

--- a/R/gs_design_npe.R
+++ b/R/gs_design_npe.R
@@ -415,8 +415,8 @@ gs_design_npe <- function(theta = .1, theta0 = NULL, theta1 = NULL,    # 3 theta
                          info = info0 * inflation_factor, info0 = info0 * inflation_factor, info1 = info1 * inflation_factor,
                          info_scale = info_scale,
                          upper = upper, upar = upar, 
-                         lower = if(!two_sided | !binding){gs_b}else{lower}, 
-                         lpar = if(!two_sided | !binding){rep(-Inf, K)}else{lpar},
+                         lower = if(!two_sided){gs_b}else{lower}, 
+                         lpar = if(!two_sided){rep(-Inf, K)}else{lpar},
                          test_upper = test_upper, test_lower = test_lower,
                          binding = binding, r = r, tol = tol)
   

--- a/tests/testthat/test-independent-gs_design_npe.R
+++ b/tests/testthat/test-independent-gs_design_npe.R
@@ -100,8 +100,13 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 b
   expect_equal(gsd$n.I, (gsdv %>% filter(Bound == "Upper"))$info, tolerance = .04) 
   
   # compare crossing boundaries probability under null hypothesis (theta = 0)
-  expect_equal((gsdv %>% filter(Bound == "Upper"))$Probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
-  expect_equal((gsdv %>% filter(Bound == "Lower"))$Probability, sfl(alpha = beta, t = timing, param = sflpar)$spend)
+  expect_equal(gsdv$Probability0, 
+               gsDesign::gsBoundSummary(gsd) %>% subset(Value == "P(Cross) if delta=0") %>% select(Efficacy, Futility) %>% t() %>% as.numeric(),
+               tolerance = .0001)
+  
+  expect_equal(gsdv$Probability, 
+               gsDesign::gsBoundSummary(gsd) %>% subset(Value == "P(Cross) if delta=1") %>% select(Efficacy, Futility) %>% t() %>% as.numeric(),
+               tolerance = .0001)
 })
 
 


### PR DESCRIPTION
The PR is to address #29 

After the PR, the probability 0 is calculated with lower bound under non-binding situation for `gs_design_ahr`, `gs_design_wlr` and `gs_design_combo`. 

```
devtools::load_all()

library(dplyr)
library(gsDesign2)

my_enrollRates <- tibble::tibble(
  Stratum = "All",
  duration = 12,
  rate = 500 / 12
)

my_failRates <- tibble::tibble(
  Stratum = "All",
  duration = c(4, 100),
  failRate = log(2) / 15, # median survival 15 month
  hr = c(1, .6),
  dropoutRate = 0.001
)

my_ratio <- 1
my_alpha <- 0.025
my_beta <- 0.2
my_power <- 1 - my_beta

my_analysisTimes <- c(12, 24, 36)

my_fh_test1 <- rbind(
  data.frame(
    rho = 0, gamma = 0, tau = -1,
    test = 1,
    Analysis = 1:3,
    analysisTimes = my_analysisTimes
  ),
  data.frame(
    rho = c(0, 0.5), gamma = 0.5, tau = -1,
    test = 2:3,
    Analysis = 3, analysisTimes = 36
  )
)

my_combo <- gsDesign2::gs_design_combo(
  enrollRates = my_enrollRates,
  failRates = my_failRates,
  fh_test = my_fh_test1,
  alpha = my_alpha,
  beta = my_beta,
  ratio = my_ratio,
  # test.type = 4 non-binding futility bound
  binding = FALSE,
  # alpha spending
  upper = gs_spending_combo,
  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
  # beta spending
  lower = gs_spending_combo,
  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2))

my_combo

my_ahr <- gsDesign2::gs_design_ahr(
  enrollRates = my_enrollRates,
  failRates = my_failRates,
  ratio = my_ratio,
  alpha = my_alpha,
  beta = my_beta,
  analysisTimes = my_analysisTimes,
  # test.type = 4 non-binding futility bound
  binding = FALSE,
  # alpha spending
  upper = gs_b,
  upar = c(3.77, 2.35, 2.01),
  # beta spending
  lower = gs_b,
  lpar = c(-1.19, 1.13, 2.01))

my_ahr


my_ahr <- gsDesign2::gs_design_ahr(
  enrollRates = my_enrollRates,
  failRates = my_failRates,
  ratio = my_ratio,
  alpha = my_alpha,
  beta = my_beta,
  analysisTimes = my_analysisTimes,
  # test.type = 4 non-binding futility bound
  binding = FALSE,
  # alpha spending
  upper = gs_spending_bound,
  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
  # beta spending
  lower = gs_spending_bound,
  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2))

my_ahr


my_wlr <- gsDesign2::gs_design_wlr(
  enrollRates = my_enrollRates,
  failRates = my_failRates,
  weight = function(x, arm0, arm1){wlr_weight_fh(x, arm0, arm1, rho = 0, gamma = 0.5, tau = -1)},
  analysisTimes = my_analysisTimes,
  alpha = my_alpha,
  beta = my_beta,
  ratio = my_ratio,
  # test.type = 4 non-binding futility bound
  binding = FALSE,
  # alpha spending
  upper = gs_spending_bound,
  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
  # beta spending
  lower = gs_spending_bound,
  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2))

round(my_wlr$bounds$Probability0, digits = 4)




my_combo <- gsDesign2::gs_design_combo(
  enrollRates = my_enrollRates,
  failRates = my_failRates,
  fh_test = my_fh_test1,
  alpha = my_alpha,
  beta = my_beta,
  ratio = my_ratio,
  # test.type = 4 non-binding futility bound
  binding = FALSE,
  # alpha spending
  upper = gs_spending_combo,
  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
  # beta spending
  lower = gs_spending_combo,
  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2))

round(my_combo$bounds$Probability0, 4)
```

