### PR TITLE
Add vignette on accuracy of group sequential bounds

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -147,6 +147,10 @@ articles:
   contents: 
   - starts_with("usage_")
 
+- title: "Best practices"
+  contents:
+  - starts_with("best_practice_")
+
 - title: "Style guide"
   contents: 
   - style

--- a/vignettes/best_practice_npe_accuracy.Rmd
+++ b/vignettes/best_practice_npe_accuracy.Rmd
@@ -1,0 +1,115 @@
+---
+title: "Accuracy of group sequential bounds"
+author: "Keaven M. Anderson, Yujie Zhao, and Nan Xiao"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Accuracy of group sequential bounds}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r, warning=FALSE, message=FALSE}
+library(gsDesign2)
+library(dplyr)
+library(tidyr)
+library(gt)
+```
+
+The preliminary evaluation below suggests sticking with the default numerical
+integration parameter `r=18` and default Newton-Raphson convergence criterion
+for bounds of `tol=1e-06` is sensible. Increasing digits even this far is
+probably a stretch for the underlying asymptotic normal approximation and
+would give a false sense of accuracy of p-values computed.
+To get the numerical integration to stabilize through even 8 digits would
+seem to require an unclear and substantial increase in grid points.
+Thus, we recommend not reporting more than 6 digits for p-values and Z-values
+for decision making at time of interim analysis. When results are close to
+bounds, there are other practical reasons to be cautious when near a boundary.
+For example, changing results for a single observation can reverse a boundary
+crossing evaluation. This type of exercise may be worth considering for a
+close call and also stresses the importance of as clean a dataset as
+possible at the time of a database lock.
+
+```{r}
+gs_power_grid <- function(n_analysis, r, tol, sf = gsDesign::sfLDOF, sfname = "OBF", param = NULL, alpha = .025) {
+  x <- gs_power_npe(
+    theta = rep(0.1, n_analysis),
+    theta0 = NULL,
+    theta1 = NULL,
+    info = 1:n_analysis,
+    info0 = 1:n_analysis,
+    info1 = NULL,
+    info_scale = 0,
+    upper = gs_spending_bound,
+    upar = list(sf = sf, total_spend = alpha, param = param, timing = NULL),
+    lower = gs_b,
+    lpar = -rep(Inf, n_analysis),
+    test_upper = TRUE,
+    test_lower = FALSE,
+    binding = FALSE,
+    r = r,
+    tol = tol
+  )
+  x %>%
+    filter(abs(Z) < Inf) %>%
+    transmute(sf = sfname, param = param, r = r, Analysis = Analysis, Z = Z, p = pnorm(-Z), tol = tol)
+}
+```
+
+```{r}
+params <- expand.grid(
+  n_analysis = 5,
+  r = c(6, 18, 24, 30, 35, 40, 50, 60, 70, 80, 90, 100),
+  tol = c(1e-6, 1e-12)
+)
+
+y <- mapply(
+  gs_power_grid,
+  n_analysis = params$n_analysis,
+  r = params$r,
+  tol = params$tol,
+  SIMPLIFY = FALSE
+) %>%
+  dplyr::bind_rows()
+```
+
+```{r}
+y %>%
+  filter(Analysis == 5) %>%
+  select(-p) %>%
+  pivot_wider(names_from = tol, values_from = Z) %>%
+  gt() %>%
+  tab_header(
+    "Z-value cutoffs by accuracy control parameters",
+    subtitle = "r controls grid size, tol sets convergence criterion"
+  ) %>%
+  tab_spanner(
+    label = "Z-value",
+    columns = c("1e-06", "1e-12")
+  ) %>%
+  fmt_number(col = 4:5, decimals = 12)
+```
+
+```{r}
+y %>%
+  filter(Analysis == 5) %>%
+  select(-Z) %>%
+  pivot_wider(names_from = tol, values_from = p) %>%
+  gt() %>%
+  tab_header(
+    "p-value cutoffs by accuracy control parameters",
+    subtitle = "r controls grid size, tol sets convergence criterion"
+  ) %>%
+  tab_spanner(
+    label = "p-value",
+    columns = c("1e-06", "1e-12")
+  ) %>%
+  fmt_number(col = 4:5, decimals = 12)
+```


### PR DESCRIPTION
This PR adds a vignette from Keaven on the numerical accuracy of group sequential bounds.

The vignette contains a preliminary examination on some key design parameters and gives a tentative recommendation, adequate to suggesting stopping the practice of reporting more than 6 digits for p-value boundaries. Beside numerical accuracy, this also highlights the importance of a single, clean locked database at the time of analysis before unblinding.

Future extensions to binomial and TTE endpoints would be awesome.