### PR TITLE
Use literal style `|` multiline string instead of `>`

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -3,13 +3,15 @@ output: github_document
 # The following code customizes the Knit button behavior to remove
 # redundant CSS from the rendered README.md for proper display on GitHub.
 # You do not need it for HTML, PDF, or other output formats.
-knit: >
+knit: |
   (function(inputFile, encoding) {
     rmarkdown::render(input = inputFile, encoding = encoding)
     output <- paste0(basename(tools::file_path_sans_ext(inputFile)), ".md")
-    content_old <- paste0(readLines(output), collapse = "\n")
-    content_new <- gsub("<style>.*?</style>", replacement = "", content_old)
-    writeLines(content_new, con = output)
+    output |>
+      readLines() |>
+      paste0(collapse = "\n") |>
+      gsub("<style>.*?</style>", replacement = "", x = _) |>
+      writeLines(con = output)
     invisible(output)
   })
 ---


### PR DESCRIPTION
This PR replaces `>` with the literal style multiline string `|` for the YAML header field `knit`, although `>` also worked before.

Also uses pipes in the R function to avoid intermediate variables.