### PR TITLE
Issue 139

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^\.github$
 ^codecov\.yml$
 ^README\.Rmd$
+^\.lintr$

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,11 @@
+linters:
+    linters_with_defaults(
+      # "No visible binding for global variable"
+      object_usage_linter = NULL,
+      # "Line should not be more than 80 characters"
+      line_length_linter(120)
+    )
+exclusions:
+    list(
+      "inst/"
+    )

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -527,7 +527,7 @@ as_gt.gs_design <- function(x,
   }
 
   ## if it is non-binding design
-  if (x_non_binding & (x_alpha < full_alpha)) {
+  if (x_non_binding && (x_alpha < full_alpha)) {
     x <- x %>%
       gt::tab_footnote(
         footnote = paste0(

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -489,7 +489,7 @@ as_gt.gs_design <- function(x,
   # --------------------------------------------- #
   if (!is.null(footnote$content)) {
     if (length(footnote$content) != 0) {
-      for (i in 1:length(footnote$content)) {
+      for (i in seq_along(footnote$content)) {
         # if the footnotes is added on the colnames
         if (footnote$attr[i] == "colname") {
           x <- x %>%

--- a/R/fixed_design.R
+++ b/R/fixed_design.R
@@ -133,19 +133,19 @@ fixed_design <- function(method = c("ahr", "fh", "mb", "lf", "rd", "maxcombo", "
   }
 
   # check test parameters, like rho, gamma, tau
-  if (has_rho & length(args$rho) > 1 & x %in% c("fh", "mb")) {
+  if (has_rho && length(args$rho) > 1 && x %in% c("fh", "mb")) {
     stop("fixed_design: multiple rho can not be used in Fleming-Harrington or Magirr-Burman method!")
   }
-  if (has_gamma & length(args$gamma) > 1 & x %in% c("fh", "mb")) {
+  if (has_gamma && length(args$gamma) > 1 && x %in% c("fh", "mb")) {
     stop("fixed_design: multiple gamma can not be used in Fleming-Harrington or Magirr-Burman method!")
   }
-  if (has_tau & length(args$tau) > 1 & x %in% c("fh", "mb")) {
+  if (has_tau && length(args$tau) > 1 && x %in% c("fh", "mb")) {
     stop("fixed_design: multiple tau can not be used in Fleming-Harrington or Magirr-Burman method!")
   }
-  if (has_tau & x == "fh") {
+  if (has_tau && x == "fh") {
     stop("fixed_design: tau is not needed for Fleming-Harrington (FH) method!")
   }
-  if (has_rho & has_gamma & x == "mb") {
+  if (has_rho && has_gamma && x == "mb") {
     stop("fixed_design: rho and gamma are not needed for Magirr-Burman (MB) method!")
   }
 

--- a/R/gs_design_ahr.R
+++ b/R/gs_design_ahr.R
@@ -197,7 +197,7 @@ gs_design_ahr <- function(enroll_rate = tibble(stratum = "All", duration = c(2, 
   # --------------------------------------------- #
   check_analysis_time(analysis_time)
   check_info_frac(info_frac)
-  if ((length(analysis_time) > 1) & (length(info_frac) > 1) & (length(info_frac) != length(analysis_time))) {
+  if ((length(analysis_time) > 1) && (length(info_frac) > 1) && (length(info_frac) != length(analysis_time))) {
     stop("gs_design_ahr() info_frac and analysis_time must have the same length if both have length > 1!")
   }
 

--- a/R/gs_design_ahr.R
+++ b/R/gs_design_ahr.R
@@ -58,7 +58,7 @@ NULL
 #' @param tol Tolerance parameter for boundary convergence (on Z-scale)
 #' @param interval An interval that is presumed to include the time at which
 #' expected event count is equal to targeted event.
-#' 
+#'
 #' @section Specification:
 #' \if{latex}{
 #'  \itemize{

--- a/R/gs_design_combo.R
+++ b/R/gs_design_combo.R
@@ -177,7 +177,7 @@ gs_design_combo <- function(enroll_rate = tibble(
   #     check design type                         #
   # --------------------------------------------- #
 
-  if (identical(lower, gs_b) & (!is.list(lpar))) {
+  if (identical(lower, gs_b) && (!is.list(lpar))) {
     two_sided <- ifelse(identical(lpar, rep(-Inf, n_analysis)), FALSE, TRUE)
   } else {
     two_sided <- TRUE

--- a/R/gs_design_npe.R
+++ b/R/gs_design_npe.R
@@ -301,7 +301,7 @@ gs_design_npe <- function(theta = .1, theta0 = NULL, theta1 = NULL, # 3 theta
   # --------------------------------------------- #
   #     check design type                         #
   # --------------------------------------------- #
-  if (identical(lower, gs_b) & (!is.list(lpar))) {
+  if (identical(lower, gs_b) && (!is.list(lpar))) {
     two_sided <- ifelse(identical(lpar, rep(-Inf, K)), FALSE, TRUE)
   } else {
     two_sided <- TRUE

--- a/R/gs_design_wlr.R
+++ b/R/gs_design_wlr.R
@@ -147,7 +147,7 @@ gs_design_wlr <- function(enroll_rate = tibble(
   if (min(info_frac - dplyr::lag(info_frac, def = 0)) <= 0) stop(msg)
   if (max(info_frac) != 1) stop(msg)
   msg <- "gs_design_wlr(): info_frac and analysis_time must have the same length if both have length > 1"
-  if ((length(analysis_time) > 1) & (length(info_frac) > 1) & (length(info_frac) != length(analysis_time))) stop(msg)
+  if ((length(analysis_time) > 1) && (length(info_frac) > 1) && (length(info_frac) != length(analysis_time))) stop(msg)
   # get the info_scale
   info_scale <- if (methods::missingArg(info_scale)) {
     2

--- a/R/gs_design_wlr.R
+++ b/R/gs_design_wlr.R
@@ -20,7 +20,7 @@
 #'
 #' @import tibble tibble
 #' @importFrom dplyr all_of
-#' 
+#'
 #' @inheritParams gs_design_ahr
 #' @inheritParams gs_info_wlr
 #' @section Specification:

--- a/R/gs_info_ahr.R
+++ b/R/gs_info_ahr.R
@@ -161,7 +161,7 @@ gs_info_ahr <- function(enroll_rate = tibble::tibble(
   # ----------------------------#
   #    compute theta            #
   # ----------------------------#
-  avehr$Analysis <- 1:nrow(avehr)
+  avehr$Analysis <- seq_len(nrow(avehr))
   avehr$theta <- -log(avehr$AHR)
 
   # ----------------------------#

--- a/R/gs_info_ahr.R
+++ b/R/gs_info_ahr.R
@@ -30,7 +30,7 @@ NULL
 #' @param analysis_time Targeted minimum study duration at each analysis
 #' @param interval An interval that is presumed to include the time at which
 #' expected event count is equal to targeted event.
-#' 
+#'
 #' @section Specification:
 #' \if{latex}{
 #'  \itemize{
@@ -94,11 +94,10 @@ gs_info_ahr <- function(enroll_rate = tibble::tibble(
                           hr = c(.9, .6),
                           dropout_rate = rep(.001, 2)
                         ),
-                        ratio = 1,            # Experimental:Control randomization ratio
-                        event = NULL,         # event at analyses
+                        ratio = 1, # Experimental:Control randomization ratio
+                        event = NULL, # event at analyses
                         analysis_time = NULL, # Times of analyses
-                        interval = c(.01, 100)
-) {
+                        interval = c(.01, 100)) {
   # ----------------------------#
   #    check input values       #
   # ----------------------------#

--- a/R/gs_info_wlr.R
+++ b/R/gs_info_wlr.R
@@ -36,7 +36,7 @@
 #' - `"asymptotic"`
 #' @param interval An interval that is presumed to include the time at which
 #' expected event count is equal to targeted event.
-#' 
+#'
 #' @return a \code{tibble} with columns \code{Analysis, Time, N, Events, AHR, delta, sigma2, theta, info, info0.}
 #' \code{info, info0} contains statistical information under H1, H0, respectively.
 #' For analysis \code{k}, \code{Time[k]} is the maximum of \code{analysis_time[k]} and the expected time
@@ -91,8 +91,7 @@ gs_info_wlr <- function(enroll_rate = tibble::tibble(
                         analysis_time = NULL, # Times of analyses
                         weight = wlr_weight_fh,
                         approx = "asymptotic",
-                        interval = c(.01, 100)
-                        ) {
+                        interval = c(.01, 100)) {
   if (is.null(analysis_time) && is.null(event)) {
     stop("gs_info_wlr(): One of event and analysis_time must be a numeric value or vector with increasing values!")
   }

--- a/R/gs_info_wlr.R
+++ b/R/gs_info_wlr.R
@@ -176,7 +176,7 @@ gs_info_wlr <- function(enroll_rate = tibble::tibble(
   N <- tail(avehr$Events / p_event, 1) * p_subject
   theta <- (-delta) / sigma2_h1
   data.frame(
-    Analysis = 1:length(time),
+    Analysis = seq_along(time),
     Time = time,
     N = N,
     Events = avehr$Events,

--- a/R/gs_power_ahr.R
+++ b/R/gs_power_ahr.R
@@ -180,7 +180,7 @@ gs_power_ahr <- function(enroll_rate = tibble(
   }
 
   # Check if it is two-sided design or not
-  if (identical(lower, gs_b) & (!is.list(lpar))) {
+  if (identical(lower, gs_b) && (!is.list(lpar))) {
     two_sided <- ifelse(identical(lpar, rep(-Inf, K)), FALSE, TRUE)
   } else {
     two_sided <- TRUE

--- a/R/gs_power_ahr.R
+++ b/R/gs_power_ahr.R
@@ -181,7 +181,7 @@ gs_power_ahr <- function(enroll_rate = tibble(
   }
 
   # Check if it is two-sided design or not
-  if (identical(lower, gs_b) & (!is.list(lpar))) {
+  if (identical(lower, gs_b) && (!is.list(lpar))) {
     if (all(test_lower) == FALSE) {
       two_sided <- FALSE
       lpar <- rep(-Inf, K)

--- a/R/gs_power_ahr.R
+++ b/R/gs_power_ahr.R
@@ -62,7 +62,7 @@ NULL
 #' @param tol Tolerance parameter for boundary convergence (on Z-scale)
 #' @param interval An interval that is presumed to include the time at which
 #' expected event count is equal to targeted event.
-#' 
+#'
 #' @section Specification:
 #' \if{latex}{
 #'  \itemize{

--- a/R/summary.R
+++ b/R/summary.R
@@ -308,7 +308,7 @@ summary.gs_design <- function(object,
   #     prepare the columns decimals              #
   # --------------------------------------------- #
   if (method == "ahr") {
-    if (is.null(col_vars) & is.null(col_decimals)) {
+    if (is.null(col_vars) && is.null(col_decimals)) {
       x_decimals <- tibble::tibble(
         col_vars = c("Analysis", "Bound", "Z", "~HR at bound", "Nominal p", "Alternate hypothesis", "Null hypothesis"),
         col_decimals = c(NA, NA, 2, 4, 4, 4, 4)
@@ -319,7 +319,7 @@ summary.gs_design <- function(object,
   }
 
   if (method == "wlr") {
-    if (is.null(col_vars) & is.null(col_decimals)) {
+    if (is.null(col_vars) && is.null(col_decimals)) {
       x_decimals <- tibble::tibble(
         col_vars = c("Analysis", "Bound", "Z", "~wHR at bound", "Nominal p", "Alternate hypothesis", "Null hypothesis"),
         col_decimals = c(NA, NA, 2, 4, 4, 4, 4)
@@ -330,7 +330,7 @@ summary.gs_design <- function(object,
   }
 
   if (method == "combo") {
-    if (is.null(col_vars) & is.null(col_decimals)) {
+    if (is.null(col_vars) && is.null(col_decimals)) {
       x_decimals <- tibble::tibble(
         col_vars = c("Analysis", "Bound", "Z", "Nominal p", "Alternate hypothesis", "Null hypothesis"),
         col_decimals = c(NA, NA, 2, 4, 4, 4)
@@ -341,7 +341,7 @@ summary.gs_design <- function(object,
   }
 
   if (method == "rd") {
-    if (is.null(col_vars) & is.null(col_decimals)) {
+    if (is.null(col_vars) && is.null(col_decimals)) {
       x_decimals <- tibble::tibble(
         col_vars = c("Analysis", "Bound", "Z", "~Risk difference at bound", "Nominal p", "Alternate hypothesis", "Null hypothesis"),
         col_decimals = c(NA, NA, 2, 4, 4, 4, 4)
@@ -357,7 +357,7 @@ summary.gs_design <- function(object,
   # get the
   # (1) analysis variables to be displayed on the header
   # (2) decimals to be displayed for the analysis variables in (3)
-  if (is.null(analysis_vars) & is.null(analysis_decimals)) {
+  if (is.null(analysis_vars) && is.null(analysis_decimals)) {
     if (method %in% c("ahr", "wlr")) {
       analysis_vars <- c("Time", "N", "Events", "AHR", "info_frac")
       analysis_decimals <- c(1, 1, 1, 2, 2)
@@ -370,9 +370,9 @@ summary.gs_design <- function(object,
       analysis_vars <- c("N", "rd", "info_frac")
       analysis_decimals <- c(1, 4, 2)
     }
-  } else if (is.null(analysis_vars) & !is.null(analysis_decimals)) {
+  } else if (is.null(analysis_vars) && !is.null(analysis_decimals)) {
     stop("summary: please input analysis_vars and analysis_decimals in pairs!")
-  } else if (!is.null(analysis_vars) & is.null(analysis_decimals)) {
+  } else if (!is.null(analysis_vars) && is.null(analysis_decimals)) {
     stop("summary: please input analysis_vars and analysis_decimals in pairs!")
   }
 
@@ -534,7 +534,7 @@ summary.gs_design <- function(object,
       (x_decimals %>% filter(col_vars == "Alternate hypothesis"))$col_decimals
     )
   }
-  if ("Null hypothesis" %in% colnames(output) & is.vector(output[["Null hypothesis"]], mode = "numeric")) {
+  if ("Null hypothesis" %in% colnames(output) && is.vector(output[["Null hypothesis"]], mode = "numeric")) {
     output <- output %>% dplyr::mutate_at(
       "Null hypothesis",
       round,

--- a/R/to_integer.R
+++ b/R/to_integer.R
@@ -98,7 +98,7 @@ to_integer.fixed_design <- function(x, sample_size = TRUE, ...) {
   multiply_factor <- x$input$ratio + 1
   enroll_rate_new <- x$enroll_rate %>% mutate(rate = rate * ceiling(output_N / multiply_factor) * multiply_factor / output_N)
 
-  if (x$design == "ahr" & input_N != output_N) {
+  if ((x$design == "ahr") && (input_N != output_N)) {
     x_new <- gs_power_ahr(
       enroll_rate = enroll_rate_new,
       fail_rate = x$input$fail_rate,
@@ -124,7 +124,7 @@ to_integer.fixed_design <- function(x, sample_size = TRUE, ...) {
     )
 
     class(ans) <- c("fixed_design", class(ans))
-  } else if (x$design == "fh" & input_N != output_N) {
+  } else if ((x$design == "fh") && (input_N != output_N)) {
     x_new <- gs_power_wlr(
       enroll_rate = enroll_rate_new,
       fail_rate = x$input$fail_rate,
@@ -156,7 +156,7 @@ to_integer.fixed_design <- function(x, sample_size = TRUE, ...) {
     )
 
     class(ans) <- c("fixed_design", class(ans))
-  } else if (x$design == "mb" & input_N != output_N) {
+  } else if ((x$design == "mb") && (input_N != output_N)) {
     x_new <- gs_power_wlr(
       enroll_rate = enroll_rate_new,
       fail_rate = x$input$fail_rate,

--- a/R/utility_combo.R
+++ b/R/utility_combo.R
@@ -165,7 +165,7 @@ pmvnorm_combo <- function(lower,
   }
 
   # One test for all group or lower bound is -Inf.
-  if (all(n_test == 1) | all(lower == -Inf)) {
+  if (all(n_test == 1) || all(lower == -Inf)) {
     p <- mvtnorm::pmvnorm(
       lower = rep(lower, n_test),
       upper = rep(upper, n_test),

--- a/R/utility_combo.R
+++ b/R/utility_combo.R
@@ -94,8 +94,8 @@ gs_utility_combo <- function(enroll_rate,
 
   # Overall Correlation
   corr_combo <- diag(1, nrow = nrow(info))
-  for (i in 1:nrow(info)) {
-    for (j in 1:nrow(info)) {
+  for (i in seq_len(nrow(info))) {
+    for (j in seq_len(nrow(info))) {
       t1 <- as.numeric(info$Analysis[i])
       t2 <- as.numeric(info$Analysis[j])
       if (t1 <= t2) {
@@ -202,7 +202,7 @@ pmvnorm_combo <- function(lower,
     k <- length(lower2)
     test_ind <- split(matrix(c(1, -1), nrow = k, ncol = 2, byrow = TRUE), 1:k)
     test_ind <- expand.grid(test_ind)
-    test <- split(test_ind, 1:nrow(test_ind))
+    test <- split(test_ind, seq_len(nrow(test_ind)))
 
     p <- sapply(test, function(x) {
       lower_bound <- rep(c(lower1, rep(-Inf, k)), n_test)
@@ -237,7 +237,7 @@ get_combo_weight <- function(rho, gamma, tau) {
   stopifnot(length(rho) == length(tau))
 
   weight <- list()
-  for (i in 1:length(rho)) {
+  for (i in seq_along(rho)) {
     if (tau[i] == -1) {
       tmp_tau <- NULL
     } else {
@@ -299,7 +299,7 @@ gs_sigma2_combo <- function(arm0,
   gamma1 <- outer(gamma, gamma, function(x, y) (x + y) / 2)
 
   sigma2 <- rho1
-  for (i in 1:length(rho)) {
+  for (i in seq_along(rho)) {
     weight <- get_combo_weight(rho1[i, ], gamma1[i, ], tau)
 
     sigma2[i, ] <- sapply(weight, function(x) {
@@ -440,7 +440,7 @@ gs_bound <- function(alpha,
                      beta,
                      theta,
                      corr,
-                     analysis = 1:length(alpha),
+                     analysis = seq_along(alpha),
                      theta0 = rep(0, length(analysis)),
                      binding_lower_bound = FALSE,
                      algorithm = GenzBretz(maxpts = 1e5, abseps = 1e-5),

--- a/R/utility_tidy_tbl.R
+++ b/R/utility_tidy_tbl.R
@@ -97,7 +97,7 @@ rounddf <- function(x, digits = rep(2, ncol(x)), func = round) {
     warning("First value in digits repeated to match length.")
   }
 
-  for (i in 1:ncol(x)) {
+  for (i in seq_len(ncol(x))) {
     if (class(x[, i, drop = TRUE])[1] == "numeric") x[, i] <- func(x[, i], digits[i])
   }
 

--- a/R/utility_wlr.R
+++ b/R/utility_wlr.R
@@ -172,7 +172,7 @@ gs_delta_wlr <- function(arm0,
   p0 <- 1 - p1
 
   if (approx == "event driven") {
-    if (sum(arm0$surv_shape != arm1$surv_shape) > 0 |
+    if (sum(arm0$surv_shape != arm1$surv_shape) > 0 ||
       length(unique(arm1$surv_scale / arm0$surv_scale)) > 1) {
       stop("gs_delta_wlr(): Hazard is not proportional over time.", call. = F)
     } else if (any(wlr_weight_fh(seq(0, tmax, length.out = 10), arm0, arm1) != "1")) {

--- a/tests/testthat/fixtures/simu_test_gs_design_combo.R
+++ b/tests/testthat/fixtures/simu_test_gs_design_combo.R
@@ -11,10 +11,10 @@ tenFHcorr <- function(x = simPWSurv(n = 200) %>%
   rg2 <- tibble(rho = as.numeric(rhoave), gamma = as.numeric(gamave))
   rgu <- rg2 %>% unique()
   rgFH <- rg2 %>% left_join(tenFH(x, rgu, returnVariance = TRUE), by = c("rho" = "rho", "gamma" = "gamma"))
-  Z <- rgFH$Z[(0:(nrow(rg) - 1)) * nrow(rg) + 1:nrow(rg)]
+  Z <- rgFH$Z[(0:(nrow(rg) - 1)) * nrow(rg) + seq_len(nrow(rg))]
   c <- matrix(rgFH$Var, nrow = nrow(rg), byrow = TRUE)
   if (corr) c <- stats::cov2cor(c)
-  names(c) <- paste("V", 1:ncol(c), sep = "")
+  names(c) <- paste("V", seq_len(ncol(c)), sep = "")
   cbind(rg, Z, as_tibble(c))
 }
 
@@ -43,7 +43,7 @@ sim_gsd_pMaxCombo_exp1_H0 <- function(N = ceiling(454.60),
 
   failRates0 <- tibble::tibble(
     Stratum = failRates$Stratum,
-    period = 1:nrow(failRates),
+    period = seq_len(nrow(failRates)),
     Treatment = "Control",
     duration = failRates$duration,
     rate = failRates$failRate
@@ -51,7 +51,7 @@ sim_gsd_pMaxCombo_exp1_H0 <- function(N = ceiling(454.60),
 
   failRates1 <- tibble::tibble(
     Stratum = failRates$Stratum,
-    period = 1:nrow(failRates),
+    period = seq_len(nrow(failRates)),
     Treatment = "Experimental",
     duration = failRates$duration,
     rate = failRates$failRate * failRates$hr
@@ -59,7 +59,7 @@ sim_gsd_pMaxCombo_exp1_H0 <- function(N = ceiling(454.60),
 
   dropoutRates0 <- tibble::tibble(
     Stratum = failRates$Stratum,
-    period = 1:nrow(failRates),
+    period = seq_len(nrow(failRates)),
     Treatment = "Control",
     duration = failRates$duration,
     rate = failRates$dropoutRate
@@ -67,7 +67,7 @@ sim_gsd_pMaxCombo_exp1_H0 <- function(N = ceiling(454.60),
 
   dropoutRates1 <- tibble::tibble(
     Stratum = failRates$Stratum,
-    period = 1:nrow(failRates),
+    period = seq_len(nrow(failRates)),
     Treatment = "Experimental",
     duration = failRates$duration,
     rate = failRates$dropoutRate
@@ -102,7 +102,7 @@ sim_gsd_pMaxCombo_exp1_H0 <- function(N = ceiling(454.60),
 
   # res <- bind_rows(lapply(time, foo, sim = sim)) # for example 2
   res <- NULL
-  for (t in 1:length(time)) {
+  for (t in seq_along(time)) {
     res <- bind_rows(res, foo(time[t], sim, rg = rg[[t]]))
   }
 
@@ -192,7 +192,7 @@ sim_gsd_pMaxCombo_exp1_H1 <- function(N = ceiling(454.60),
 
   failRates0 <- tibble::tibble(
     Stratum = failRates$Stratum,
-    period = 1:nrow(failRates),
+    period = seq_len(nrow(failRates)),
     Treatment = "Control",
     duration = failRates$duration,
     rate = failRates$failRate
@@ -200,7 +200,7 @@ sim_gsd_pMaxCombo_exp1_H1 <- function(N = ceiling(454.60),
 
   failRates1 <- tibble::tibble(
     Stratum = failRates$Stratum,
-    period = 1:nrow(failRates),
+    period = seq_len(nrow(failRates)),
     Treatment = "Experimental",
     duration = failRates$duration,
     rate = failRates$failRate * failRates$hr
@@ -208,7 +208,7 @@ sim_gsd_pMaxCombo_exp1_H1 <- function(N = ceiling(454.60),
 
   dropoutRates0 <- tibble::tibble(
     Stratum = failRates$Stratum,
-    period = 1:nrow(failRates),
+    period = seq_len(nrow(failRates)),
     Treatment = "Control",
     duration = failRates$duration,
     rate = failRates$dropoutRate
@@ -216,7 +216,7 @@ sim_gsd_pMaxCombo_exp1_H1 <- function(N = ceiling(454.60),
 
   dropoutRates1 <- tibble::tibble(
     Stratum = failRates$Stratum,
-    period = 1:nrow(failRates),
+    period = seq_len(nrow(failRates)),
     Treatment = "Experimental",
     duration = failRates$duration,
     rate = failRates$dropoutRate
@@ -253,7 +253,7 @@ sim_gsd_pMaxCombo_exp1_H1 <- function(N = ceiling(454.60),
 
   # res <- bind_rows(lapply(time, foo, sim = sim)) # for example 2
   res <- NULL
-  for (t in 1:length(time)) {
+  for (t in seq_along(time)) {
     res <- bind_rows(res, foo(time[t], sim, rg = rg[[t]]))
   }
 

--- a/tests/testthat/test-double_programming_ppwe.R
+++ b/tests/testthat/test-double_programming_ppwe.R
@@ -9,7 +9,7 @@ test_ppwe <- function(x = 0:20,
   max.x <- max(x)
 
   if (length(x) <= maxlen) {
-    for (t in 1:length(xvals)) {
+    for (t in seq_along(xvals)) {
       val <- xvals[t]
       if (val <= boundary[1]) {
         H[t] <- val * rate[1]
@@ -23,7 +23,7 @@ test_ppwe <- function(x = 0:20,
   } else {
     boundary1 <- boundary
     boundary1[2] <- max.x
-    for (t in 1:length(xvals)) {
+    for (t in seq_along(xvals)) {
       val <- xvals[t]
       if (val <= boundary1[1]) {
         H[t] <- val * rate[1]
@@ -57,7 +57,7 @@ test_2_ppwe <- function(x = 0:20,
   rate <- failRates$rate
   xvals <- unique(c(x, boundary))
   H <- numeric(length(xvals))
-  for (t in 1:length(xvals)) {
+  for (t in seq_along(xvals)) {
     val <- xvals[t]
     if (val <= boundary[1]) {
       H[t] <- val * rate[1]

--- a/tests/testthat/test-independent-expected_accrual.R
+++ b/tests/testthat/test-independent-expected_accrual.R
@@ -9,7 +9,7 @@ test_eAccrual <- function(x = 0:24,
   # maxlen=sum(enroll_rate$duration)
   # xvals1=xvals[xvals<=maxlen]
   eAc2 <- numeric(length(xvals))
-  for (t in 1:length(xvals)) {
+  for (t in seq_along(xvals)) {
     val <- xvals[t]
     if (val <= boundary[1]) {
       eAc2[t] <- val * rate[1]

--- a/tests/testthat/test-independent-expected_event.R
+++ b/tests/testthat/test-independent-expected_event.R
@@ -71,7 +71,7 @@ nEvent <- function(followup) {
 test_Event <- function(enrollRates, failRates, totalDuration) {
   enrolltime <- c(0, cumsum(enrollRates$duration))
   Event <- 0
-  for (i in c(1:length(enrollRates$duration))) {
+  for (i in seq_along(enrollRates$duration)) {
     enrollmentstart <- 0
     enrollmentend <- enrollRates$duration[i]
     enrollrate <- enrollRates$rate[i]

--- a/vignettes/story_ahr_under_nph.Rmd
+++ b/vignettes/story_ahr_under_nph.Rmd
@@ -413,7 +413,7 @@ to overall enrollment rates needed for `simtrial::simfix()`.
 ```{r, message=FALSE}
 er <- enroll_rate %>%
   group_by(stratum) %>%
-  mutate(period = 1:n()) %>%
+  mutate(period = seq_len(n())) %>%
   group_by(period) %>%
   summarise(rate = sum(rate), duration = last(duration))
 

--- a/vignettes/story_compute_expected_events.Rmd
+++ b/vignettes/story_compute_expected_events.Rmd
@@ -264,9 +264,9 @@ First, we sum the $\bar{n}_m$ values `sum(y$nbar)` to get `r round(sum(y$nbar),6
 Events <- gsDesign::eEvents(
   lambda = y$lambda,
   eta = y$eta,
-  gamma = y$gamma[length(y$gamma):1],
-  S = y$tdel[1:(length(y$tdel) - 1)],
-  R = y$tdel[(length(y$tdel):1)],
+  gamma = y$gamma[rev(seq_along(y$gamma))],
+  S = y$tdel[seq_len(length(y$tdel) - 1)],
+  R = y$tdel[rev(seq_along(y$tdel))],
   T = max(y$tm)
 )$d
 

--- a/vignettes/story_power_evaluation_with_spending_bound.Rmd
+++ b/vignettes/story_power_evaluation_with_spending_bound.Rmd
@@ -197,7 +197,7 @@ gs_info_binomial <- function(p1, p2, xi1, n, delta = NULL) {
   info1 <- n / (p1star * (1 - p1star) / xi1 + p2star * (1 - p2star) / (1 - xi1))
 
   out <- tibble(
-    Analysis = 1:length(n),
+    Analysis = seq_along(n),
     n = n,
     theta = theta,
     theta1 = rep(delta, length(n)),

--- a/vignettes/style.Rmd
+++ b/vignettes/style.Rmd
@@ -46,7 +46,7 @@ All user-facing interactions should have a functional API.
 
 Function names, argument names, and variable names should use `snake_case`.
 
-```{r}
+```r
 # Good
 gs_design_ahr <- function(enroll_rates = ...) {}
 
@@ -61,7 +61,7 @@ as they are inherently, functions.
 One should still follow the S3 convention to use dot (`.`) to
 connect the method name and class name.
 
-```{r}
+```r
 # Good
 as_gt.gsDesign <- function(...) {}
 
@@ -85,7 +85,7 @@ and follows the conventions in R6.
 
 The input argument names and variable names should still use `snake_case`.
 
-```{r}
+```r
 # Good
 RangedDoubleOrNULL <- new_class(
   "RangedDoubleOrNULL",
@@ -152,7 +152,7 @@ In contrast, optional arguments should have a default value.
 
 Use lower case abbreviations or `snake_case` for the enumerated type arguments.
 
-```{r}
+```r
 # Bad
 f <- function(method = c("AHR", "WLR", ...)) {}
 
@@ -160,7 +160,7 @@ f <- function(method = c("AHR", "WLR", ...)) {}
 f <- function(method = c("ahr", "wlr", ...)) {}
 ```
 
-```{r}
+```r
 # Bad
 f <- function(approx = c("event driven", "asymptotic", "generalized schoenfeld", ...)) {}
 

--- a/vignettes/usage_gs_info_ahr.Rmd
+++ b/vignettes/usage_gs_info_ahr.Rmd
@@ -141,7 +141,7 @@ AHR(
   enroll_rate = enroll_rate, fail_rate = fail_rate,
   ratio = ratio, total_duration = analysis_time
 ) %>%
-  mutate(theta = -log(AHR), Analysis = 1:length(analysis_time)) %>%
+  mutate(theta = -log(AHR), Analysis = seq_along(analysis_time)) %>%
   select(Analysis, Time, Events, AHR, theta, info, info0) %>%
   gt()
 ```
@@ -183,7 +183,7 @@ for (i in seq_along(events)) {
 }
 
 ans %>%
-  mutate(theta = -log(AHR), Analysis = 1:length(analysis_time)) %>%
+  mutate(theta = -log(AHR), Analysis = seq_along(analysis_time)) %>%
   select(Analysis, Time, Events, AHR, theta, info, info0) %>%
   gt()
 ```
@@ -241,7 +241,7 @@ for (i in seq_along(events)) {
 }
 
 ans %>%
-  mutate(theta = -log(AHR), Analysis = 1:length(analysis_time)) %>%
+  mutate(theta = -log(AHR), Analysis = seq_along(analysis_time)) %>%
   select(Analysis, Time, Events, AHR, theta, info, info0) %>%
   gt()
 ```


### PR DESCRIPTION
This PR fixes #139 (at least as an initial step).

- Added three lintr rules
  - Don't mark "No visible binding for global variable" issues as they are such a common false positive when non-standard evaluation is used.
  - Allow 120 characters per line, instead of the default 80 characters.
  - Exclude `inst/` from linting as it contains old code
- Fixed all code linting hints marked as "warning", especially on the use of `&&`/`||` and `seq_along()`/`seq_len()`. Now there are only 561 "style" hints. Reduced from 2000+ (!).

To see the linting issues identified as warning or style hints locally:

```r
x <- lintr::lint_package()
x[which(sapply(x, "[[", "type") == "warning")]
x[which(sapply(x, "[[", "type") == "style")]
```