### PR TITLE
Pass linting workflow

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -3,9 +3,63 @@ linters:
       # "No visible binding for global variable"
       object_usage_linter = NULL,
       # "Line should not be more than 80 characters"
-      line_length_linter(120)
+      line_length_linter(120),
+      # "Functions should have cyclomatic complexity of less than 15"
+      cyclocomp_linter(100)
     )
 exclusions:
     list(
-      "inst/"
+      "inst/",
+      "R/gridpts_h1_hupdate_rcpp_interface.R" = list(
+        object_name_linter = Inf
+      ),
+      "tests/testthat/fixtures/simu_test_gs_design_combo.R" = list(
+        object_name_linter = Inf,
+        commented_code_linter = Inf
+      ),
+      "tests/testthat/test-double_programming_ppwe.R" = list(
+        object_name_linter = Inf
+      ),
+      "tests/testthat/test-independent_test_gs_design_wlr.R" = list(
+        commented_code_linter = Inf
+      ),
+      "tests/testthat/test-independent_test_gs_info_wlr.R" = list(
+        object_name_linter = Inf,
+        commented_code_linter = Inf
+      ),
+      "tests/testthat/test-independent_test_wlr_weight.R" = list(
+        object_name_linter = Inf,
+        commented_code_linter = Inf
+      ),
+      "tests/testthat/test-independent-expected_accrual.R" = list(
+        object_name_linter = Inf,
+        commented_code_linter = Inf
+      ),
+      "tests/testthat/test-independent-expected_event.R" = list(
+        object_name_linter = Inf
+      ),
+      "tests/testthat/test-independent-expected_time.R" = list(
+        object_name_linter = Inf
+      ),
+      "tests/testthat/test-independent-gs_b.R" = list(
+        object_name_linter = Inf
+      ),
+      "tests/testthat/test-independent-gs_design_combo.R" = list(
+        object_name_linter = Inf
+      ),
+      "tests/testthat/test-independent-gs_design_npe.R" = list(
+        object_name_linter = Inf
+      ),
+      "tests/testthat/test-independent-gs_power_combo.R" = list(
+        object_name_linter = Inf
+      ),
+      "tests/testthat/test-independent-gs_power_npe.R" = list(
+        object_name_linter = Inf
+      ),
+      "tests/testthat/test-independent-h1.R" = list(
+        object_name_linter = Inf
+      ),
+      "tests/testthat/test-independent-hupdate.R" = list(
+        object_name_linter = Inf
+      )
     )

--- a/R/gs_design_wlr.R
+++ b/R/gs_design_wlr.R
@@ -226,7 +226,10 @@ gs_design_wlr <- function(enroll_rate = tibble(
       lower = lower, lpar = lpar, test_lower = test_lower,
       r = r, tol = tol
     ) %>%
-      full_join(y %>% select(-c(info, info0, theta)), by = "analysis") %>%
+      full_join(
+        y %>% select(-c(info, info0, theta)),
+        by = "analysis"
+      ) %>%
       select(c(
         "analysis", "bound", "time", "n", "event", "z",
         "probability", "probability0", "ahr",

--- a/R/gs_info_rd.R
+++ b/R/gs_info_rd.R
@@ -235,16 +235,22 @@ gs_info_rd <- function(p_c = tibble::tibble(
   } else if (weight == "ss") {
     suppressMessages(
       tbl <- tbl %>%
-        left_join(tbl %>% dplyr::group_by(analysis) %>% summarize(sum_ss = sum(n_c * n_e / (n_c + n_e)))) %>%
+        left_join(
+          tbl %>%
+            dplyr::group_by(analysis) %>%
+            summarize(sum_ss = sum(n_c * n_e / (n_c + n_e)))
+        ) %>%
         mutate(weight_per_k_per_s = n_c * n_e / (n_c + n_e) / sum_ss) %>%
         select(-sum_ss)
     )
   } else if (weight == "invar") {
     suppressMessages(
       tbl <- tbl %>%
-        left_join(tbl %>%
-          dplyr::group_by(analysis) %>%
-          summarize(sum_inv_var_per_s = sum(1 / sigma2_H0_per_k_per_s))) %>%
+        left_join(
+          tbl %>%
+            dplyr::group_by(analysis) %>%
+            summarize(sum_inv_var_per_s = sum(1 / sigma2_H0_per_k_per_s))
+        ) %>%
         mutate(weight_per_k_per_s = 1 / sigma2_H0_per_k_per_s / sum_inv_var_per_s) %>%
         select(-sum_inv_var_per_s)
     )

--- a/R/gs_power_rd.R
+++ b/R/gs_power_rd.R
@@ -334,7 +334,11 @@ gs_power_rd <- function(p_c = tibble::tibble(
         `~risk difference at bound` = z / sqrt(info) / theta * (x$rd[1] - x$rd0[1]) + x$rd0[1],
         `nominal p` = pnorm(-z)
       ) %>%
-      left_join(y_h0 %>% select(analysis, bound, probability) %>% dplyr::rename(probability0 = probability)) %>%
+      left_join(
+        y_h0 %>%
+          select(analysis, bound, probability) %>%
+          dplyr::rename(probability0 = probability)
+      ) %>%
       select(analysis, bound, probability, probability0, z, `~risk difference at bound`, `nominal p`)
   )
   # summarize the analysis

--- a/R/gs_power_wlr.R
+++ b/R/gs_power_wlr.R
@@ -266,12 +266,16 @@ gs_power_wlr <- function(enroll_rate = tibble(stratum = "all", duration = c(2, 2
     bounds <- y_h0 %>%
       select(analysis, bound, z, probability) %>%
       dplyr::rename(probability0 = probability) %>%
-      dplyr::left_join(x %>% select(analysis, event)) %>%
+      dplyr::left_join(
+        x %>% select(analysis, event)
+      ) %>%
       mutate(
         `~hr at bound` = gsDesign::zn2hr(z = z, n = event, ratio = ratio),
         `nominal p` = pnorm(-z)
       ) %>%
-      dplyr::left_join(y_h1 %>% select(analysis, bound, probability)) %>%
+      dplyr::left_join(
+        y_h1 %>% select(analysis, bound, probability)
+      ) %>%
       select(analysis, bound, probability, probability0, z, `~hr at bound`, `nominal p`) %>%
       arrange(analysis, desc(bound))
   )
@@ -283,11 +287,17 @@ gs_power_wlr <- function(enroll_rate = tibble(stratum = "all", duration = c(2, 2
     analysis <- x %>%
       select(analysis, time, event, ahr) %>%
       mutate(n = expected_accrual(time = x$time, enroll_rate = enroll_rate)) %>%
-      dplyr::left_join(y_h1 %>% select(analysis, info, info_frac, theta) %>% unique()) %>%
-      dplyr::left_join(y_h0 %>%
-        select(analysis, info, info_frac) %>%
-        dplyr::rename(info0 = info, info_frac0 = info_frac) %>%
-        unique()) %>%
+      dplyr::left_join(
+        y_h1 %>%
+          select(analysis, info, info_frac, theta) %>%
+          unique()
+      ) %>%
+      dplyr::left_join(
+        y_h0 %>%
+          select(analysis, info, info_frac) %>%
+          dplyr::rename(info0 = info, info_frac0 = info_frac) %>%
+          unique()
+      ) %>%
       select(analysis, time, n, event, ahr, theta, info, info0, info_frac, info_frac0) %>%
       arrange(analysis)
   )

--- a/tests/testthat/test-developer-gs_design_rd.R
+++ b/tests/testthat/test-developer-gs_design_rd.R
@@ -21,8 +21,8 @@ test_that("fixed design", {
     rd0 = rd0, ratio = 1, info_frac = 1,
     upper = gs_b,
     lower = gs_b,
-    upar = - qnorm(.025),
-    lpar = - Inf
+    upar = -qnorm(.025),
+    lpar = -Inf
   )
 
   expect_equal(x1, x2$analysis$n)

--- a/tests/testthat/test-developer-gs_power_rd.R
+++ b/tests/testthat/test-developer-gs_power_rd.R
@@ -23,8 +23,8 @@ test_that("fixed design", {
     rd0 = rd0, ratio = 1,
     upper = gs_b,
     lower = gs_b,
-    upar = - qnorm(.025),
-    lpar = - Inf
+    upar = -qnorm(.025),
+    lpar = -Inf
   )
 
   expect_equal(x1, x2$bound$probability)

--- a/tests/testthat/test-double_programming_ppwe.R
+++ b/tests/testthat/test-double_programming_ppwe.R
@@ -19,7 +19,7 @@ test_ppwe <- function(x = 0:20,
         H[t] <- boundary[1] * rate[1] + (boundary[2] - boundary[1]) * rate[2]
       }
     }
-    surv <- exp(- H)
+    surv <- exp(-H)
   } else {
     boundary1 <- boundary
     boundary1[2] <- max.x
@@ -33,7 +33,7 @@ test_ppwe <- function(x = 0:20,
         H[t] <- boundary1[1] * rate[1] + (boundary1[2] - boundary1[1]) * rate[2]
       }
     }
-    surv <- exp(- H)
+    surv <- exp(-H)
   }
 
   ind <- !is.na(match(xvals, x))
@@ -71,7 +71,7 @@ test_2_ppwe <- function(x = 0:20,
         boundary[2]) * rate[3]
     }
   }
-  surv <- exp(- H)
+  surv <- exp(-H)
 
   ind <- !is.na(match(xvals, x))
 
@@ -137,47 +137,61 @@ testthat::test_that("ppwe is incorrect when there are 3-step fail rates", {
 
 testthat::test_that("ppwe fail to identify a non-numerical input", {
   x <- c(0:20, "NA")
-  expect_error(expect_message(gsDesign2::ppwe(x = x), 
-                              "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"))
+  expect_error(expect_message(
+    gsDesign2::ppwe(x = x),
+    "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"
+  ))
 })
 
 testthat::test_that("ppwe fail to identify a negative input", {
   x <- -20:-1
-  expect_error(expect_message(gsDesign2::ppwe(x = x), 
-                              "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"))
+  expect_error(expect_message(
+    gsDesign2::ppwe(x = x),
+    "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"
+  ))
 })
 
 
 testthat::test_that("ppwe fail to identify a non-increasing input", {
   x <- 20:1
-  expect_error(expect_message(gsDesign2::ppwe(x = x), 
-                              "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"))
+  expect_error(expect_message(
+    gsDesign2::ppwe(x = x),
+    "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"
+  ))
 })
 
 testthat::test_that("ppwe fail to identify a non-dataframe input", {
   failRates <- as.matrix(tibble::tibble(duration = c(13, 100), rate = log(12) / c(9, 18)))
-  expect_error(expect_message(gsDesign2::ppwe(failRates = failRates), 
-                              "gsDesign2: failRates in `ppwe()` must be a data.frame"))
+  expect_error(expect_message(
+    gsDesign2::ppwe(failRates = failRates),
+    "gsDesign2: failRates in `ppwe()` must be a data.frame"
+  ))
 })
 
 
 testthat::test_that("ppwe fail to identify duration input", {
   failRates <- tibble::tibble(Times = c(13, 100), rate = log(12) / c(9, 18))
-  expect_error(expect_message(gsDesign2::ppwe(failRates = failRates), 
-                              "gsDesign2: failRates in `ppwe()` column names must contain duration"))
+  expect_error(expect_message(
+    gsDesign2::ppwe(failRates = failRates),
+    "gsDesign2: failRates in `ppwe()` column names must contain duration"
+  ))
 })
 
 
 testthat::test_that("ppwe fail to identify rates input", {
   failRates <- tibble::tibble(duration = c(13, 100), freqs = log(12) / c(9, 18))
-  expect_error(expect_message(gsDesign2::ppwe(failRates = failRates), 
-                              "gsDesign2: failRates in `ppwe()` column names must contain rate"))
+  expect_error(expect_message(
+    gsDesign2::ppwe(failRates = failRates),
+    "gsDesign2: failRates in `ppwe()` column names must contain rate"
+  ))
 })
 
 testthat::test_that("ppwe fail to identify lower.tail input", {
   lower.tail <- 123
-  expect_error(expect_message(gsDesign2::ppwe(lower.tail = lower.tail), 
-                              "gsDesign2: lower.tail in `ppwe()` must be logical"))
+  expect_error(expect_message(
+    gsDesign2::ppwe(lower.tail = lower.tail),
+    "gsDesign2: lower.tail in `ppwe()` must be logical"
+  ))
 })
 
 
@@ -187,45 +201,59 @@ testthat::test_that("ppwe fail to identify lower.tail input", {
 
 testthat::test_that("ppwe fail to identify a non-numerical input", {
   x <- c(0:20, "NA")
-  expect_error(expect_message(gsDesign2::ppwe(x = x), 
-                              "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"))
+  expect_error(expect_message(
+    gsDesign2::ppwe(x = x),
+    "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"
+  ))
 })
 
 testthat::test_that("ppwe fail to identify a negative input", {
   x <- -20:-1
-  expect_error(expect_message(gsDesign2::ppwe(x = x), 
-                              "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"))
+  expect_error(expect_message(
+    gsDesign2::ppwe(x = x),
+    "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"
+  ))
 })
 
 
 testthat::test_that("ppwe fail to identify a non-increasing input", {
   x <- 20:1
-  expect_error(expect_message(ppwe(x = x), 
-                              "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"))
+  expect_error(expect_message(
+    ppwe(x = x),
+    "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"
+  ))
 })
 
 testthat::test_that("ppwe fail to identify a non-dataframe input", {
   failRates <- as.matrix(tibble::tibble(duration = c(13, 100), rate = log(12) / c(9, 18)))
-  expect_error(expect_message(ppwe(failRates = failRates), 
-                              "gsDesign2: failRates in `ppwe()` must be a data.frame"))
+  expect_error(expect_message(
+    ppwe(failRates = failRates),
+    "gsDesign2: failRates in `ppwe()` must be a data.frame"
+  ))
 })
 
 
 testthat::test_that("ppwe fail to identify duration input", {
   failRates <- tibble::tibble(Times = c(13, 100), rate = log(12) / c(9, 18))
-  expect_error(expect_message(ppwe(failRates = failRates), 
-                              "gsDesign2: failRates in `ppwe()` column names must contain duration"))
+  expect_error(expect_message(
+    ppwe(failRates = failRates),
+    "gsDesign2: failRates in `ppwe()` column names must contain duration"
+  ))
 })
 
 
 testthat::test_that("ppwe fail to identify rates input", {
   failRates <- tibble::tibble(duration = c(13, 100), freqs = log(12) / c(9, 18))
-  expect_error(expect_message(ppwe(failRates = failRates), 
-                              "gsDesign2: failRates in `ppwe()` column names must contain rate"))
+  expect_error(expect_message(
+    ppwe(failRates = failRates),
+    "gsDesign2: failRates in `ppwe()` column names must contain rate"
+  ))
 })
 
 testthat::test_that("ppwe fail to identify lower.tail input", {
   lower.tail <- 123
-  expect_error(expect_message(ppwe(lower.tail = lower.tail), 
-                              "gsDesign2: lower.tail in `ppwe()` must be logical"))
+  expect_error(expect_message(
+    ppwe(lower.tail = lower.tail),
+    "gsDesign2: lower.tail in `ppwe()` must be logical"
+  ))
 })

--- a/tests/testthat/test-independent-check_arg.R
+++ b/tests/testthat/test-independent-check_arg.R
@@ -25,12 +25,44 @@ test_that("check fail_rate", {
   expect_error(check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c(2, -4), dropout_rate = 0.01)))
 
   # check of column `hr`
-  expect_error(check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c(0.02, 0.04), dropout_rate = 0.01, hr = "a")))
-  expect_error(check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c(2, -4), dropout_rate = 0.01, hr = -1)))
+  expect_error(
+    check_fail_rate(
+      tibble::tibble(
+        duration = c(10, 20),
+        fail_rate = c(0.02, 0.04),
+        dropout_rate = 0.01, hr = "a"
+      )
+    )
+  )
+  expect_error(
+    check_fail_rate(
+      tibble::tibble(
+        duration = c(10, 20),
+        fail_rate = c(2, -4),
+        dropout_rate = 0.01, hr = -1
+      )
+    )
+  )
 
   # check of column `dropoutRate`
-  expect_error(check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c(0.02, 0.04), dropout_rate = "a", hr = 0.6)))
-  expect_error(check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c(2, -4), dropout_rate = -1, hr = 0.6)))
+  expect_error(
+    check_fail_rate(
+      tibble::tibble(
+        duration = c(10, 20),
+        fail_rate = c(0.02, 0.04),
+        dropout_rate = "a", hr = 0.6
+      )
+    )
+  )
+  expect_error(
+    check_fail_rate(
+      tibble::tibble(
+        duration = c(10, 20),
+        fail_rate = c(2, -4),
+        dropout_rate = -1, hr = 0.6
+      )
+    )
+  )
 })
 
 test_that("check enrollments and fail_rate together", {

--- a/tests/testthat/test-independent-expected_accrual.R
+++ b/tests/testthat/test-independent-expected_accrual.R
@@ -96,7 +96,12 @@ testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
 
 testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
   enroll_rate <- tibble::tibble(duration = c(3, 3, 18), freqs = c(5, 10, 20))
-  expect_error(expect_message(expected_accrual(enroll_rate = enroll_rate), "gsDesign2: enroll_rate in `expected_accrual()` column names must contain rate"))
+  expect_error(
+    expect_message(
+      expected_accrual(enroll_rate = enroll_rate),
+      "gsDesign2: enroll_rate in `expected_accrual()` column names must contain rate"
+    )
+  )
 })
 
 

--- a/tests/testthat/test-independent-expected_event.R
+++ b/tests/testthat/test-independent-expected_event.R
@@ -24,11 +24,13 @@ test_that("data frame returned from expected_event not as expected", {
   enrollRates <- tibble::tibble(duration = c(1, 1, 8), rate = c(3, 2, 0))
   failRates <- tibble::tibble(duration = c(4, Inf), failRate = c(.03, .06), dropoutRate = c(.001, .002))
   totalDuration <- 7
-  xx <- expected_event(enrollRates,
+  xx <- expected_event(
+    enrollRates,
     failRates %>% rename(fail_rate = failRate, dropout_rate = dropoutRate),
     totalDuration,
     simple = FALSE
-  ) %>% data.frame()
+  ) %>%
+    data.frame()
   # expected checked with alternate calculations in gsSurvNPH vignette
   expected <- data.frame(
     t = c(0, 4),

--- a/tests/testthat/test-independent-fixed_design.R
+++ b/tests/testthat/test-independent-fixed_design.R
@@ -22,10 +22,28 @@ ratio <- 1
 
 test_that("input checking", {
   # miss enroll_rate
-  expect_error(fixed_design("ahr", alpha = 0.025, power = 0.9, fail_rate = fail_rate, study_duration = study_duration, ratio = ratio))
+  expect_error(
+    fixed_design(
+      "ahr",
+      alpha = 0.025,
+      power = 0.9,
+      fail_rate = fail_rate,
+      study_duration = study_duration,
+      ratio = ratio
+    )
+  )
 
   # miss fail_rate
-  expect_error(fixed_design("ahr", alpha = 0.025, power = 0.9, enroll_rate = enroll_rate, study_duration = study_duration, ratio = ratio))
+  expect_error(
+    fixed_design(
+      "ahr",
+      alpha = 0.025,
+      power = 0.9,
+      enroll_rate = enroll_rate,
+      study_duration = study_duration,
+      ratio = ratio
+    )
+  )
 
   # multiple rho for FH/MB
   expect_error(fixed_design("fh",

--- a/tests/testthat/test-independent-gs_b.R
+++ b/tests/testthat/test-independent-gs_b.R
@@ -1,6 +1,12 @@
 test_that("gs_b() returns values as expected", {
   IF <- c(.6, .8, 1)
-  par <- gsDesign::gsDesign(alpha = .02, k = length(IF), test.type = 1, sfu = gsDesign::sfLDOF, timing = IF)$upper$bound
+  par <- gsDesign::gsDesign(
+    alpha = .02,
+    k = length(IF),
+    test.type = 1,
+    sfu = gsDesign::sfLDOF,
+    timing = IF
+  )$upper$bound
   expect_equal(par, gs_b(par))
 
   par <- 1:10
@@ -10,6 +16,12 @@ test_that("gs_b() returns values as expected", {
 
 testthat::test_that("gs_b() returns NA if the number of interim analysis is larger than the length of par", {
   IF <- c(.8, 1)
-  par <- gsDesign::gsDesign(alpha = .025, k = length(IF), test.type = 1, sfu = gsDesign::sfLDOF, timing = IF)$upper$bound
+  par <- gsDesign::gsDesign(
+    alpha = .025,
+    k = length(IF),
+    test.type = 1,
+    sfu = gsDesign::sfLDOF,
+    timing = IF
+  )$upper$bound
   expect_true(is.na(gs_b(par, k = 3)))
 })

--- a/tests/testthat/test-independent-gs_design_ahr.R
+++ b/tests/testthat/test-independent-gs_design_ahr.R
@@ -44,49 +44,52 @@ testthat::test_that("compare results with AHR in the situation of single analysi
   )
 })
 
-testthat::test_that("compare results with gsDesign2::AHR in the situation with IF and multiple analysis times specified", {
-  enroll_rate <- tibble::tibble(
-    stratum = "All",
-    duration = c(2, 2, 10),
-    rate = c(3, 6, 9)
-  )
-  fail_rate <- tibble::tibble(
-    stratum = "All",
-    duration = c(3, 100),
-    fail_rate = log(2) / c(9, 18),
-    hr = c(0.9, 0.6),
-    dropout_rate = rep(0.001, 2)
-  )
-  total_duration <- c(12, 25, 36)
-  analysis_time <- total_duration
+testthat::test_that(
+  "compare results with gsDesign2::AHR in the situation with IF and multiple analysis times specified",
+  {
+    enroll_rate <- tibble::tibble(
+      stratum = "All",
+      duration = c(2, 2, 10),
+      rate = c(3, 6, 9)
+    )
+    fail_rate <- tibble::tibble(
+      stratum = "All",
+      duration = c(3, 100),
+      fail_rate = log(2) / c(9, 18),
+      hr = c(0.9, 0.6),
+      dropout_rate = rep(0.001, 2)
+    )
+    total_duration <- c(12, 25, 36)
+    analysis_time <- total_duration
 
-  out <- gs_design_ahr(
-    enroll_rate = enroll_rate,
-    fail_rate = fail_rate,
-    analysis_time = analysis_time
-  )
-
-  testthat::expect_equal(
-    out$analysis %>% select(time, ahr) %>% dplyr::distinct(.keep_all = TRUE),
-    ahr(
+    out <- gs_design_ahr(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
-      total_duration = total_duration
-    ) %>% select(time, ahr)
-  )
+      analysis_time = analysis_time
+    )
 
-  # update enroll_rate for AHR to make Events/info/info0 also match in outputs
-  enroll_rate1 <- enroll_rate %>% mutate(rate = rate * c(max(out$analysis$n) / (duration %*% rate)))
+    testthat::expect_equal(
+      out$analysis %>% select(time, ahr) %>% dplyr::distinct(.keep_all = TRUE),
+      ahr(
+        enroll_rate = enroll_rate,
+        fail_rate = fail_rate,
+        total_duration = total_duration
+      ) %>% select(time, ahr)
+    )
 
-  testthat::expect_equal(
-    out$analysis %>%
-      select(time, ahr, event, info, info0) %>%
-      dplyr::distinct(.keep_all = TRUE),
-    ahr(
-      enroll_rate = enroll_rate1,
-      fail_rate = fail_rate,
-      total_duration = total_duration
-    ) %>%
-      select(time, ahr, event, info, info0)
-  )
-})
+    # update enroll_rate for AHR to make Events/info/info0 also match in outputs
+    enroll_rate1 <- enroll_rate %>% mutate(rate = rate * c(max(out$analysis$n) / (duration %*% rate)))
+
+    testthat::expect_equal(
+      out$analysis %>%
+        select(time, ahr, event, info, info0) %>%
+        dplyr::distinct(.keep_all = TRUE),
+      ahr(
+        enroll_rate = enroll_rate1,
+        fail_rate = fail_rate,
+        total_duration = total_duration
+      ) %>%
+        select(time, ahr, event, info, info0)
+    )
+  }
+)

--- a/tests/testthat/test-independent-gs_design_combo.R
+++ b/tests/testthat/test-independent-gs_design_combo.R
@@ -146,9 +146,17 @@ for (i in 1:max(fh_test$analysis)) {
 }
 
 testthat::test_that("calculate probability under alternative", {
-  expect_equal(1 - beta, max((gs_design_combo_test2$bounds %>% filter(bound == "upper"))$probability), tolerance = 0.0001)
+  expect_equal(
+    1 - beta,
+    max((gs_design_combo_test2$bounds %>% filter(bound == "upper"))$probability),
+    tolerance = 0.0001
+  )
 })
 
 testthat::test_that("calculate probability under null", {
-  expect_equal(alpha, max((gs_design_combo_test2$bounds %>% filter(bound == "upper"))$probability0), tolerance = 0.1) ## NEAD REVISED THE TOLERANCE AFTER YILONNG FIXED THE BINDING BUG IN MAXCOMBO
+  expect_equal(
+    alpha,
+    max((gs_design_combo_test2$bounds %>% filter(bound == "upper"))$probability0),
+    tolerance = 0.1 # NEED TO REVISE THE TOLERANCE AFTER YILONG FIXED THE BINDING BUG IN MAXCOMBO
+  )
 })

--- a/tests/testthat/test-independent-gs_design_npe.R
+++ b/tests/testthat/test-independent-gs_design_npe.R
@@ -163,7 +163,9 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 b
       upar = list(sf = sfu, total_spend = alpha, param = sfupar),
       lower = gs_spending_bound,
       lpar = list(sf = sfl, total_spend = astar, param = sflpar)
-    ) %>% filter(bound == "lower"))$probability,
+    ) %>%
+      filter(bound == "lower")
+    )$probability,
     sfl(alpha = astar, t = timing, param = sflpar)$spend
   )
 })
@@ -203,7 +205,9 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=6 b
       upar = list(sf = sfu, total_spend = alpha, param = sfupar),
       lower = gs_spending_bound,
       lpar = list(sf = sfl, total_spend = astar, param = sflpar)
-    ) %>% filter(bound == "lower"))$probability,
+    ) %>%
+      filter(bound == "lower")
+    )$probability,
     sfl(alpha = astar, t = timing, param = sflpar)$spend
   )
 })

--- a/tests/testthat/test-independent-gs_design_npe.R
+++ b/tests/testthat/test-independent-gs_design_npe.R
@@ -116,13 +116,23 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 b
   expect_equal(gsd$n.I, (gsdv %>% filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability under null hypothesis (theta = 0)
-  expect_equal(gsdv$probability0,
-    gsDesign::gsBoundSummary(gsd) %>% subset(Value == "P(Cross) if delta=0") %>% select(Efficacy, Futility) %>% t() %>% as.numeric(),
+  expect_equal(
+    gsdv$probability0,
+    gsDesign::gsBoundSummary(gsd) %>%
+      subset(Value == "P(Cross) if delta=0") %>%
+      select(Efficacy, Futility) %>%
+      t() %>%
+      as.numeric(),
     tolerance = .0001
   )
 
-  expect_equal(gsdv$probability,
-    gsDesign::gsBoundSummary(gsd) %>% subset(Value == "P(Cross) if delta=1") %>% select(Efficacy, Futility) %>% t() %>% as.numeric(),
+  expect_equal(
+    gsdv$probability,
+    gsDesign::gsBoundSummary(gsd) %>%
+      subset(Value == "P(Cross) if delta=1") %>%
+      select(Efficacy, Futility) %>%
+      t() %>%
+      as.numeric(),
     tolerance = .0001
   )
 })
@@ -150,7 +160,7 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 b
 
   # compare statistical information
   # While tolerance should not be problematic, it seems large
-  expect_equal(gsd$n.I, (gsdv %>% filter(bound == "upper"))$info, tolerance = .04) # While tolerance should not be problematic, it seems large
+  expect_equal(gsd$n.I, (gsdv %>% filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability under null hypothesis (theta = 0)
   expect_equal((gsdv %>% filter(bound == "upper"))$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
@@ -195,7 +205,11 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=6 b
   expect_equal(gsd$n.I, (gsdv %>% filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability under null hypothesis (theta = 0)
-  expect_equal((gsdv %>% filter(bound == "upper"))$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend, tolerance = 1e-5)
+  expect_equal(
+    (gsdv %>% filter(bound == "upper"))$probability0,
+    sfu(alpha = alpha, t = timing, param = sfupar)$spend,
+    tolerance = 1e-5
+  )
   expect_equal(
     (gs_power_npe(
       theta = 0, info = (gsdv %>% filter(bound == "upper"))$info,

--- a/tests/testthat/test-independent-gs_info_ahr.R
+++ b/tests/testthat/test-independent-gs_info_ahr.R
@@ -21,7 +21,6 @@ testthat::test_that("results match if only put in targeted analysis times", {
       fail_rate = fail_rate,
       analysis_time = total_duration
     ) %>% select(time, ahr, event, info, info0),
-    
     ahr(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,

--- a/tests/testthat/test-independent-gs_info_ahr.R
+++ b/tests/testthat/test-independent-gs_info_ahr.R
@@ -99,9 +99,11 @@ testthat::test_that("results match if put in both analysis time and targeted eve
     )
   )
 
-  # since above test is based on the output "Time", here is to check whether the output "Time" is reasonable
+  # since above test is based on the output "Time",
+  # here is to check whether the output "Time" is reasonable
 
-  # either being equal to the corresponding element in the input analysis_time or at the time point when targeted event number achieved
+  # either being equal to the corresponding element in the input
+  # analysis_time or at the time point when targeted event number achieved
   testthat::expect_equal(
     max((1 - (out1$time == analysis_time)) * (1 - (round(out1$event) == round(event)))),
     0

--- a/tests/testthat/test-independent-gs_power_combo.R
+++ b/tests/testthat/test-independent-gs_power_combo.R
@@ -16,19 +16,21 @@ test_tEvents <- function(enrollRates = tibble::tibble(
   failRatesc <- failRates[, c("duration", "failRate", "dropoutRate")]
   failRatest <- failRatesc
   failRatest$failRate <- failRates$failRate * failRates$hr
-  
+
   eventc <- gsDesign2::expected_event(
     enroll_rate = enrollRates_1,
     fail_rate = failRatesc %>% dplyr::rename(fail_rate = failRate, dropout_rate = dropoutRate),
     total_duration = td,
-    simple = FALSE)
-  
+    simple = FALSE
+  )
+
   eventt <- gsDesign2::expected_event(
     enroll_rate = enrollRates_1,
     fail_rate = failRatest %>% dplyr::rename(fail_rate = failRate, dropout_rate = dropoutRate),
     total_duration = td,
-    simple = FALSE)
-  
+    simple = FALSE
+  )
+
   totale <- sum(eventc$event + eventt$event)
   return(totale)
 }

--- a/tests/testthat/test-independent-gs_spending_combo.R
+++ b/tests/testthat/test-independent-gs_spending_combo.R
@@ -1,16 +1,16 @@
 test_that("gs_spending_combo spend output identical as gsDesign spending", {
-  IF <- c(.6, .8, 1)
+  info_frac <- c(.6, .8, 1)
   alpha <- 0.02
   par_test <- gsDesign::gsDesign(
     alpha = alpha,
-    k = length(IF),
+    k = length(info_frac),
     test.type = 1,
-    sfu = gsDesign::sfLDOF, timing = IF
+    sfu = gsDesign::sfLDOF, timing = info_frac
   )$upper$spend
   spend_test <- cumsum(par_test)
 
   par <- list(sf = gsDesign::sfLDOF, total_spend = alpha)
-  spend_combo <- gsDesign2::gs_spending_combo(par, info = IF)
+  spend_combo <- gsDesign2::gs_spending_combo(par, info = info_frac)
 
   expect_equal(spend_test, spend_combo)
 })

--- a/tests/testthat/test-independent-wlr_weight.R
+++ b/tests/testthat/test-independent-wlr_weight.R
@@ -24,7 +24,7 @@ test_that("test wlr_weight_n", {
 
   expect_equal(
     gsDesign2::wlr_weight_n(x = analysis_time, arm0 = arm0, arm1 = arm1, power = 2),
-    (2 * (0.5 * gsDesign2:::prob_risk(arm0, analysis_time, total_time) + 
-            0.5 * gsDesign2:::prob_risk(arm1, analysis_time, total_time)))^2
+    (2 * (0.5 * gsDesign2:::prob_risk(arm0, analysis_time, total_time) +
+      0.5 * gsDesign2:::prob_risk(arm1, analysis_time, total_time)))^2
   )
 })

--- a/tests/testthat/test-independent_test_gs_power_wlr.R
+++ b/tests/testthat/test-independent_test_gs_power_wlr.R
@@ -60,13 +60,13 @@ test_that("Check using gs_info_wlr and gs_power_npe", {
     theta = fh01$theta,
     info = fh01$info,
     info0 = fh01$info0,
-    binding = F,
+    binding = FALSE,
     upper = gsDesign2::gs_b,
     lower = gsDesign2::gs_b,
     upar = up,
     lpar = c(qnorm(.1), rep(-Inf, length(fh01$event) - 1)),
-    test_upper = T,
-    test_lower = T,
+    test_upper = TRUE,
+    test_lower = TRUE,
     r = 18,
     tol = 1e-6
   ) %>% dplyr::arrange(analysis, bound)

--- a/tests/testthat/test-independent_test_s2pwe.R
+++ b/tests/testthat/test-independent_test_s2pwe.R
@@ -8,67 +8,110 @@ testthat::test_that("s2pwe fails to come up with the correct answer", {
   )
 })
 
-
-
-
 testthat::test_that("s2pwe fails to identify non-numeric value", {
   times <- c(1, "NA")
   survival <- c(0.5, 0.4)
-  expect_error(expect_message(gsDesign2::s2pwe(times = times, survival = survival), "gsDesign2: times in `s2pwe()` must be increasing positive finite numbers"))
+  expect_error(
+    expect_message(
+      gsDesign2::s2pwe(times = times, survival = survival),
+      "gsDesign2: times in `s2pwe()` must be increasing positive finite numbers"
+    )
+  )
 })
-
 
 testthat::test_that("s2pwe fails to identify non-positive value", {
   times2 <- c(1, NA)
   survival <- c(0.5, 0.4)
-  expect_error(expect_message(gsDesign2::s2pwe(times = times2, survival = survival), "gsDesign2: times in `s2pwe()` must be increasing positive finite numbers"))
+  expect_error(
+    expect_message(
+      gsDesign2::s2pwe(times = times2, survival = survival),
+      "gsDesign2: times in `s2pwe()` must be increasing positive finite numbers"
+    )
+  )
 })
-
-
 
 testthat::test_that("s2pwe fails to identify infinity value", {
   times3 <- c(1, Inf)
   survival <- c(0.5, 0.4)
-  expect_error(expect_message(gsDesign2::s2pwe(times = times2, survival = survival), "gsDesign2: times in `s2pwe()` must be increasing positive finite numbers"))
+  expect_error(
+    expect_message(
+      gsDesign2::s2pwe(times = times2, survival = survival),
+      "gsDesign2: times in `s2pwe()` must be increasing positive finite numbers"
+    )
+  )
 })
-
 
 testthat::test_that("s2pwe fails to identify non-increasing value", {
   times4 <- c(1, 2, 1)
   survival <- c(0.5, 0.4, 0.3)
-  expect_error(expect_message(gsDesign2::s2pwe(times = times4, survival = survival), "gsDesign2: times in `s2pwe()` must be increasing positive finite numbers"))
+  expect_error(
+    expect_message(
+      gsDesign2::s2pwe(times = times4, survival = survival),
+      "gsDesign2: times in `s2pwe()` must be increasing positive finite numbers"
+    )
+  )
 })
 
 testthat::test_that("s2pwe fails to identify non-numerical survival", {
   times5 <- c(1, 2)
   survival <- c(0.5, "NA")
-  expect_error(expect_message(gsDesign2::s2pwe(times = times5, survival = survival), "gsDesign2: survival in `s2pwe()` must be numeric and of same length as times"))
+  expect_error(
+    expect_message(
+      gsDesign2::s2pwe(times = times5, survival = survival),
+      "gsDesign2: survival in `s2pwe()` must be numeric and of same length as times"
+    )
+  )
 })
 
 testthat::test_that("s2pwe survival and time should have the same length", {
   times6 <- c(1, 2, 5)
   survival <- c(0.5, 0.3)
-  expect_error(expect_message(gsDesign2::s2pwe(times = times6, survival = survival), "gsDesign2: survival in `s2pwe()` must be numeric and of same length as times"))
+  expect_error(
+    expect_message(
+      gsDesign2::s2pwe(times = times6, survival = survival),
+      "gsDesign2: survival in `s2pwe()` must be numeric and of same length as times"
+    )
+  )
 })
-
-
 
 testthat::test_that("s2pwe fails to identify non-positive survival", {
   times <- c(1, 3)
   survival2 <- c(0.5, -0.1)
-  expect_error(expect_message(gsDesign2::s2pwe(times = times, survival = survival2), "gsDesign2: survival in `s2pwe()` must be non-increasing positive finite numbers less than or equal to 1 with at least 1 value < 1"))
+  expect_error(
+    expect_message(
+      gsDesign2::s2pwe(times = times, survival = survival2),
+      paste(
+        "gsDesign2: survival in `s2pwe()` must be non-increasing positive",
+        "finite numbers less than or equal to 1 with at least 1 value < 1"
+      )
+    )
+  )
 })
-
 
 testthat::test_that("s2pwe fails to identify large than 1 survival", {
   times <- c(1, 3)
   survival3 <- c(0.5, 1.5)
-  expect_error(expect_message(gsDesign2::s2pwe(times = times, survival = survival3), "gsDesign2: survival in `s2pwe()` must be non-increasing positive finite numbers less than or equal to 1 with at least 1 value < 1"))
+  expect_error(
+    expect_message(
+      gsDesign2::s2pwe(times = times, survival = survival3),
+      paste(
+        "gsDesign2: survival in `s2pwe()` must be non-increasing positive",
+        "finite numbers less than or equal to 1 with at least 1 value < 1"
+      )
+    )
+  )
 })
-
 
 testthat::test_that("s2pwe fails to identify an increasing survival series", {
   times <- c(1, 3)
   survival4 <- c(0.5, 0.9)
-  expect_error(expect_message(gsDesign2::s2pwe(times = times, survival = survival4), "gsDesign2: survival in `s2pwe()` must be non-increasing positive finite numbers less than or equal to 1 with at least 1 value < 1"))
+  expect_error(
+    expect_message(
+      gsDesign2::s2pwe(times = times, survival = survival4),
+      paste(
+        "gsDesign2: survival in `s2pwe()` must be non-increasing positive",
+        "finite numbers less than or equal to 1 with at least 1 value < 1"
+      )
+    )
+  )
 })

--- a/tests/testthat/test-independent_test_wlr_weight.R
+++ b/tests/testthat/test-independent_test_wlr_weight.R
@@ -22,11 +22,11 @@ test_that("Validate the function based on simple calculation", {
   # calculate theoretical results
   # Tarone-Ware weight is the (N at risk)^factor
 
-  wlrn <- (npsurvSS::psurv(1:36, arm0, lower.tail = F) *
-    npsurvSS::ploss(1:36, arm0, lower.tail = F) *
+  wlrn <- (npsurvSS::psurv(1:36, arm0, lower.tail = FALSE) *
+    npsurvSS::ploss(1:36, arm0, lower.tail = FALSE) *
     npsurvSS::paccr(pmin(arm0$accr_time, 36 - 1:36), arm0) +
-    npsurvSS::psurv(1:36, arm1, lower.tail = F) *
-      npsurvSS::ploss(1:36, arm1, lower.tail = F) *
+    npsurvSS::psurv(1:36, arm1, lower.tail = FALSE) *
+      npsurvSS::ploss(1:36, arm1, lower.tail = FALSE) *
       npsurvSS::paccr(pmin(arm1$accr_time, 36 - 1:36), arm1) * 2)^0.666
 
 

--- a/vignettes/best_practice_npe_accuracy.Rmd
+++ b/vignettes/best_practice_npe_accuracy.Rmd
@@ -50,7 +50,7 @@ gs_power_grid <- function(n_analysis, r, tol, sf = gsDesign::sfLDOF, sfname = "O
     upper = gs_spending_bound,
     upar = list(sf = sf, total_spend = alpha, param = param, timing = NULL),
     lower = gs_b,
-    lpar = - rep(Inf, n_analysis),
+    lpar = -rep(Inf, n_analysis),
     test_upper = TRUE,
     test_lower = FALSE,
     binding = FALSE,
@@ -59,7 +59,7 @@ gs_power_grid <- function(n_analysis, r, tol, sf = gsDesign::sfLDOF, sfname = "O
   )
   x %>%
     filter(abs(z) < Inf) %>%
-    transmute(sf = sfname, param = param, r = r, Analysis = analysis, Z = z, p = pnorm(- z), tol = tol)
+    transmute(sf = sfname, param = param, r = r, Analysis = analysis, Z = z, p = pnorm(-z), tol = tol)
 }
 ```
 
@@ -83,7 +83,7 @@ y <- mapply(
 ```{r}
 y %>%
   filter(Analysis == 5) %>%
-  select(- p) %>%
+  select(-p) %>%
   pivot_wider(names_from = tol, values_from = Z) %>%
   gt() %>%
   tab_header(
@@ -100,7 +100,7 @@ y %>%
 ```{r}
 y %>%
   filter(Analysis == 5) %>%
-  select(- Z) %>%
+  select(-Z) %>%
   pivot_wider(names_from = tol, values_from = p) %>%
   gt() %>%
   tab_header(

--- a/vignettes/story_ahr_under_nph.Rmd
+++ b/vignettes/story_ahr_under_nph.Rmd
@@ -226,12 +226,12 @@ avehrtbl <- ahr(
 ggplot(avehrtbl, aes(x = time, y = ahr)) +
   geom_line() +
   ylab("Average HR") +
-  ggtitle("Average HR as a function of study duration") 
+  ggtitle("Average HR as a function of study duration")
 
 ggplot(avehrtbl, aes(x = time, y = event)) +
   geom_line() +
   ylab("Expected events") +
-  ggtitle("Expected event accumulation as a function of study duration") 
+  ggtitle("Expected event accumulation as a function of study duration")
 ```
 
 ## Simulation to verify power
@@ -392,12 +392,12 @@ avehrtbl <- ahr(
 ggplot(avehrtbl, aes(x = time, y = ahr)) +
   geom_line() +
   ylab("Average HR") +
-  ggtitle("Average HR as a function of study duration") 
+  ggtitle("Average HR as a function of study duration")
 
 ggplot(avehrtbl, aes(x = time, y = event)) +
   geom_line() +
   ylab("Expected events") +
-  ggtitle("Expected event accumulation as a function of study duration") 
+  ggtitle("Expected event accumulation as a function of study duration")
 ```
 
 ## Simulation to verify power

--- a/vignettes/story_arbitrary_distribution.Rmd
+++ b/vignettes/story_arbitrary_distribution.Rmd
@@ -86,7 +86,7 @@ Note that we set the default of `lower.tail=FALSE` so that the survival function
 
 ```{r}
 p_pm <- function(x, theta, lambda, lower_tail = FALSE) {
-  exp(- theta * (1 - exp(- lambda * x)))
+  exp(-theta * (1 - exp(-lambda * x)))
 }
 ```
 
@@ -95,7 +95,7 @@ We set $\theta = -\log(.4)$ to obtain a cure rate of 0.4. we then overlay with t
 
 ```{r, fig.width=6.5, fig.height=4}
 lambda <- log(2) / 10
-theta <- - log(.4)
+theta <- -log(.4)
 times <- 0:40
 plot(times, p_pm(times, theta, lambda), type = "l", ylab = "Survival", xlab = "Time", log = "y")
 
@@ -122,8 +122,8 @@ $$\lambda = -\log\left(\frac{\theta - \log(c_1)}{\theta}\right)/t_1.$$
 We compute $\theta$ and $\lambda$ values with a cure rate of 0.4 and a survival rate of 0.6 at 30 months:
 
 ```{r}
-theta <- - log(0.4)
-lambda <- - log((theta + log(.6)) / theta) / 30
+theta <- -log(0.4)
+lambda <- -log((theta + log(.6)) / theta) / 30
 ```
 
 We confirm the survival at time 30:

--- a/vignettes/story_compare_power_delay_effect.Rmd
+++ b/vignettes/story_compare_power_delay_effect.Rmd
@@ -84,7 +84,7 @@ for (trial_duration in seq(24, 60, 4)) {
       wlr_weight_fh(x, arm0, arm1, rho = 0, gamma = 0.5)
     },
     upar = qnorm(.975),
-    lpar = - Inf,
+    lpar = -Inf,
     analysis_time = trial_duration
   )
 
@@ -97,14 +97,14 @@ for (trial_duration in seq(24, 60, 4)) {
       wlr_weight_fh(x, arm0, arm1, rho = 0, gamma = 0)
     },
     upar = qnorm(.975),
-    lpar = - Inf,
+    lpar = -Inf,
     analysis_time = trial_duration,
     event = .1
   )
 
   # Max combo test 1
   mc2_test <- data.frame(
-    rho = 0, gamma = c(0, .5), tau = - 1,
+    rho = 0, gamma = c(0, .5), tau = -1,
     test = 1:2, analysis = 1, analysis_time = trial_duration
   )
 
@@ -120,7 +120,7 @@ for (trial_duration in seq(24, 60, 4)) {
 
   # Max combo test 2
   mc3_test <- data.frame(
-    rho = c(0, 0, .5), gamma = c(0, .5, .5), tau = - 1,
+    rho = c(0, 0, .5), gamma = c(0, .5, .5), tau = -1,
     test = 1:3, analysis = 1, analysis_time = trial_duration
   )
 
@@ -136,7 +136,7 @@ for (trial_duration in seq(24, 60, 4)) {
 
   # Max combo test
   mc4_test <- data.frame(
-    rho = c(0, 0, .5, .5), gamma = c(0, .5, .5, 0), tau = - 1,
+    rho = c(0, 0, .5, .5), gamma = c(0, .5, .5, 0), tau = -1,
     test = 1:4, analysis = 1, analysis_time = trial_duration
   )
 
@@ -156,10 +156,10 @@ for (trial_duration in seq(24, 60, 4)) {
     fail_rate = fail_rate,
     ratio = 1,
     weight = function(x, arm0, arm1) {
-      wlr_weight_fh(x, arm0, arm1, rho = - 1, gamma = 0, tau = 15)
+      wlr_weight_fh(x, arm0, arm1, rho = -1, gamma = 0, tau = 15)
     },
     upar = qnorm(.975),
-    lpar = - Inf,
+    lpar = -Inf,
     analysis_time = trial_duration,
     event = .1
   )
@@ -228,7 +228,7 @@ for (trial_duration in seq(20, 60, 4)) {
     upper = gs_b,
     upar = qnorm(.975),
     lower = gs_b,
-    lpar = - Inf,
+    lpar = -Inf,
     analysis_time = trial_duration
   )
 
@@ -243,14 +243,14 @@ for (trial_duration in seq(20, 60, 4)) {
     upper = gs_b,
     upar = qnorm(.975),
     lower = gs_b,
-    lpar = - Inf,
+    lpar = -Inf,
     analysis_time = trial_duration,
     event = .1
   )
 
   # Max combo test
   mc2_test <- data.frame(
-    rho = 0, gamma = c(0, .5), tau = - 1,
+    rho = 0, gamma = c(0, .5), tau = -1,
     test = 1:2, analysis = 1, analysis_time = trial_duration
   )
   mc_2 <- gs_power_combo(
@@ -265,7 +265,7 @@ for (trial_duration in seq(20, 60, 4)) {
 
   # Max combo test
   mc3_test <- data.frame(
-    rho = c(0, 0, .5), gamma = c(0, .5, .5), tau = - 1,
+    rho = c(0, 0, .5), gamma = c(0, .5, .5), tau = -1,
     test = 1:3, analysis = 1, analysis_time = trial_duration
   )
 
@@ -281,7 +281,7 @@ for (trial_duration in seq(20, 60, 4)) {
 
   # Max combo test
   mc4_test <- data.frame(
-    rho = c(0, 0, .5, .5), gamma = c(0, .5, .5, 0), tau = - 1,
+    rho = c(0, 0, .5, .5), gamma = c(0, .5, .5, 0), tau = -1,
     test = 1:4, analysis = 1, analysis_time = trial_duration
   )
 
@@ -300,10 +300,10 @@ for (trial_duration in seq(20, 60, 4)) {
     fail_rate = fail_rate,
     ratio = 1,
     weight = function(x, arm0, arm1) {
-      wlr_weight_fh(x, arm0, arm1, rho = - 1, gamma = 0, tau = 15)
+      wlr_weight_fh(x, arm0, arm1, rho = -1, gamma = 0, tau = 15)
     },
     upar = qnorm(.975),
-    lpar = - Inf,
+    lpar = -Inf,
     analysis_time = trial_duration,
     event = .1
   )

--- a/vignettes/story_compute_expected_events.Rmd
+++ b/vignettes/story_compute_expected_events.Rmd
@@ -226,7 +226,7 @@ names(x) <- c("m", "tm", "lambda", "eta", "j", "omega", "gamma")
 y <- x %>%
   mutate(
     tdel = tm - lag(tm, default = 0),
-    q = exp(- (lambda + eta) * tdel),
+    q = exp(-(lambda + eta) * tdel),
     Q = lag(cumprod(q), default = 1),
     d = Q * (1 - q) * lambda / (lambda + eta),
     G = c(5, 5, 3, 0),

--- a/vignettes/story_design_with_ahr.Rmd
+++ b/vignettes/story_design_with_ahr.Rmd
@@ -124,7 +124,7 @@ s <- rbind(
   s %>% mutate(Treatment = "Experimental", rate = rate * hr)
 ) %>%
   group_by(Scenario, Treatment) %>%
-  mutate(Survival = exp(- cumsum(duration * rate)))
+  mutate(Survival = exp(-cumsum(duration * rate)))
 ggplot(s, aes(x = Month, y = Survival, col = Scenario, lty = Treatment)) +
   geom_line() +
   scale_y_log10(breaks = (1:10) / 10, lim = c(.1, 1)) +
@@ -164,9 +164,9 @@ s <- tibble(
 )
 
 # calculate the survival at each change point for each scenario
-s <- rbind(s, s %>% mutate(Treatment = "Experimental", rate = rate * hr)) %>%  
+s <- rbind(s, s %>% mutate(Treatment = "Experimental", rate = rate * hr)) %>%
   group_by(Scenario, Treatment) %>%
-  mutate(Survival = exp(- cumsum(duration * rate)))
+  mutate(Survival = exp(-cumsum(duration * rate)))
 ```
 
 ```{r, fig.width=3}
@@ -219,7 +219,8 @@ hr <- do.call(
       ahr(
         enroll_rate = enroll_rate %>% filter(Scenario == x),
         fail_rate = fail_rate %>% filter(Scenario == x),
-        total_duration = c(.001, seq(4, 44, 4))) %>%  
+        total_duration = c(.001, seq(4, 44, 4))
+      ) %>%
         mutate(Scenario = x)
     }
   )
@@ -272,7 +273,7 @@ ss_ahr_fixed <- do.call(
         upper = gs_b,
         upar = qnorm(.975),
         lower = gs_b,
-        lpar = - Inf,
+        lpar = -Inf,
         alpha = .025,
         beta = .1
       )
@@ -310,7 +311,7 @@ do.call(
         fail_rate = fail_rate %>% filter(Scenario == "Shorter delayed effect"),
         analysis_time = x,
         upper = gs_b, upar = qnorm(.975),
-        lower = gs_b, lpar = - Inf,
+        lower = gs_b, lpar = -Inf,
         alpha = .025,
         beta = .1
       )$analysis %>%
@@ -342,7 +343,8 @@ for (g in c("PH", "Shorter delayed effect", "Longer delayed effect", "Crossing")
     ahr(
       enroll_rate = enroll_rate %>% filter(Scenario == g),
       fail_rate = fail_rate %>% filter(Scenario == g),
-      total_duration = c(12, 20, 28, 36), simple = FALSE) %>% 
+      total_duration = c(12, 20, 28, 36), simple = FALSE
+    ) %>%
       mutate(Scenario = g)
   )
 }
@@ -382,7 +384,7 @@ Interim analyses are planned after 12, 20, and 28 months.
 ```{r}
 analysis_time <- c(12, 20, 28, 36)
 upar <- list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL, theta = 0)
-lpar <- list(sf = gsDesign::sfHSD, total_spend = .1, param = - 2, timing = NULL, theta = NULL)
+lpar <- list(sf = gsDesign::sfHSD, total_spend = .1, param = -2, timing = NULL, theta = NULL)
 
 nph_asymmetric <- gs_design_ahr(
   enroll_rate = enroll_rate,
@@ -412,7 +414,7 @@ do.call(
       ahr1 <- (ahr_by_analysis %>% filter(Scenario == x))$AHR1
 
       lparx <- lpar
-      lparx$theta1 <- - log(ahr1)
+      lparx$theta1 <- -log(ahr1)
 
       yy <- gs_power_ahr(
         enroll_rate = enroll_rate %>% filter(Scenario == x),
@@ -453,7 +455,7 @@ do.call(
         alpha = .025,
         beta = .1,
         upar = qnorm(.975),
-        lpar = - Inf,
+        lpar = -Inf,
         analysis_time = 44
       )$analysis %>%
         mutate(Scenario = x)
@@ -482,7 +484,7 @@ do.call(
         alpha = .025,
         beta = .1,
         upar = qnorm(.975),
-        lpar = - Inf,
+        lpar = -Inf,
         analysis_time = 44
       )$analysis %>%
         mutate(Scenario = x)

--- a/vignettes/story_design_with_ahr.Rmd
+++ b/vignettes/story_design_with_ahr.Rmd
@@ -164,7 +164,10 @@ s <- tibble(
 )
 
 # calculate the survival at each change point for each scenario
-s <- rbind(s, s %>% mutate(Treatment = "Experimental", rate = rate * hr)) %>%
+s <- rbind(
+  s,
+  s %>% mutate(Treatment = "Experimental", rate = rate * hr)
+) %>%
   group_by(Scenario, Treatment) %>%
   mutate(Survival = exp(-cumsum(duration * rate)))
 ```

--- a/vignettes/story_design_with_spending.Rmd
+++ b/vignettes/story_design_with_spending.Rmd
@@ -150,8 +150,8 @@ target_power <- 0.9
 If we were using a fixed design, we would approximate the sample size as follows:
 
 ```{r}
-minx <- ((qnorm(.025) / sqrt(zz$info0[n_analysis]) + 
-            qnorm(1 - target_power) / sqrt(zz$info[n_analysis])) / zz$theta[n_analysis])^2
+minx <- ((qnorm(.025) / sqrt(zz$info0[n_analysis]) +
+  qnorm(1 - target_power) / sqrt(zz$info[n_analysis])) / zz$theta[n_analysis])^2
 minx
 ```
 
@@ -163,7 +163,7 @@ gs_power_npe(
   info = yy$info[n_analysis] * minx,
   info0 = yy$info0[n_analysis] * minx,
   upar = qnorm(.975),
-  lpar = - Inf
+  lpar = -Inf
 ) %>%
   filter(bound == "upper") %>%
   select(probability)

--- a/vignettes/story_npe_background.Rmd
+++ b/vignettes/story_npe_background.Rmd
@@ -101,15 +101,15 @@ It can be useful to think of $B_k$ as a sum of independent random variables.
 
 ```{r, message=FALSE, warning=FALSE, echo=FALSE}
 mt <- tibble::tribble(
-  ~ Statistic, ~ Example, ~ "Expected value", ~ Variance,
+  ~Statistic, ~Example, ~"Expected value", ~Variance,
   "$\\hat\\theta_k$", "$\\bar X_k$", "$\\theta(t_k)$", "$\\mathcal{I}_k^{-1}$",
-  "$Z_k=\\sqrt{\\mathcal{I}_k}\\hat\\theta_k$", 
-  "$\\sqrt{n_k}\\bar X_k$", "$\\sqrt{\\mathcal{I}_k}\\theta(t_k)$", 
+  "$Z_k=\\sqrt{\\mathcal{I}_k}\\hat\\theta_k$",
+  "$\\sqrt{n_k}\\bar X_k$", "$\\sqrt{\\mathcal{I}_k}\\theta(t_k)$",
   "$1$",
   "$B_k=\\sqrt{t_k}Z_k$", "$\\sum_{i=1}^{n_k}X_i/\\sqrt N$",
   "$t_k\\sqrt{\\mathcal{I}_K}\\
   theta(t_k)=\\mathcal{I}_k\\
-  theta(t_k)/\\sqrt{\\mathcal{I}_K}$", 
+  theta(t_k)/\\sqrt{\\mathcal{I}_K}$",
   "$t_k$"
 )
 mt %>% kable(escape = FALSE)

--- a/vignettes/story_npe_integration.Rmd
+++ b/vignettes/story_npe_integration.Rmd
@@ -284,7 +284,7 @@ We now update the lower bound in an analogous fashion.
 ```{r}
 # Lower rejection region grid under H1
 grid2_1 <- gsDesign2:::hupdate(
-  theta = theta[2], I = info[2], a = - Inf, b = a2_0,
+  theta = theta[2], I = info[2], a = -Inf, b = a2_0,
   thetam1 = theta[1], Im1 = info[1], gm1 = grid1_1
 )
 plower_0 <- sum(grid2_1$h)
@@ -303,7 +303,7 @@ cat(
 )
 
 grid2_1 <- gsDesign2:::hupdate(
-  theta = theta[2], I = info[2], a = - Inf, b = a2_1,
+  theta = theta[2], I = info[2], a = -Inf, b = a2_1,
   thetam1 = theta[1], Im1 = info[1], gm1 = grid1_1
 )
 plower_1 <- sum(grid2_1$h)

--- a/vignettes/story_nph_futility.Rmd
+++ b/vignettes/story_nph_futility.Rmd
@@ -43,7 +43,7 @@ enroll_rate <- tibble(stratum = "All", duration = 12, rate = 680 / 12)
 ## Censoring rate is 0
 fail_rate <- tibble(
   stratum = "All", duration = c(3, 100),
-  fail_rate = - log(.5) / 12, hr = c(1, .693), dropout_rate = 0
+  fail_rate = -log(.5) / 12, hr = c(1, .693), dropout_rate = 0
 )
 ## Study duration was 34.8 in Korn & Freidlin Table 1
 ## We change to 34.86 here to obtain 512 expected events more precisely
@@ -63,7 +63,7 @@ fixedevents <- fixed_design(
 
 fixedevents %>%
   summary() %>%
-  select(- bound) %>%
+  select(-bound) %>%
   as_gt(footnote = "Power based on 512 events") %>%
   fmt_number(columns = 3:4, decimals = 2) %>%
   fmt_number(columns = 5:6, decimals = 3)
@@ -83,7 +83,7 @@ In the last row under *Alternate hypothesis* below we see the power is 88.44%.
 wieand <- gs_power_ahr(
   enroll_rate = enroll_rate, fail_rate = fail_rate,
   upper = gs_b, upar = c(rep(Inf, 2), qnorm(.975)),
-  lower = gs_b, lpar = c(0, 0, - Inf),
+  lower = gs_b, lpar = c(0, 0, -Inf),
   event = 512 * c(.5, .75, 1)
 )
 wieand %>%

--- a/vignettes/story_power_evaluation_with_spending_bound.Rmd
+++ b/vignettes/story_power_evaluation_with_spending_bound.Rmd
@@ -228,7 +228,7 @@ gs_power_npe(
   upper = gs_spending_bound,
   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
   lower = gs_spending_bound,
-  lpar = list(sf = gsDesign::sfHSD, param = - 2, total_spend = 0.2)
+  lpar = list(sf = gsDesign::sfHSD, param = -2, total_spend = 0.2)
 ) %>%
   gt() %>%
   fmt_number(columns = 3:10, decimals = 4)
@@ -245,7 +245,7 @@ gs_power_npe(
   upper = gs_spending_bound,
   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
   lower = gs_spending_bound,
-  lpar = list(sf = gsDesign::sfHSD, param = - 2, total_spend = 0.2)
+  lpar = list(sf = gsDesign::sfHSD, param = -2, total_spend = 0.2)
 ) %>%
   gt() %>%
   fmt_number(columns = 3:10, decimals = 4)

--- a/vignettes/story_quick_start.Rmd
+++ b/vignettes/story_quick_start.Rmd
@@ -190,7 +190,7 @@ design1s <- gs_design_ahr(
   analysis_time = c(16, 26, 36), # Calendar time of planned analyses
   upper = gs_spending_bound, # Spending function bound for efficacy
   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025), # specify spending function and total Type I error
-  lower = gs_b, lpar = rep(- Inf, 3), # No futility bound
+  lower = gs_b, lpar = rep(-Inf, 3), # No futility bound
   info_scale = 2
 )
 ```
@@ -289,7 +289,7 @@ design2sa <- gs_design_ahr(
   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025), # Same efficacy bound as before
   test_lower = c(FALSE, TRUE, TRUE, TRUE), # Only test efficacy after IA1
   lower = gs_b,
-  lpar = c(rep(qnorm(.05), 2), - Inf, - Inf) # Fixed lower bound at first 2 analyses
+  lpar = c(rep(qnorm(.05), 2), -Inf, -Inf) # Fixed lower bound at first 2 analyses
 )
 ```
 
@@ -301,7 +301,7 @@ design2sa %>%
   summary() %>%
   as_gt(
     title = "2-sided asymmetric group sequential bound using AHR method",
-    subtitle = "Lan-DeMets spending to approximate O'Brien-Fleming bound 
+    subtitle = "Lan-DeMets spending to approximate O'Brien-Fleming bound
     for efficacy, futility disaster check at IA1, IA2 only"
   )
 ```

--- a/vignettes/story_risk_difference.Rmd
+++ b/vignettes/story_risk_difference.Rmd
@@ -459,7 +459,7 @@ pbar <- (x_c + x_e) / n
 se0 <- sqrt(pbar * (1 - pbar) * (1 / n_c + 1 / n_e))
 # Z to test H0
 z <- thetahat / se0
-x <- seq(- 4, 4, .1)
+x <- seq(-4, 4, .1)
 se0a <- sqrt(p * (1 - p) * (1 / n_c + 1 / n_e))
 y <- data.frame(z = x, Density = dnorm(x = x, mean = 0, sd = 1))
 
@@ -551,7 +551,7 @@ theta_h0 <- 0
 theta_h1 <- abs(p_c - p_e) / sigma_h1
 
 tibble::tribble(
-  ~ n_c, ~ n_e, ~ p_c, ~ p_e, ~ theta_h1, ~ theta_h0, ~ info_h1, ~ info_h0,
+  ~n_c, ~n_e, ~p_c, ~p_e, ~theta_h1, ~theta_h0, ~info_h1, ~info_h0,
   n_c, n_e, p_c, p_e, theta_h1, theta_h0, info_h1, info_h0,
 ) %>% gt::gt()
 ```
@@ -587,8 +587,8 @@ y_0 <- gs_design_npe(
   beta = .1,
   upper = gs_b,
   lower = gs_b,
-  upar = list(par = - qnorm(.025)),
-  lpar = list(par = - Inf)
+  upar = list(par = -qnorm(.025)),
+  lpar = list(par = -Inf)
 )
 
 # under info_scale = 1
@@ -601,8 +601,8 @@ y_1 <- gs_design_npe(
   beta = .1,
   upper = gs_b,
   lower = gs_b,
-  upar = list(par = - qnorm(.025)),
-  lpar = list(par = - Inf)
+  upar = list(par = -qnorm(.025)),
+  lpar = list(par = -Inf)
 )
 
 # under info_scale = 2
@@ -615,8 +615,8 @@ y_2 <- gs_design_npe(
   beta = .1,
   upper = gs_b,
   lower = gs_b,
-  upar = list(par = - qnorm(.025)),
-  lpar = list(par = - Inf)
+  upar = list(par = -qnorm(.025)),
+  lpar = list(par = -Inf)
 )
 
 tibble(
@@ -642,8 +642,8 @@ z_info_scale_0 <- gs_design_rd(
   weight = "un-stratified",
   upper = gs_b,
   lower = gs_b,
-  upar = - qnorm(.025),
-  lpar = - Inf,
+  upar = -qnorm(.025),
+  lpar = -Inf,
   info_scale = 0
 )
 
@@ -657,8 +657,8 @@ z_info_scale_1 <- gs_design_rd(
   weight = "un-stratified",
   upper = gs_b,
   lower = gs_b,
-  upar = - qnorm(.025),
-  lpar = - Inf,
+  upar = -qnorm(.025),
+  lpar = -Inf,
   info_scale = 1
 )
 
@@ -672,8 +672,8 @@ z_info_scale_2 <- gs_design_rd(
   weight = "un-stratified",
   upper = gs_b,
   lower = gs_b,
-  upar = - qnorm(.025),
-  lpar = - Inf,
+  upar = -qnorm(.025),
+  lpar = -Inf,
   info_scale = 2
 )
 ```
@@ -757,7 +757,7 @@ y_gs0 <- gs_design_npe(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE
 )
 
@@ -770,7 +770,7 @@ y_gs1 <- gs_design_npe(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE
 )
 
@@ -783,7 +783,7 @@ y_gs2 <- gs_design_npe(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE
 )
 
@@ -793,8 +793,10 @@ tibble(
   `info_scale = 2` = y_gs2$info / x_gs$info1[3]
 ) %>%
   gt::gt() %>%
-  gt::tab_header(title = "The sample size calculated by `gsDesign2` under 3 info_scale", 
-                 subtitle = "under group sequential design")
+  gt::tab_header(
+    title = "The sample size calculated by `gsDesign2` under 3 info_scale",
+    subtitle = "under group sequential design"
+  )
 ```
 
 The above logic is implemented in `gs_design_rd()`.
@@ -812,7 +814,7 @@ x_gsdesign2_info_scale_0 <- gs_design_rd(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE,
   info_scale = 0
 )
@@ -829,7 +831,7 @@ x_gsdesign2_info_scale_1 <- gs_design_rd(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE,
   info_scale = 1
 )
@@ -846,7 +848,7 @@ x_gsdesign2_info_scale_2 <- gs_design_rd(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE,
   info_scale = 2
 )
@@ -975,8 +977,8 @@ x <- p_c %>%
   left_join(p_e) %>%
   rename(p_e = rate) %>%
   mutate(p_pool = (p_c + p_e) / 2) %>%
-  mutate(xi_c = (ratio_strata_c %>% mutate(prop = ratio / sum(ratio)))$prop) %>% 
-  mutate(xi_e = (ratio_strata_e %>% mutate(prop = ratio / sum(ratio)))$prop) %>% 
+  mutate(xi_c = (ratio_strata_c %>% mutate(prop = ratio / sum(ratio)))$prop) %>%
+  mutate(xi_e = (ratio_strata_e %>% mutate(prop = ratio / sum(ratio)))$prop) %>%
   mutate(n_c = n_c * xi_c, n_e = n_e * xi_e)
 
 x %>%
@@ -1073,7 +1075,7 @@ x <- x %>%
     weight_invar_H1 = 1 / sigma_h1^2 / sum_invar_H1,
     weight_ss = (n_c * n_e) / (n_c + n_e) / sum_ss
   ) %>%
-  select(- c(sum_invar_H0, sum_invar_H1, sum_ss))
+  select(-c(sum_invar_H0, sum_invar_H1, sum_ss))
 
 x %>%
   gt() %>%
@@ -1131,34 +1133,33 @@ x <- x %>%
     rd_invar_H1 = sum(weight_invar_H1 * abs(p_c - p_e)),
     rd_ss = sum(weight_ss * abs(p_c - p_e)),
     rd0 = 0,
-    info_invar_H0 = 1 / 
+    info_invar_H0 = 1 /
       sum(
-        weight_invar_H0^2 * p_c * (1 - p_c) / 
+        weight_invar_H0^2 * p_c * (1 - p_c) /
           n_c + weight_invar_H0^2 * p_e * (1 - p_e) / n_e
-        ),
-    info_invar_H1 = 1 / 
+      ),
+    info_invar_H1 = 1 /
       sum(
-        weight_invar_H1^2 * p_c * (1 - p_c) / 
+        weight_invar_H1^2 * p_c * (1 - p_c) /
           n_c + weight_invar_H1^2 * p_e * (1 - p_e) / n_e
-        ),
-    info_ss = 1 / 
+      ),
+    info_ss = 1 /
       sum(
         weight_ss^2 * p_c * (1 - p_c) / n_c + weight_ss^2 * p_e * (1 - p_e) / n_e
-        ),
-    info0_invar_H0 = 1 / 
+      ),
+    info0_invar_H0 = 1 /
       sum(
-        weight_invar_H0^2 * p_pool * (1 - p_pool) / n_c + 
+        weight_invar_H0^2 * p_pool * (1 - p_pool) / n_c +
           weight_invar_H0^2 * p_pool * (1 - p_pool) / n_e
-        ),
-    info0_invar_H1 = 1 / 
-      sum(weight_invar_H1^2 * p_pool * (1 - p_pool) / 
-            n_c + weight_invar_H1^2 * p_pool * (1 - p_pool) / n_e
-          ),
-    info0_ss = 1 / 
+      ),
+    info0_invar_H1 = 1 /
+      sum(weight_invar_H1^2 * p_pool * (1 - p_pool) /
+        n_c + weight_invar_H1^2 * p_pool * (1 - p_pool) / n_e),
+    info0_ss = 1 /
       sum(
-        weight_ss^2 * p_pool * (1 - p_pool) / n_c + 
-            weight_ss^2 * p_pool * (1 - p_pool) / n_e
-          )
+        weight_ss^2 * p_pool * (1 - p_pool) / n_c +
+          weight_ss^2 * p_pool * (1 - p_pool) / n_e
+      )
   )
 ```
 
@@ -1168,32 +1169,32 @@ x %>%
   gt::gt() %>%
   fmt_number(c(2:4, 6:11), decimals = 6) %>%
   gt::tab_footnote(
-    footnote = "info_invar_H0 = the statistical information under H1 
+    footnote = "info_invar_H0 = the statistical information under H1
     per stratum per analysis calculated by INVAR by using variance under H0.",
     locations = gt::cells_column_labels(columns = info_invar_H0)
   ) %>%
   gt::tab_footnote(
-    footnote = "info_invar_H1 = the statistical information under H1 
+    footnote = "info_invar_H1 = the statistical information under H1
     per stratum per analysis calculated by INVAR by using variance under H0.",
     locations = gt::cells_column_labels(columns = info_invar_H1)
   ) %>%
   gt::tab_footnote(
-    footnote = "info_ss = the statistical information under H1 
+    footnote = "info_ss = the statistical information under H1
     per stratum per analysis calculated by SS.",
     locations = gt::cells_column_labels(columns = info_ss)
   ) %>%
   gt::tab_footnote(
-    footnote = "info0_invar_H0 = the statistical information under H0 
+    footnote = "info0_invar_H0 = the statistical information under H0
     per stratum per analysis calculated by INVAR by using variance under H0.",
     locations = gt::cells_column_labels(columns = info0_invar_H0)
   ) %>%
   gt::tab_footnote(
-    footnote = "info0_invar_H1 = the statistical information under H0 
+    footnote = "info0_invar_H1 = the statistical information under H0
     per stratum per analysis calculated by INVAR by using variance under H0.",
     locations = gt::cells_column_labels(columns = info0_invar_H1)
   ) %>%
   gt::tab_footnote(
-    footnote = "info0_ss = the statistical information under H0 
+    footnote = "info0_ss = the statistical information under H0
     per stratum per analysis calculated by SS.",
     locations = gt::cells_column_labels(columns = info0_ss)
   )
@@ -1213,7 +1214,7 @@ y_invar_h0 <- gs_design_npe(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE,
 )
 
@@ -1227,7 +1228,7 @@ y_invar_h1 <- gs_design_npe(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE,
 )
 
@@ -1241,7 +1242,7 @@ y_ss <- gs_design_npe(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE,
 )
 
@@ -1258,7 +1259,7 @@ yy_invar_h0 <- gs_design_npe(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE,
 )
 
@@ -1272,7 +1273,7 @@ yy_invar_h1 <- gs_design_npe(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE,
 )
 
@@ -1286,7 +1287,7 @@ yy_ss <- gs_design_npe(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = rep(- Inf, 3),
+  lpar = rep(-Inf, 3),
   test_lower = FALSE,
 )
 
@@ -1325,7 +1326,7 @@ x_ss0 <- gs_design_rd(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = c(qnorm(.1), rep(- Inf, 2)),
+  lpar = c(qnorm(.1), rep(-Inf, 2)),
   info_scale = 0,
   binding = FALSE
 )
@@ -1346,7 +1347,7 @@ x_ss1 <- gs_design_rd(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = c(qnorm(.1), rep(- Inf, 2)),
+  lpar = c(qnorm(.1), rep(-Inf, 2)),
   info_scale = 1,
   binding = FALSE
 )
@@ -1367,7 +1368,7 @@ x_ss2 <- gs_design_rd(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = c(qnorm(.1), rep(- Inf, 2)),
+  lpar = c(qnorm(.1), rep(-Inf, 2)),
   info_scale = 2,
   binding = FALSE
 )
@@ -1388,7 +1389,7 @@ x_invar0 <- gs_design_rd(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = c(qnorm(.1), rep(- Inf, 2)),
+  lpar = c(qnorm(.1), rep(-Inf, 2)),
   info_scale = 0,
   binding = FALSE
 )
@@ -1409,7 +1410,7 @@ x_invar1 <- gs_design_rd(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = c(qnorm(.1), rep(- Inf, 2)),
+  lpar = c(qnorm(.1), rep(-Inf, 2)),
   info_scale = 1,
   binding = FALSE
 )
@@ -1430,7 +1431,7 @@ x_invar2 <- gs_design_rd(
   upper = gs_b,
   lower = gs_b,
   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-  lpar = c(qnorm(.1), rep(- Inf, 2)),
+  lpar = c(qnorm(.1), rep(-Inf, 2)),
   info_scale = 2,
   binding = FALSE
 )
@@ -1553,7 +1554,7 @@ run_simulation <- function(n, weight_method, n_sim, prevalence_ratio, info_frac,
           weight_invar_H1 = 1 / sigma_h1^2 / sum_invar_H1,
           weight_ss = (sample_size_c * sample_size_e) / (sample_size_c + sample_size_e) / sum_ss
         ) %>%
-        select(- c(sum_invar_H0, sum_invar_H1, sum_ss)) %>%
+        select(-c(sum_invar_H0, sum_invar_H1, sum_ss)) %>%
         # calculated the weighted rd and info
         group_by(analysis) %>%
         summarise( # weighted risk difference
@@ -1562,15 +1563,15 @@ run_simulation <- function(n, weight_method, n_sim, prevalence_ratio, info_frac,
           rd_ss = sum(weight_ss * abs(p_c - p_e)),
           rd0 = 0,
           # weighted statistical information under H1
-          info_invar_H0 = 1 / 
-            sum(weight_invar_H0^2 * p_c * (1 - p_c) / sample_size_c + 
-                  weight_invar_H0^2 * p_e * (1 - p_e) / sample_size_e),
-          info_invar_H1 = 1 / 
-            sum(weight_invar_H1^2 * p_c * (1 - p_c) / sample_size_c + 
-                  weight_invar_H1^2 * p_e * (1 - p_e) / sample_size_e),
-          info_ss = 1 / 
-            sum(weight_ss^2 * p_c * (1 - p_c) / sample_size_c + 
-                  weight_ss^2 * p_e * (1 - p_e) / sample_size_e),
+          info_invar_H0 = 1 /
+            sum(weight_invar_H0^2 * p_c * (1 - p_c) / sample_size_c +
+              weight_invar_H0^2 * p_e * (1 - p_e) / sample_size_e),
+          info_invar_H1 = 1 /
+            sum(weight_invar_H1^2 * p_c * (1 - p_c) / sample_size_c +
+              weight_invar_H1^2 * p_e * (1 - p_e) / sample_size_e),
+          info_ss = 1 /
+            sum(weight_ss^2 * p_c * (1 - p_c) / sample_size_c +
+              weight_ss^2 * p_e * (1 - p_e) / sample_size_e),
           # weighted statistical information under H0
           info0_invar_H0 = 1 / sum(weight_invar_H0^2 * p_pool * (1 - p_pool) * (1 / sample_size_e + 1 / sample_size_c)),
           info0_invar_H1 = 1 / sum(weight_invar_H1^2 * p_pool * (1 - p_pool) * (1 / sample_size_e + 1 / sample_size_c)),
@@ -1591,7 +1592,7 @@ run_simulation <- function(n, weight_method, n_sim, prevalence_ratio, info_frac,
             upper = gs_b,
             lower = gs_b,
             upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-            lpar = c(qnorm(.1), rep(- Inf, 2)),
+            lpar = c(qnorm(.1), rep(-Inf, 2)),
             test_upper = TRUE,
             test_lower = TRUE,
             r = 18,
@@ -1607,7 +1608,7 @@ run_simulation <- function(n, weight_method, n_sim, prevalence_ratio, info_frac,
             upper = gs_b,
             lower = gs_b,
             upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-            lpar = c(qnorm(.1), rep(- Inf, 2)),
+            lpar = c(qnorm(.1), rep(-Inf, 2)),
             test_upper = TRUE,
             test_lower = TRUE,
             r = 18,
@@ -1623,7 +1624,7 @@ run_simulation <- function(n, weight_method, n_sim, prevalence_ratio, info_frac,
             upper = gs_b,
             lower = gs_b,
             upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-            lpar = c(qnorm(.1), rep(- Inf, 2)),
+            lpar = c(qnorm(.1), rep(-Inf, 2)),
             test_upper = TRUE,
             test_lower = TRUE,
             r = 18,
@@ -1670,7 +1671,7 @@ run_simulation <- function(n, weight_method, n_sim, prevalence_ratio, info_frac,
       }
 
       p <- pmvnorm(
-        lower = c(rep(- Inf, 3)),
+        lower = c(rep(-Inf, 3)),
         upper = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
         mean = mean_sim,
         corr = matrix(

--- a/vignettes/story_risk_difference.Rmd
+++ b/vignettes/story_risk_difference.Rmd
@@ -977,8 +977,16 @@ x <- p_c %>%
   left_join(p_e) %>%
   rename(p_e = rate) %>%
   mutate(p_pool = (p_c + p_e) / 2) %>%
-  mutate(xi_c = (ratio_strata_c %>% mutate(prop = ratio / sum(ratio)))$prop) %>%
-  mutate(xi_e = (ratio_strata_e %>% mutate(prop = ratio / sum(ratio)))$prop) %>%
+  mutate(
+    xi_c = (
+      ratio_strata_c %>% mutate(prop = ratio / sum(ratio))
+    )$prop
+  ) %>%
+  mutate(
+    xi_e = (
+      ratio_strata_e %>% mutate(prop = ratio / sum(ratio))
+    )$prop
+  ) %>%
   mutate(n_c = n_c * xi_c, n_e = n_e * xi_e)
 
 x %>%

--- a/vignettes/story_spending_time_example.Rmd
+++ b/vignettes/story_spending_time_example.Rmd
@@ -333,7 +333,7 @@ m <- 12
 planned_info_frac <- c(.8, 1)
 
 # No futility bound
-lpar <- rep(- Inf, 2)
+lpar <- rep(-Inf, 2)
 
 # enrollment rate
 enroll_rate <- tibble(
@@ -466,7 +466,7 @@ fho <- gs_power_ahr(
   # allocated will not be used
   test_upper = c(FALSE, FALSE, TRUE, TRUE, TRUE),
   lower = gs_b,
-  lpar = c(rep(qnorm(.05), 4), - Inf)
+  lpar = c(rep(qnorm(.05), 4), -Inf)
 )
 
 fho %>%
@@ -651,7 +651,7 @@ upar_design_spend <- list(
 )
 
 # lower bound: no futility bound
-lpar <- rep(- Inf, 2) # Z = -infinity for lower bound
+lpar <- rep(-Inf, 2) # Z = -infinity for lower bound
 
 # we will base the combined hypothesis design to ensure power in the biomarker subgroup
 positive <- gs_design_ahr(
@@ -821,7 +821,7 @@ positive_60_power <- gs_power_ahr(
   enroll_rate = positive_60_enroll_rate %>% filter(stratum == "Positive"),
   fail_rate = fail_rate %>% filter(stratum == "Positive"),
   # number of events
-  event = positive$analysis$event, 
+  event = positive$analysis$event,
   # analysis time will be calcuated to achieve the targeted events
   analysis_time = NULL,
   # upper bound
@@ -857,7 +857,7 @@ gs_power_ahr(
   upar = upar_overall_planned_info_frac,
   # set lower bound: no futility
   lower = gs_b,
-  lpar = rep(- Inf, 2)
+  lpar = rep(-Inf, 2)
 ) %>%
   summary() %>%
   gt() %>%
@@ -928,7 +928,7 @@ positive_40_power <- gs_power_ahr(
   upar = upar_actual_info_frac,
   # set lower bound
   lower = gs_b,
-  lpar = rep(- Inf, 2)
+  lpar = rep(-Inf, 2)
 )
 
 positive_40_power %>%
@@ -951,7 +951,7 @@ gs_power_ahr(
   upper = gs_spending_bound,
   upar = upar_overall_planned_info_frac,
   lower = gs_b,
-  lpar = rep(- Inf, 2)
+  lpar = rep(-Inf, 2)
 ) %>%
   summary() %>%
   gt() %>%
@@ -975,7 +975,7 @@ Where crossing survival curves or inferior survival curves may exist, this may b
 
 In addition to the delayed effect example, we considered an example testing in both a biomarker positive subgroup and the overall population.
 Using a common spending time for all hypotheses with a common interim analysis strategy as advocated by @FPG can be helpful to implement spending so that all hypotheses have adequate $\alpha$ to spend at the final analysis and also to ensure full utilization of $\alpha$-spending. We suggested again using the minimum of planned and actual spending at interim analysis. Spending can be based on a key hypothesis (e.g., the biomarker positive population) or the minimum spending time among all hypotheses being tested.
-Taking advantage of know correlations to ensure full $\alpha$ utilitization in multiple hypothesis testing is also more simply implemented with this strategy @AGZS2021unified.
+Taking advantage of know correlations to ensure full $\alpha$ utilization in multiple hypothesis testing is also more simply implemented with this strategy @AGZS2021unified.
 
 In summary, we have illustrated both the motivation and the illustration of the spending time approach through examples we have commonly encountered. Approaches suggested included an implementation of @FHO with a fixed incremental $\alpha$-spend at each interim analysis as well as the use of the minimum of planned and actual spending at interim analyses.
 

--- a/vignettes/story_summarize_designs.Rmd
+++ b/vignettes/story_summarize_designs.Rmd
@@ -103,9 +103,9 @@ wgt05 <- function(x, arm0, arm1) { # Early downweighting with FH(0,.5)
 # Both of above tests for MaxCombo: logrank and FH(0,.5)
 fh_test <- rbind(
   # Include logrank for all 3 analyses
-  data.frame(rho = 0, gamma = 0, tau = - 1, test = 1, Analysis = 1:3, analysis_time = c(12, 24, 36)),
+  data.frame(rho = 0, gamma = 0, tau = -1, test = 1, Analysis = 1:3, analysis_time = c(12, 24, 36)),
   # Only include FH(0,.5) for analyses 2 and 3
-  data.frame(rho = c(0, 0.5), gamma = 0.5, tau = - 1, test = 2:3, Analysis = 3, analysis_time = 36)
+  data.frame(rho = c(0, 0.5), gamma = 0.5, tau = -1, test = 2:3, Analysis = 3, analysis_time = 36)
 )
 ```
 

--- a/vignettes/usage_AHR.Rmd
+++ b/vignettes/usage_AHR.Rmd
@@ -170,14 +170,14 @@ Here the `t` column is the start of period, the `fail_rate` column is the failur
 events <- rbind(
   events_c %>% mutate(Treatment = "Control"),
   events_e %>% mutate(Treatment = "Experimental")
-  ) %>%
+) %>%
   arrange(t, Treatment) %>%
   ungroup() %>%
   # recompute HR, events, info by period
   group_by(t) %>%
   summarize(
     stratum = s,
-    info = (sum(1 / event))^(- 1),
+    info = (sum(1 / event))^(-1),
     Events = sum(event),
     HR = last(fail_rate) / first(fail_rate)
   ) %>%

--- a/vignettes/usage_expected_event.Rmd
+++ b/vignettes/usage_expected_event.Rmd
@@ -124,7 +124,7 @@ sf_enroll_rate <- stepfun(c(0, cumsum(enroll_rate$duration)),
 
 plot(sf_enroll_rate,
   xlab = "duration", ylab = "enrollment rates",
-  main = "Piecewise enrollment rate over time", xlim = c(- 0.01, 21)
+  main = "Piecewise enrollment rate over time", xlim = c(-0.01, 21)
 )
 ```
 
@@ -147,7 +147,7 @@ sf_fail_rate <- stepfun(time_start_fail,
 )
 plot(sf_fail_rate,
   xlab = "duration", ylab = "failure rates",
-  main = "Piecewise failure rate over time", xlim = c(- 0.01, 101)
+  main = "Piecewise failure rate over time", xlim = c(-0.01, 101)
 )
 
 # plot the piecewise dropout rate
@@ -157,7 +157,7 @@ sf_dropout_rate <- stepfun(time_start_fail,
 )
 plot(sf_dropout_rate,
   xlab = "duration", ylab = "dropout rates",
-  main = "Piecewise dropout rate over time", xlim = c(- 0.01, 101)
+  main = "Piecewise dropout rate over time", xlim = c(-0.01, 101)
 )
 ```
 
@@ -173,19 +173,19 @@ Given the above piecewise enrollment rates, failure rates, dropout rates, the ti
 plot(sf_enroll_rate,
   xlab = "time", ylab = "enrollment rates",
   lty = 1, col = "red", pch = 1,
-  main = "Piecewise enrollment, failure, dropout rate over time", xlim = c(- 0.01, 101)
+  main = "Piecewise enrollment, failure, dropout rate over time", xlim = c(-0.01, 101)
 )
 
 plot(sf_fail_rate,
   xlab = "time", ylab = "failure rates",
   lty = 2, col = "blue", pch = 2,
-  xlim = c(- 0.01, 101), add = TRUE
+  xlim = c(-0.01, 101), add = TRUE
 )
 
 plot(sf_dropout_rate,
   xlab = "time", ylab = "dropout rates",
   lty = 3, col = "green", pch = 3,
-  xlim = c(- 0.01, 101), add = TRUE
+  xlim = c(-0.01, 101), add = TRUE
 )
 
 legend(60, 20, c("enrollment rate", "failure rate", "dropout rate"),
@@ -263,7 +263,7 @@ For the above `df_2`, one needs to discriminate if the analysis time (`total_dur
 ```{r}
 # if the analysis time is after the total failure rate duration
 if (sum(fail_rate$duration) < total_duration) {
-  df_2 <- df_2[- nrow(df_2), ]
+  df_2 <- df_2[-nrow(df_2), ]
 } else {
   df_2 <- df_2 %>% filter(startEnroll > 0)
 }
@@ -329,7 +329,7 @@ df <- df %>%
     dropoutRate = sf_dropout_rate(time_start_fail),
     enrollRate = sf_enroll_rate(startEnroll)
   ) %>%
-  select(- rate)
+  select(-rate)
 ```
 
 ```{r, echo=FALSE}
@@ -350,9 +350,9 @@ df %>%
     locations = cells_column_labels("time_start_fail")
   ) %>%
   tab_footnote(
-    footnote = "The time when the failure rate ends. 
-    And startEnroll + endFail = 50. 
-    Besides, (time_start_fail, endFail  ] forms 
+    footnote = "The time when the failure rate ends.
+    And startEnroll + endFail = 50.
+    Besides, (time_start_fail, endFail  ] forms
     the piecewise model of the enrollment rates.",
     locations = cells_column_labels("endFail")
   ) %>%
@@ -370,7 +370,7 @@ df %>%
 # Q: cumulative product of q (pool all sub-intervals)
 df <- df %>%
   mutate(
-    q = exp(- duration * (failRate + dropoutRate)),
+    q = exp(-duration * (failRate + dropoutRate)),
     Q = lag(cumprod(q), default = 1)
   ) %>%
   arrange(desc(time_start_fail)) %>%
@@ -384,13 +384,16 @@ df <- df %>%
   arrange(time_start_fail) %>%
   # Compute expected events as nbar in a sub-interval
   mutate(
-    d = ifelse(failRate == 0, 0, Q * (1 - q) * failRate / 
-                 (failRate + dropoutRate)),
-    nbar = ifelse(failRate == 0, 0, 
-                  G * d + 
-                    (failRate * Q * enrollRate) / 
-                    (failRate + dropoutRate) * 
-                    (duration - (1 - q) / (failRate + dropoutRate)))
+    d = ifelse(
+      failRate == 0,
+      0,
+      Q * (1 - q) * failRate / (failRate + dropoutRate)
+    ),
+    nbar = ifelse(
+      failRate == 0,
+      0,
+      G * d + (failRate * Q * enrollRate) / (failRate + dropoutRate) * (duration - (1 - q) / (failRate + dropoutRate))
+    )
   )
 ```
 

--- a/vignettes/usage_fixed_design.Rmd
+++ b/vignettes/usage_fixed_design.Rmd
@@ -291,7 +291,7 @@ fixed_design(
 In the above example, the MaxCombo parameters take the default value
 
 ```{r}
-data.frame(rho = c(0, 0), gamma = c(0, 0.5), tau = - 1) %>% gt()
+data.frame(rho = c(0, 0), gamma = c(0, 0.5), tau = -1) %>% gt()
 ```
 
 But users can always custom their `rho`, `gamma`, `tau` by
@@ -307,7 +307,7 @@ fixed_design(
   study_duration = study_duration,
   rho = c(0, 0.5, 0.5),
   gamma = c(0, 0, 0.5),
-  tau = c(- 1, 4, 6)
+  tau = c(-1, 4, 6)
 ) %>%
   summary() %>%
   as_gt()
@@ -340,7 +340,7 @@ fixed_design(
   study_duration = study_duration,
   rho = c(0, 0.5, 0.5),
   gamma = c(0, 0, 0.5),
-  tau = c(- 1, 4, 6)
+  tau = c(-1, 4, 6)
 ) %>%
   summary() %>%
   as_gt()
@@ -502,7 +502,7 @@ x_maxcombo <- fixed_design(
   study_duration = study_duration,
   rho = c(0, 0.5, 0.5),
   gamma = c(0, 0, 0.5),
-  tau = c(- 1, 4, 6)
+  tau = c(-1, 4, 6)
 )
 
 x_rmst <- fixed_design(
@@ -525,8 +525,10 @@ x_milestone <- fixed_design(
   tau = 30
 )
 
-rbind(summary(x_ahr), summary(x_fh), 
-      summary(x_mb), summary(x_lf), 
-      summary(x_maxcombo), summary(x_rmst), 
-      summary(x_milestone)) %>% gt()
+rbind(
+  summary(x_ahr), summary(x_fh),
+  summary(x_mb), summary(x_lf),
+  summary(x_maxcombo), summary(x_rmst),
+  summary(x_milestone)
+) %>% gt()
 ```

--- a/vignettes/usage_gs_info_ahr.Rmd
+++ b/vignettes/usage_gs_info_ahr.Rmd
@@ -141,7 +141,7 @@ ahr(
   enroll_rate = enroll_rate, fail_rate = fail_rate,
   ratio = ratio, total_duration = analysis_time
 ) %>%
-  mutate(theta = - log(ahr), Analysis = seq_along(analysis_time)) %>%
+  mutate(theta = -log(ahr), Analysis = seq_along(analysis_time)) %>%
   select(Analysis, time, event, ahr, theta, info, info0) %>%
   gt()
 ```
@@ -183,7 +183,7 @@ for (i in seq_along(events)) {
 }
 
 ans %>%
-  mutate(theta = - log(ahr), Analysis = seq_along(analysis_time)) %>%
+  mutate(theta = -log(ahr), Analysis = seq_along(analysis_time)) %>%
   select(Analysis, time, event, ahr, theta, info, info0) %>%
   gt()
 ```
@@ -241,7 +241,7 @@ for (i in seq_along(events)) {
 }
 
 ans %>%
-  mutate(theta = - log(ahr), Analysis = seq_along(analysis_time)) %>%
+  mutate(theta = -log(ahr), Analysis = seq_along(analysis_time)) %>%
   select(Analysis, time, event, ahr, theta, info, info0) %>%
   gt()
 ```

--- a/vignettes/usage_gs_power_npe.Rmd
+++ b/vignettes/usage_gs_power_npe.Rmd
@@ -48,7 +48,7 @@ gs_power_npe(
   theta = rep(0, 3),
   info = (1:3) * 40,
   upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
-  lpar = rep(- Inf, 3)
+  lpar = rep(-Inf, 3)
 ) %>%
   filter(bound == "upper") %>%
   gt()
@@ -64,7 +64,7 @@ gs_power_npe(
   upper = gs_b,
   upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
   lower = gs_b,
-  lpar = c(- 1, 0, 0)
+  lpar = c(-1, 0, 0)
 ) %>% gt()
 ```
 
@@ -77,7 +77,7 @@ gs_power_npe(
   upper = gs_b,
   upar = c(Inf, 3, 2),
   lower = gs_b,
-  lpar = c(qnorm(.1), - Inf, - Inf)
+  lpar = c(qnorm(.1), -Inf, -Inf)
 ) %>% gt()
 ```
 
@@ -92,7 +92,7 @@ gs_power_npe(
   upper = gs_spending_bound,
   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
   lower = gs_spending_bound,
-  lpar = list(sf = gsDesign::sfHSD, total_spend = 0.1, param = - 1, timing = NULL)
+  lpar = list(sf = gsDesign::sfHSD, total_spend = 0.1, param = -1, timing = NULL)
 )
 ```
 
@@ -122,7 +122,7 @@ gs_power_npe(
   info = (1:3) * 40,
   binding = TRUE,
   upar = (x %>% filter(bound == "upper"))$z,
-  lpar = - (x %>% filter(bound == "upper"))$z
+  lpar = -(x %>% filter(bound == "upper"))$z
 ) %>%
   gt()
 ```

--- a/vignettes/usage_gs_spending_bound.Rmd
+++ b/vignettes/usage_gs_spending_bound.Rmd
@@ -69,7 +69,6 @@ b2 <- gs_spending_bound(
   hgm1 = gsDesign2:::h1(r = 18, theta = 0, I = info[1], a = a1, b = b1)
 )
 cat("The upper boundary at the 2nd analysis is (", a2, ", ", b2, ").\n")
-
 ```
 
 # Inner Logic of `gs_spending_bound()`

--- a/vignettes/usage_summary_as_gt.Rmd
+++ b/vignettes/usage_summary_as_gt.Rmd
@@ -106,9 +106,9 @@ wgt05 <- function(x, arm0, arm1) { # Early downweighting with FH(0,.5)
 # Both of above tests for MaxCombo: logrank and FH(0,.5)
 fh_test <- rbind(
   # Include logrank for all 3 analyses
-  data.frame(rho = 0, gamma = 0, tau = - 1, test = 1, Analysis = 1:3, analysis_time = c(12, 24, 36)),
+  data.frame(rho = 0, gamma = 0, tau = -1, test = 1, Analysis = 1:3, analysis_time = c(12, 24, 36)),
   # Only include FH(0,.5) for analyses 2 and 3
-  data.frame(rho = c(0, 0.5), gamma = 0.5, tau = - 1, test = 2:3, Analysis = 3, analysis_time = 36)
+  data.frame(rho = c(0, 0.5), gamma = 0.5, tau = -1, test = 2:3, Analysis = 3, analysis_time = 36)
 )
 ```
 


### PR DESCRIPTION
This PR fixes all remaining code linting issues by:

- Fixing the specific issue if it is obvious.
- Adding rules to `.lintr` to exclude specific linters (object name linter and commented code linter) for specific files (mostly tests) if the proper fix is too much overhead.

Now all workflows should pass, including the lintr workflow.