### PR TITLE
Use `\donttest{}` to replace `\dontrun{}`

### DIFF
--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -225,7 +225,7 @@ as_gt.fixed_design <- function(x, title = NULL, footnote = NULL, ...) {
 #' @export
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # the default output
 #' library(dplyr)
 #'

--- a/inst/helper_function/ahr_blinded.R
+++ b/inst/helper_function/ahr_blinded.R
@@ -56,7 +56,7 @@
 #' and `HR` is returned instead of `AHR`
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' library(simtrial)
 #' library(survival)
 #' ahr_blinded(

--- a/man/as_gt.Rd
+++ b/man/as_gt.Rd
@@ -122,7 +122,7 @@ fixed_design(
   summary() \%>\%
   as_gt()
 
-\dontrun{
+\donttest{
 # the default output
 library(dplyr)
 


### PR DESCRIPTION
This PR replaces the last remaining `\dontrun{}` directives with `\donttest{}`.

Otherwise, using `\dontrun{}` in an example often get a note.