### PR TITLE
Replace `devtools::load_all()`

### DIFF
--- a/vignettes/articles/story-compute-npe-bound.Rmd
+++ b/vignettes/articles/story-compute-npe-bound.Rmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(
 ## Overview
 
 We consider group sequential designs with possibly non-constant treatment effects over time.
-This can be useful for situations such as an assumed non-proportional hazards model as laid out in `vignette("NPEbackground", package="gsDesign2")`.
+This can be useful for situations such as an assumed non-proportional hazards model as laid out in `vignettes/articles/story-npe-background.Rmd`.
 In general, we assume $K \geq 1$ analyses with statistical information $\mathcal{I}_k$ and information fraction $t_k=\mathcal{I}_k/\mathcal{I}_k$ at analysis $k$, $1\leq k\leq K$.
 We denote the null hypothesis $H_{0}$: $\theta(t)=0$ and an alternate hypothesis $H_1$: $\theta(t)=\theta_1(t)$ for $t> 0$ where $t$ represents the information fraction for a study.
 While a study is planned to stop at information fraction $t=1$, we define $\theta(t)$ for $t>0$ since a trial can overrun its planned statistical information at the final analysis.

--- a/vignettes/articles/story-npe-background.Rmd
+++ b/vignettes/articles/story-npe-background.Rmd
@@ -20,10 +20,13 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+```
+
+```{r}
 library(tibble)
 library(dplyr)
 library(knitr)
-devtools::load_all()
+library(gsDesign2)
 ```
 
 ## Overview

--- a/vignettes/articles/story-npe-integration.Rmd
+++ b/vignettes/articles/story-npe-integration.Rmd
@@ -272,7 +272,7 @@ cat(
   "Original bound approximation:", b2_0,
   "\nUpdated bound approximation:", b2_1
 )
-grid2_0 <- hupdate(theta = 0, I = info[2], a = b2_1, b = Inf, Im1 = info[1], gm1 = grid1_0)
+grid2_0 <- gsDesign2:::hupdate(theta = 0, I = info[2], a = b2_1, b = Inf, Im1 = info[1], gm1 = grid1_0)
 pupper_1 <- sum(grid2_0$h)
 cat(
   "\nOriginal boundary crossing probability:", pupper_0,

--- a/vignettes/articles/story-npe-integration.Rmd
+++ b/vignettes/articles/story-npe-integration.Rmd
@@ -20,16 +20,19 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+```
+
+```{r}
 library(tibble)
 library(dplyr)
 library(knitr)
-devtools::load_all()
+library(gsDesign2)
 ```
 
 ## Overview
 
-We have provided asymptotic distribution theory and notation for group sequential boundaries in
-`vignette("NPEbackground", package="gsDesign2")`.
+We have provided asymptotic distribution theory and notation for
+group sequential boundaries in `vignettes/articles/story-npe-background.Rmd`.
 
 This vignettes generalize computational algorithms provided in Chapter 19 of @jennison1999group that are used to compute boundary crossing probabilities as well as derive boundaries for group sequential designs.
 


### PR DESCRIPTION
This PR replaces the last remaining `devtools::load_all()` with `library(gsDesign2)` in the vignettes (articles).