### PR TITLE
Standardize enumerate and class names

### DIFF
--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -317,7 +317,7 @@ as_gt.gs_design <- function(x,
                             ...) {
   method <- class(x)[class(x) %in% c("ahr", "wlr", "combo", "rd")]
   x_alpha <- max((x %>% dplyr::filter(Bound == display_bound[1]))[[colname_spannersub[2]]])
-  x_non_binding <- "non-binding" %in% class(x)
+  x_non_binding <- "non_binding" %in% class(x)
   x_k <- lapply(x$Analysis, function(x) {
     return(as.numeric(substring(x, 11, 11)))
   }) %>% unlist()

--- a/R/gs_design_ahr.R
+++ b/R/gs_design_ahr.R
@@ -358,7 +358,7 @@ gs_design_ahr <- function(enroll_rate = tibble(stratum = "all", duration = c(2, 
 
   class(ans) <- c("ahr", "gs_design", class(ans))
   if (!binding) {
-    class(ans) <- c("non-binding", class(ans))
+    class(ans) <- c("non_binding", class(ans))
   }
 
   return(ans)

--- a/R/gs_design_combo.R
+++ b/R/gs_design_combo.R
@@ -343,7 +343,7 @@ gs_design_combo <- function(enroll_rate = tibble(
 
   class(output) <- c("combo", "gs_design", class(output))
   if (!binding) {
-    class(output) <- c("non-binding", class(output))
+    class(output) <- c("non_binding", class(output))
   }
 
   return(output)

--- a/R/gs_design_rd.R
+++ b/R/gs_design_rd.R
@@ -272,7 +272,7 @@ gs_design_rd <- function(p_c = tibble(stratum = "all", rate = .2),
 
   class(ans) <- c("rd", "gs_design", class(ans))
   if (!binding) {
-    class(ans) <- c("non-binding", class(ans))
+    class(ans) <- c("non_binding", class(ans))
   }
 
   return(ans)

--- a/R/gs_design_wlr.R
+++ b/R/gs_design_wlr.R
@@ -288,7 +288,7 @@ gs_design_wlr <- function(enroll_rate = tibble(
 
   class(ans) <- c("wlr", "gs_design", class(ans))
   if (!binding) {
-    class(ans) <- c("non-binding", class(ans))
+    class(ans) <- c("non_binding", class(ans))
   }
 
   return(ans)

--- a/R/gs_info_wlr.R
+++ b/R/gs_info_wlr.R
@@ -32,7 +32,7 @@
 #'   - `"sqrtN"` = Tarone-Ware.
 #'   - `"FH_p[a]_q[b]"` = Fleming-Harrington with p=a and q=b.
 #' @param approx Approximate estimation method for Z statistics.
-#'   - `"event driven"` = only work under proportional hazard model with log rank test.
+#'   - `"event_driven"` = only work under proportional hazard model with log rank test.
 #'   - `"asymptotic"`.
 #' @param interval An interval that is presumed to include the time at which
 #'   expected event count is equal to targeted event.
@@ -168,7 +168,7 @@ gs_info_wlr <- function(enroll_rate = tibble::tibble(
     num_log_ahr[i] <- gs_delta_wlr(arm01, arm11, tmax = t, weight = weight, approx = approx)
     dem_log_ahr[i] <- gs_delta_wlr(arm01, arm11,
       tmax = t, weight = weight,
-      approx = "generalized schoenfeld", normalization = TRUE
+      approx = "generalized_schoenfeld", normalization = TRUE
     )
 
     sigma2_h1[i] <- gs_sigma2_wlr(arm0, arm1, tmax = t, weight = weight, approx = approx)

--- a/R/gs_power_ahr.R
+++ b/R/gs_power_ahr.R
@@ -275,7 +275,7 @@ gs_power_ahr <- function(enroll_rate = tibble(
 
   class(ans) <- c("ahr", "gs_design", class(ans))
   if (!binding) {
-    class(ans) <- c("non-binding", class(ans))
+    class(ans) <- c("non_binding", class(ans))
   }
 
   return(ans)

--- a/R/gs_power_combo.R
+++ b/R/gs_power_combo.R
@@ -265,7 +265,7 @@ gs_power_combo <- function(enroll_rate = tibble(
 
   class(output) <- c("combo", "gs_design", class(output))
   if (!binding) {
-    class(output) <- c("non-binding", class(output))
+    class(output) <- c("non_binding", class(output))
   }
 
   return(output)

--- a/R/gs_power_rd.R
+++ b/R/gs_power_rd.R
@@ -366,7 +366,7 @@ gs_power_rd <- function(p_c = tibble::tibble(
 
   class(ans) <- c("rd", "gs_design", class(ans))
   if (!binding) {
-    class(ans) <- c("non-binding", class(ans))
+    class(ans) <- c("non_binding", class(ans))
   }
 
   return(ans)

--- a/R/gs_power_wlr.R
+++ b/R/gs_power_wlr.R
@@ -334,7 +334,7 @@ gs_power_wlr <- function(enroll_rate = tibble(stratum = "all", duration = c(2, 2
 
   class(ans) <- c("wlr", "gs_design", class(ans))
   if (!binding) {
-    class(ans) <- c("non-binding", class(ans))
+    class(ans) <- c("non_binding", class(ans))
   }
 
   return(ans)

--- a/R/summary.R
+++ b/R/summary.R
@@ -661,8 +661,8 @@ summary.gs_design <- function(object,
   }
 
   class(output) <- c(method, "gs_design", class(output))
-  if ("non-binding" %in% class(object)) {
-    class(output) <- c("non-binding", class(output))
+  if ("non_binding" %in% class(object)) {
+    class(output) <- c("non_binding", class(output))
   }
 
   return(output)

--- a/R/utility_wlr.R
+++ b/R/utility_wlr.R
@@ -171,7 +171,7 @@ gs_delta_wlr <- function(arm0,
   p1 <- arm1$size / (arm0$size + arm1$size)
   p0 <- 1 - p1
 
-  if (approx == "event driven") {
+  if (approx == "event_driven") {
     if (sum(arm0$surv_shape != arm1$surv_shape) > 0 ||
       length(unique(arm1$surv_scale / arm0$surv_scale)) > 1) {
       stop("gs_delta_wlr(): Hazard is not proportional over time.", call. = FALSE)
@@ -194,7 +194,7 @@ gs_delta_wlr <- function(arm0,
       lower = 0,
       upper = tmax, rel.tol = 1e-5
     )$value
-  } else if (approx == "generalized schoenfeld") {
+  } else if (approx == "generalized_schoenfeld") {
     delta <- stats::integrate(
       function(x) {
         if (normalization) {
@@ -232,10 +232,10 @@ gs_sigma2_wlr <- function(arm0,
   p1 <- arm1$size / (arm0$size + arm1$size)
   p0 <- 1 - p1
 
-  if (approx == "event driven") {
+  if (approx == "event_driven") {
     nu <- p0 * prob_event(arm0, tmax = tmax) + p1 * prob_event(arm1, tmax = tmax)
     sigma2 <- p0 * p1 * nu
-  } else if (approx %in% c("asymptotic", "generalized schoenfeld")) {
+  } else if (approx %in% c("asymptotic", "generalized_schoenfeld")) {
     sigma2 <- stats::integrate(
       function(x) {
         weight(x, arm0, arm1)^2 *

--- a/man/gs_design_wlr.Rd
+++ b/man/gs_design_wlr.Rd
@@ -45,7 +45,7 @@ gs_design_wlr(
 
 \item{approx}{Approximate estimation method for Z statistics.
 \itemize{
-\item \code{"event driven"} = only work under proportional hazard model with log rank test.
+\item \code{"event_driven"} = only work under proportional hazard model with log rank test.
 \item \code{"asymptotic"}.
 }}
 

--- a/man/gs_info_wlr.Rd
+++ b/man/gs_info_wlr.Rd
@@ -38,7 +38,7 @@ gs_info_wlr(
 
 \item{approx}{Approximate estimation method for Z statistics.
 \itemize{
-\item \code{"event driven"} = only work under proportional hazard model with log rank test.
+\item \code{"event_driven"} = only work under proportional hazard model with log rank test.
 \item \code{"asymptotic"}.
 }}
 

--- a/man/gs_power_wlr.Rd
+++ b/man/gs_power_wlr.Rd
@@ -72,7 +72,7 @@ lower bound.}
 
 \item{approx}{Approximate estimation method for Z statistics.
 \itemize{
-\item \code{"event driven"} = only work under proportional hazard model with log rank test.
+\item \code{"event_driven"} = only work under proportional hazard model with log rank test.
 \item \code{"asymptotic"}.
 }}
 


### PR DESCRIPTION
Fixes https://github.com/Merck/gsDesign2/issues/22. I looked into all enumerated options in function arguments and this seems to be the last thing that's not using snake case.

Also, I updated the S3 class name `"non-binding"` to `"non_binding"` to be consistent with all other class names, for example, `gs_design`, `fixed_design`.