### PR TITLE
Set `message` and `warning` options in package loading chunks

### DIFF
--- a/vignettes/articles/story-compute-expected-events.Rmd
+++ b/vignettes/articles/story-compute-expected-events.Rmd
@@ -15,7 +15,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
@@ -25,7 +25,9 @@ knitr::opts_chunk$set(
   warning = FALSE
 )
 options(width = 58)
+```
 
+```{r, message=FALSE, warning=FALSE}
 library(gsDesign2)
 ```
 

--- a/vignettes/articles/story-compute-npe-bound.Rmd
+++ b/vignettes/articles/story-compute-npe-bound.Rmd
@@ -15,7 +15,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r setup, include = FALSE}
+```{r setup, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"

--- a/vignettes/articles/story-design-with-ahr.Rmd
+++ b/vignettes/articles/story-design-with-ahr.Rmd
@@ -15,7 +15,7 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
 ---
 
-```{r setup, include=FALSE, message=FALSE, warning=FALSE}
+```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
 ```
 

--- a/vignettes/articles/story-design-with-spending.Rmd
+++ b/vignettes/articles/story-design-with-spending.Rmd
@@ -15,7 +15,7 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"

--- a/vignettes/articles/story-npe-background.Rmd
+++ b/vignettes/articles/story-npe-background.Rmd
@@ -15,14 +15,14 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
 ```
 
-```{r}
+```{r, message=FALSE, warning=FALSE}
 library(tibble)
 library(dplyr)
 library(knitr)

--- a/vignettes/articles/story-npe-integration.Rmd
+++ b/vignettes/articles/story-npe-integration.Rmd
@@ -15,14 +15,14 @@ vignette: |
   %\VignetteEngine{knitr::rmarkdown}
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
 ```
 
-```{r}
+```{r, message=FALSE, warning=FALSE}
 library(tibble)
 library(dplyr)
 library(knitr)
@@ -319,7 +319,7 @@ cat(
 
 - Confirm with `gs_power_npe()`
 
-```{r, message = FALSE}
+```{r, message=FALSE}
 gs_power_npe(
   theta = theta, theta1 = theta, info = info, binding = TRUE,
   upper = gs_spending_bound,

--- a/vignettes/articles/story-nph-futility.Rmd
+++ b/vignettes/articles/story-nph-futility.Rmd
@@ -14,7 +14,7 @@ vignette: >
   %\VignetteIndexEntry{Futility bounds at design and analysis under non-proportional hazards}
 ---
 
-```{r, warning=FALSE, message = FALSE}
+```{r, warning=FALSE, message=FALSE}
 library(gsDesign2)
 library(gt)
 library(dplyr)

--- a/vignettes/articles/story-power-evaluation-with-spending-bound.Rmd
+++ b/vignettes/articles/story-power-evaluation-with-spending-bound.Rmd
@@ -15,14 +15,14 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
 ```
 
-```{r, message=FALSE, echo=FALSE, warning=FALSE}
+```{r, message=FALSE, warning=FALSE}
 library(tibble)
 library(gt)
 library(gsDesign2)

--- a/vignettes/articles/story-risk-difference.Rmd
+++ b/vignettes/articles/story-risk-difference.Rmd
@@ -20,12 +20,14 @@ editor_options:
     wrap: 72
 ---
 
-```{r, include = FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+```
 
+```{r, message=FALSE, warning=FALSE}
 library(tibble)
 library(dplyr)
 library(knitr)
@@ -438,7 +440,7 @@ $r=1, d = 1, p_C=p_E=0.125, N=200$. We then compute $\sigma$ as
 size the normal density fits quite well other than some flatness in the
 middle.
 
-```{r, message = FALSE}
+```{r, message=FALSE}
 # Hypothesized failure rate
 p <- .125
 #  Other parameters
@@ -685,7 +687,7 @@ x_gsdesign <- gsDesign::nBinomial(p1 = .28, p2 = .4, delta0 = 0, alpha = .025, s
 
 ### EAST
 
-```{r label = EastFix, echo = FALSE, fig.cap = "Sample size calculated by EAST", out.width = '90%'}
+```{r EastFix, echo=FALSE, fig.cap="Sample size calculated by EAST", out.width="90%"}
 knitr::include_graphics("figures/east-n-fix.png")
 ```
 
@@ -906,15 +908,15 @@ gsBoundSummary(x_gsdesign, digits = 4, ddigits = 2, tdigits = 1)
 
 ### EAST
 
-```{r label = EastGs, echo = FALSE, fig.cap = "Sample size calculated by EAST", out.width = '90%'}
+```{r EastGs, echo=FALSE, fig.cap="Sample size calculated by EAST", out.width="90%"}
 knitr::include_graphics("figures/east-n-gs.png")
 ```
 
-```{r label = EastGsUnpool, echo = FALSE, fig.cap = "Sample size calculated by EAST", out.width = '90%'}
+```{r EastGsUnpool, echo=FALSE, fig.cap="Sample size calculated by EAST", out.width="90%"}
 knitr::include_graphics("figures/east-n-gs-unpool.png")
 ```
 
-```{r label = EastGsPool, echo = FALSE, fig.cap = "Sample size calculated by EAST", out.width = '90%'}
+```{r EastGsPool, echo=FALSE, fig.cap="Sample size calculated by EAST", out.width="90%"}
 knitr::include_graphics("figures/east-n-gs-pool.png")
 ```
 

--- a/vignettes/articles/story-spending-time-example.Rmd
+++ b/vignettes/articles/story-spending-time-example.Rmd
@@ -16,10 +16,13 @@ vignette: >
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE, message = FALSE, warning = FALSE)
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
 ```
 
-```{r}
+```{r, message=FALSE, warning=FALSE}
 library(gsDesign)
 library(gsDesign2)
 library(tibble)

--- a/vignettes/articles/story-summarize-designs.Rmd
+++ b/vignettes/articles/story-summarize-designs.Rmd
@@ -15,7 +15,7 @@ vignette: |
   %\VignetteEngine{knitr::rmarkdown}
 ---
 
-```{r setup, include = FALSE}
+```{r setup, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"

--- a/vignettes/articles/usage-ahr.Rmd
+++ b/vignettes/articles/usage-ahr.Rmd
@@ -14,7 +14,7 @@ vignette: >
   %\VignetteIndexEntry{ahr: computes AHR under NPH assumptions and (stratified) populations}
 ---
 
-```{r, message=FALSE}
+```{r, message=FALSE, warning=FALSE}
 library(tibble)
 library(dplyr)
 library(gsDesign2)

--- a/vignettes/articles/usage-expected-accrual.Rmd
+++ b/vignettes/articles/usage-expected-accrual.Rmd
@@ -13,7 +13,7 @@ vignette: >
   %\VignetteIndexEntry{expected_accrual: computes the expected cumulative enrollment (accrual) given a set of piecewise constant enrollment rates and times}
 ---
 
-```{r, message=FALSE}
+```{r, message=FALSE, warning=FALSE}
 library(tibble)
 library(dplyr)
 library(gsDesign2)

--- a/vignettes/articles/usage-expected-event.Rmd
+++ b/vignettes/articles/usage-expected-event.Rmd
@@ -13,11 +13,11 @@ vignette: >
   %\VignetteIndexEntry{expected_event: compute expected number of events at 1 time point}
 ---
 
-```{r, message=FALSE, echo=FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(fig.width = 5, fig.height = 4, fig.align = "center")
 ```
 
-```{r, message=FALSE, echo=FALSE}
+```{r, message=FALSE, warning=FALSE}
 library(gt)
 library(tibble)
 library(dplyr)

--- a/vignettes/articles/usage-expected-time.Rmd
+++ b/vignettes/articles/usage-expected-time.Rmd
@@ -13,11 +13,11 @@ vignette: >
   %\VignetteIndexEntry{expected_time: compute time when a targeted number of events is made}
 ---
 
-```{r, message=FALSE, echo=FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(fig.width = 5, fig.height = 4, fig.align = "center")
 ```
 
-```{r, message=FALSE, echo=FALSE}
+```{r, message=FALSE, warning=FALSE}
 library(gt)
 library(tibble)
 library(dplyr)

--- a/vignettes/articles/usage-fixed-design.Rmd
+++ b/vignettes/articles/usage-fixed-design.Rmd
@@ -453,7 +453,7 @@ fixed_design(
 
 # Examples to get multiple designs together
 
-```{r, message = FALSE}
+```{r, message=FALSE}
 x_ahr <- fixed_design(
   "ahr",
   alpha = alpha,

--- a/vignettes/articles/usage-gs-b.Rmd
+++ b/vignettes/articles/usage-gs-b.Rmd
@@ -14,7 +14,7 @@ vignette: >
   %\VignetteIndexEntry{gs_b: specify fixed boundaries in group sequential designs}
 ---
 
-```{r, message=FALSE}
+```{r, message=FALSE, warning=FALSE}
 library(tibble)
 library(dplyr)
 library(gsDesign2)

--- a/vignettes/articles/usage-gs-info-ahr.Rmd
+++ b/vignettes/articles/usage-gs-info-ahr.Rmd
@@ -13,11 +13,11 @@ vignette: >
   %\VignetteIndexEntry{gs_info_ahr: compute statistical information by the AHR method}
 ---
 
-```{r, message=FALSE, echo=FALSE}
+```{r, include=FALSE}
 knitr::opts_chunk$set(fig.width = 5, fig.height = 4, fig.align = "center")
 ```
 
-```{r, message=FALSE, echo=FALSE}
+```{r, message=FALSE, warning=FALSE}
 library(gt)
 library(tibble)
 library(dplyr)

--- a/vignettes/articles/usage-gs-power-npe.Rmd
+++ b/vignettes/articles/usage-gs-power-npe.Rmd
@@ -14,7 +14,7 @@ vignette: >
   %\VignetteIndexEntry{gs_power_npe: derives bounds and crossing probabilities for group sequential designs under NPH assumptions}
 ---
 
-```{r, message=FALSE}
+```{r, message=FALSE, warning=FALSE}
 library(tibble)
 library(dplyr)
 library(gt)

--- a/vignettes/articles/usage-gs-spending-bound.Rmd
+++ b/vignettes/articles/usage-gs-spending-bound.Rmd
@@ -14,7 +14,7 @@ vignette: >
   %\VignetteIndexEntry{gs_spending_bound: compute spending boundary in group sequential design}
 ---
 
-```{r, message=FALSE}
+```{r, message=FALSE, warning=FALSE}
 library(tibble)
 library(dplyr)
 library(gsDesign2)

--- a/vignettes/articles/usage-summary-as-gt.Rmd
+++ b/vignettes/articles/usage-summary-as-gt.Rmd
@@ -17,7 +17,7 @@ vignette: |
   %\VignetteEngine{knitr::rmarkdown}
 ---
 
-```{r setup, include = FALSE}
+```{r setup, include=FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"


### PR DESCRIPTION
This PR sets `message=FALSE` and `warning=FALSE` in package loading chunks in vignettes (articles) to remove the verbose outputs when loading dplyr.

Also standardizes the style of such chunk options by removing the whitespaces before and after `=`.