### PR TITLE
Add GitHub Linguist rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+inst/** linguist-generated=true


### PR DESCRIPTION
This PR adds a rule to `.gitattributes` to ignore all files and directories under `inst/` for GitHub Linguist so the repo languages stats is correct (currently, HTML ranks the top by number of lines).

GitHub Linguist references: [[1](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)] and [[2](https://github.com/github/linguist/blob/master/docs/overrides.md)].