### PR TITLE
Update dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,27 +36,23 @@ Imports:
     corpcor,
     dplyr,
     gsDesign,
+    gt,
     methods,
     mvtnorm,
     npsurvSS,
     purrr,
     rlang,
     tibble,
+    tidyr,
     utils,
     Rcpp
 Suggests:
-    bench,
     covr,
-    devtools,
     ggplot2,
-    gt,
     kableExtra,
     knitr,
-    microbenchmark,
     rmarkdown,
-    survival,
-    testthat,
-    tidyr
+    testthat
 VignetteBuilder:
     knitr
 LinkingTo:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.0.6
+Version: 1.0.7
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# gsDesign2 1.0.7
+
+## Improvements
+
+- Move imported dependencies from `Suggests` to `Imports`.
+- Remove redundant dependencies from `Suggests`.
+- Update the GitHub Actions workflows to their latest versions from upstream.
+- Add a rule to `.gitattributes` for GitHub Linguist to keep the repository's
+  language statistics accurate.
+
 # gsDesign2 1.0.6
 
 ## Improvements


### PR DESCRIPTION
This PR:

- Moved imported dependencies from `Suggests` to `Imports`.
- Removed redundant dependencies from `Suggests`.
- Incremented version number to 1.0.7.
- Updated news.

I check v1.0.6 in a fresh, latest R-devel environment and there is no actual problems reported, so the email from the auto-check service could just be a false positive. In any case, this PR still makes some updates to improve things.

Please feel free to go through the v1.0.7 release check list after merging this. Thanks.