### PR TITLE
Add CRAN link back to badge

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -30,7 +30,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/Merck/gsDesign2/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Merck/gsDesign2/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/Merck/gsDesign2/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Merck/gsDesign2?branch=main)
-![CRAN status](https://www.r-pkg.org/badges/version/gsDesign2)
+[![CRAN status](https://www.r-pkg.org/badges/version/gsDesign2)](https://CRAN.R-project.org/package=gsDesign2)
 <!-- badges: end -->
 
 ## Objective

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 [![R-CMD-check](https://github.com/Merck/gsDesign2/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Merck/gsDesign2/actions/workflows/R-CMD-check.yaml)
 [![Codecov test
 coverage](https://codecov.io/gh/Merck/gsDesign2/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Merck/gsDesign2?branch=main)
-![CRAN status](https://www.r-pkg.org/badges/version/gsDesign2)
+[![CRAN
+status](https://www.r-pkg.org/badges/version/gsDesign2)](https://CRAN.R-project.org/package=gsDesign2)
 <!-- badges: end -->
 
 ## Objective


### PR DESCRIPTION
This PR adds back the CRAN link that was previously removed from the badge to pass checks.