### PR TITLE
Add installation guide for CRAN version

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -45,7 +45,13 @@ features are encouraged as this is still a young package.
 
 ## Installation
 
-You can install gsDesign2 with:
+Install the released version of gsDesign2 from CRAN:
+
+```{r, eval=FALSE}
+install.packages("gsDesign2")
+```
+
+Or install the development version from GitHub with:
 
 ```{r, eval=FALSE}
 remotes::install_github("Merck/gsDesign2")

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ features are encouraged as this is still a young package.
 
 ## Installation
 
-You can install gsDesign2 with:
+Install the released version of gsDesign2 from CRAN:
+
+``` r
+install.packages("gsDesign2")
+```
+
+Or install the development version from GitHub with:
 
 ``` r
 remotes::install_github("Merck/gsDesign2")


### PR DESCRIPTION
This PR completes the installation guide in the README by adding the CRAN installation command.