### PR TITLE
Format alpha in footnote using decimal notation

### DIFF
--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -542,15 +542,22 @@ as_gt.gs_design <- function(x,
     x <- x %>%
       gt::tab_footnote(
         footnote = paste0(
-          "Cumulative alpha for final analysis (", x_alpha,
-          ") is less than the full alpha (", full_alpha, ") when
-          the futility bound is non-binding. ",
-          "The smaller value subtracts the probability of
-          crossing a futility bound before ",
-          " crossing an efficacy bound at
-          a later analysis (", full_alpha, " - ",
-          full_alpha - x_alpha, " = ", x_alpha,
-          ") under the null hypothesis."
+          "Cumulative alpha for final analysis ",
+          "(", format(x_alpha, scientific = FALSE), ") ",
+          "is less than the full alpha ",
+          "(", format(full_alpha, scientific = FALSE), ") ",
+          "when the futility bound is non-binding. ",
+          "The smaller value subtracts the probability of ",
+          "crossing a futility bound before ",
+          "crossing an efficacy bound at a later analysis ",
+          "(",
+          format(full_alpha, scientific = FALSE),
+          " - ",
+          format(full_alpha - x_alpha, scientific = FALSE),
+          " = ",
+          format(x_alpha, scientific = FALSE),
+          ") ",
+          "under the null hypothesis."
         ),
         locations = gt::cells_body(
           columns = colname_spannersub[2],

--- a/README.md
+++ b/README.md
@@ -342,10 +342,7 @@ gsd %>%
       <td class="gt_footnote" colspan="6"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;"><sup>2</sup></span> Approximate hazard ratio to cross bound.</td>
     </tr>
     <tr>
-      <td class="gt_footnote" colspan="6"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;"><sup>3</sup></span> Cumulative alpha for final analysis (0.0244) is less than the full alpha (0.025) when
-          the futility bound is non-binding. The smaller value subtracts the probability of
-          crossing a futility bound before  crossing an efficacy bound at
-          a later analysis (0.025 - 6e-04 = 0.0244) under the null hypothesis.</td>
+      <td class="gt_footnote" colspan="6"><span class="gt_footnote_marks" style="white-space:nowrap;font-style:italic;font-weight:normal;"><sup>3</sup></span> Cumulative alpha for final analysis (0.0244) is less than the full alpha (0.025) when the futility bound is non-binding. The smaller value subtracts the probability of crossing a futility bound before crossing an efficacy bound at a later analysis (0.025 - 0.0006 = 0.0244) under the null hypothesis.</td>
     </tr>
   </tfoot>
 </table>


### PR DESCRIPTION
This PR fixes https://github.com/Merck/gsDesign2/issues/222

It uses `format(..., scientific = FALSE)` to format the alpha values in the table footnote using decimal notation.

Note that `scientific = FALSE` only solve this formatting issue in general. Since there is this `digits` option (default is 7) in the global options, therefore calling something like

```r
format(0.025 - 6e-10, scientific = FALSE)
```

will give 0.025 instead of 0.024999999.

Although we can set a specific higher `digits` value in the `format()` calls, I choose to leave that option to the users. One can increase the `digits` in the global options or use `withr::with_options()` to change the number of digits displayed:

```r
options(digits = 8)
format(0.025 - 6e-10, scientific = FALSE)
```

This will give 0.024999999.

We can revisit this decision later if this option has to be made more explicit.