### PR TITLE
using tibble to allow size 1 input

### DIFF
--- a/R/define.R
+++ b/R/define.R
@@ -42,14 +42,12 @@
 define_enroll_rate <- function(
     duration,
     rate,
-    stratum = "All"
-) {
-  
-  if(is.null(duration)){
+    stratum = "All") {
+  if (is.null(duration)) {
     stop("define_enroll_rate: duration variable is NULL")
   }
-  
-  if(is.null(rate)){
+
+  if (is.null(rate)) {
     stop("define_enroll_rate: rate variable is NULL")
   }
 
@@ -110,21 +108,19 @@ define_fail_rate <- function(
     fail_rate,
     dropout_rate,
     hr = 1,
-    stratum = "All"
-) {
-
-  if(is.null(duration)){
+    stratum = "All") {
+  if (is.null(duration)) {
     stop("define_enroll_rate: duration variable is NULL")
   }
-  
-  if(is.null(fail_rate)){
+
+  if (is.null(fail_rate)) {
     stop("define_enroll_rate: fail_rate variable is NULL")
   }
-  
-  if(is.null(dropout_rate)){
+
+  if (is.null(dropout_rate)) {
     stop("define_enroll_rate: dropout_rate variable is NULL")
   }
-  
+
   check_args(duration, type = c("numeric", "integer"))
   check_args(fail_rate, type = c("numeric", "integer"))
   check_args(dropout_rate, type = c("numeric", "integer"))

--- a/R/define.R
+++ b/R/define.R
@@ -43,15 +43,12 @@
 define_enroll_rate <- function(
     duration,
     rate,
-    stratum = rep("All", length(duration))) {
-  # Length of variables
-  l <- unique(c(length(duration), length(rate), length(stratum)))
+    stratum = "All"
+) {
 
-  if (length(l) > 1) stop("define_enroll_rate: length of input arguments must be the same.")
-
-  check_args(duration, length = l, type = c("numeric", "integer"))
-  check_args(rate, length = l, type = c("numeric", "integer"))
-  check_args(stratum, length = l, type = c("character"))
+  check_args(duration, type = c("numeric", "integer"))
+  check_args(rate, type = c("numeric", "integer"))
+  check_args(stratum, type = c("character"))
 
   if (any(duration < 0)) {
     stop("define_enroll_rate: enrollment duration `duration` can not be negative")
@@ -61,7 +58,7 @@ define_enroll_rate <- function(
     stop("define_enroll_rate: enrollment rate `rate` can not be negative")
   }
 
-  df <- data.frame(
+  df <- tibble::tibble(
     stratum = stratum,
     duration = duration,
     rate = rate
@@ -92,7 +89,7 @@ define_enroll_rate <- function(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
 #'   hr = c(.9, .6),
-#'   dropout_rate = rep(.001, 2)
+#'   dropout_rate = .001
 #' )
 #'
 #' # define enroll rate with stratum
@@ -100,31 +97,22 @@ define_enroll_rate <- function(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
 #'   hr = c(.9, .6),
-#'   dropout_rate = rep(.001, 2),
+#'   dropout_rate = .001,
 #'   stratum = c("low", "high")
 #' )
 define_fail_rate <- function(
     duration,
     fail_rate,
     dropout_rate,
-    hr = rep(1, length(duration)),
-    stratum = rep("All", length(duration))) {
-  # Length of variables
-  l <- unique(c(
-    length(duration),
-    length(fail_rate),
-    length(dropout_rate),
-    length(hr),
-    length(stratum)
-  ))
+    hr = 1,
+    stratum = "All"
+) {
 
-  if (length(l) > 1) stop("define_fail_rate: length of input arguments must be the same.")
-
-  check_args(duration, length = l, type = c("numeric", "integer"))
-  check_args(fail_rate, length = l, type = c("numeric", "integer"))
-  check_args(dropout_rate, length = l, type = c("numeric", "integer"))
-  check_args(hr, length = l, type = c("numeric", "integer"))
-  check_args(stratum, length = l, type = c("character"))
+  check_args(duration, type = c("numeric", "integer"))
+  check_args(fail_rate, type = c("numeric", "integer"))
+  check_args(dropout_rate, type = c("numeric", "integer"))
+  check_args(hr, type = c("numeric", "integer"))
+  check_args(stratum, type = c("character"))
 
   if (any(duration < 0)) {
     stop("define_fail_rate: enrollment duration `duration` can not be negative")
@@ -142,7 +130,7 @@ define_fail_rate <- function(
     stop("define_fail_rate: hazard ratio `hr` can not be negative")
   }
 
-  df <- data.frame(
+  df <- tibble::tibble(
     stratum = stratum,
     duration = duration,
     fail_rate = fail_rate,

--- a/R/define.R
+++ b/R/define.R
@@ -45,6 +45,14 @@ define_enroll_rate <- function(
     rate,
     stratum = "All"
 ) {
+  
+  if(is.null(duration)){
+    stop("define_enroll_rate: duration variable is NULL")
+  }
+  
+  if(is.null(rate)){
+    stop("define_enroll_rate: rate variable is NULL")
+  }
 
   check_args(duration, type = c("numeric", "integer"))
   check_args(rate, type = c("numeric", "integer"))
@@ -108,6 +116,18 @@ define_fail_rate <- function(
     stratum = "All"
 ) {
 
+  if(is.null(duration)){
+    stop("define_enroll_rate: duration variable is NULL")
+  }
+  
+  if(is.null(fail_rate)){
+    stop("define_enroll_rate: fail_rate variable is NULL")
+  }
+  
+  if(is.null(dropout_rate)){
+    stop("define_enroll_rate: dropout_rate variable is NULL")
+  }
+  
   check_args(duration, type = c("numeric", "integer"))
   check_args(fail_rate, type = c("numeric", "integer"))
   check_args(dropout_rate, type = c("numeric", "integer"))

--- a/man/define_enroll_rate.Rd
+++ b/man/define_enroll_rate.Rd
@@ -4,7 +4,7 @@
 \alias{define_enroll_rate}
 \title{Define enrollment rate}
 \usage{
-define_enroll_rate(duration, rate, stratum = rep("All", length(duration)))
+define_enroll_rate(duration, rate, stratum = "All")
 }
 \arguments{
 \item{duration}{A numeric vector of piecewise study duration interval.}

--- a/man/define_fail_rate.Rd
+++ b/man/define_fail_rate.Rd
@@ -4,13 +4,7 @@
 \alias{define_fail_rate}
 \title{Define fail rate}
 \usage{
-define_fail_rate(
-  duration,
-  fail_rate,
-  dropout_rate,
-  hr = rep(1, length(duration)),
-  stratum = rep("All", length(duration))
-)
+define_fail_rate(duration, fail_rate, dropout_rate, hr = 1, stratum = "All")
 }
 \arguments{
 \item{duration}{A numeric vector of piecewise study duration interval.}
@@ -36,7 +30,7 @@ define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = .001
 )
 
 # define enroll rate with stratum
@@ -44,7 +38,7 @@ define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
-  dropout_rate = rep(.001, 2),
+  dropout_rate = .001,
   stratum = c("low", "high")
 )
 }


### PR DESCRIPTION
based on team discussion, we should keep allowing size 1 input by leveraging `tibble`'s default behavior. 