### PR TITLE
Update define fail rate

### DIFF
--- a/R/ahr.R
+++ b/R/ahr.R
@@ -83,7 +83,6 @@
 #' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
 #' @importFrom dplyr filter mutate group_by summarize ungroup first last "%>%"
-#' @importFrom tibble tibble
 #'
 #' @export
 #'
@@ -101,7 +100,7 @@
 #'   duration = c(2, 10, 4, 4, 8),
 #'   rate = c(5, 10, 0, 3, 6)
 #' )
-#' fail_rate <- tibble::tibble(
+#' fail_rate <- define_fail_rate(
 #'   stratum = c(rep("Low", 2), rep("High", 2)),
 #'   duration = 1,
 #'   fail_rate = c(.1, .2, .3, .4),
@@ -116,12 +115,11 @@ ahr <- function(enroll_rate = define_enroll_rate(
                   duration = c(2, 2, 10),
                   rate = c(3, 6, 9)
                 ),
-                fail_rate = tibble::tibble(
-                  stratum = "All",
+                fail_rate = define_fail_rate(
                   duration = c(3, 100),
                   fail_rate = log(2) / c(9, 18),
                   hr = c(.9, .6),
-                  dropout_rate = rep(.001, 2)
+                  dropout_rate = .001
                 ),
                 total_duration = 30,
                 ratio = 1,

--- a/R/ahr.R
+++ b/R/ahr.R
@@ -24,9 +24,7 @@
 #' and enrollment pattern where the enrollment, failure and dropout rates changes over time.
 #'
 #' @param enroll_rate An `enroll_rate` data frame with or without stratum created by `define_enroll_rate`.
-#' @param fail_rate Piecewise constant control group failure rates, duration
-#'   for each piecewise constant period,
-#' hazard ratio for experimental vs control, and dropout rates by stratum and time period.
+#' @param fail_rate A `fail_rate` data frame with or without stratum created by `define_fail_rate`.
 #' @param total_duration Total follow-up from start of enrollment to data cutoff;
 #'   this can be a single value or a vector of positive numbers.
 #' @param ratio Ratio of experimental to control randomization.
@@ -104,8 +102,8 @@
 #'   stratum = c(rep("Low", 2), rep("High", 2)),
 #'   duration = 1,
 #'   fail_rate = c(.1, .2, .3, .4),
-#'   hr = c(.9, .75, .8, .6),
-#'   dropout_rate = .001
+#'   dropout_rate = .001,
+#'   hr = c(.9, .75, .8, .6)
 #' )
 #' ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, total_duration = c(15, 30))
 #'

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -46,8 +46,8 @@ as_gt <- function(x, ...) {
 #' fail_rate <- define_fail_rate(
 #'   duration = c(4, 100),
 #'   fail_rate = log(2) / 12,
-#'   hr = c(1, .6),
-#'   dropout_rate = .001
+#'   dropout_rate = .001,
+#'   hr = c(1, .6)
 #' )
 #'
 #' # Study duration in months

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -43,8 +43,7 @@ as_gt <- function(x, ...) {
 #' )
 #'
 #' # Failure rates
-#' fail_rate <- tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(4, 100),
 #'   fail_rate = log(2) / 12,
 #'   hr = c(1, .6),

--- a/R/check_arg.R
+++ b/R/check_arg.R
@@ -202,7 +202,7 @@ check_fail_rate <- function(fail_rate) {
 #' enroll_rate <- define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9))
 #' fail_rate <- define_fail_rate(
 #'   duration = c(3, 100),
-#'   fail_rate = log(2) / c(9, 18), 
+#'   fail_rate = log(2) / c(9, 18),
 #'   dropout_rate = .001,
 #'   hr = c(.9, .6)
 #' )

--- a/R/check_arg.R
+++ b/R/check_arg.R
@@ -145,19 +145,18 @@ check_enroll_rate <- function(enroll_rate) {
 #' fail_rate <- define_fail_rate(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
-#'   dropout_rate = rep(.001, 2),
+#'   dropout_rate = .001,
 #'   hr = c(.9, .6)
 #' )
 #'
 #' check_fail_rate(fail_rate)
 #'
 #' # Non-standard use
-#' fail_rate <- tibble::tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
 #'   hr = c(.9, .6),
-#'   dropout_rate = rep(.001, 2)
+#'   dropout_rate = .001
 #' )
 #'
 #' check_fail_rate(fail_rate)
@@ -203,10 +202,11 @@ check_fail_rate <- function(fail_rate) {
 #'
 #' @examples
 #' enroll_rate <- define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9))
-#' fail_rate <- tibble::tibble(
-#'   stratum = "All", duration = c(3, 100),
-#'   fail_rate = log(2) / c(9, 18), hr = c(.9, .6),
-#'   dropout_rate = rep(.001, 2)
+#' fail_rate <- define_fail_rate(
+#'   duration = c(3, 100),
+#'   fail_rate = log(2) / c(9, 18), 
+#'   hr = c(.9, .6),
+#'   dropout_rate = .001
 #' )
 #' check_enroll_rate_fail_rate(enroll_rate, fail_rate)
 check_enroll_rate_fail_rate <- function(enroll_rate, fail_rate) {

--- a/R/check_arg.R
+++ b/R/check_arg.R
@@ -141,7 +141,7 @@ check_enroll_rate <- function(enroll_rate) {
 #'
 #' @examples
 #'
-#' # proper definition
+#' # Proper definition
 #' fail_rate <- define_fail_rate(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
@@ -151,7 +151,7 @@ check_enroll_rate <- function(enroll_rate) {
 #'
 #' check_fail_rate(fail_rate)
 #'
-#' # off-label use
+#' # Non-standard use
 #' fail_rate <- tibble::tibble(
 #'   stratum = "All",
 #'   duration = c(3, 100),

--- a/R/check_arg.R
+++ b/R/check_arg.R
@@ -133,7 +133,7 @@ check_enroll_rate <- function(enroll_rate) {
 
 #' A function to check the arguments `fail_rate` used in gsDesign2
 #'
-#' @param fail_rate Failure rates.
+#' @inheritParams ahr
 #'
 #' @return `TRUE` or `FALSE`.
 #'
@@ -155,8 +155,8 @@ check_enroll_rate <- function(enroll_rate) {
 #' fail_rate <- define_fail_rate(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
-#'   hr = c(.9, .6),
-#'   dropout_rate = .001
+#'   dropout_rate = .001,
+#'   hr = c(.9, .6)
 #' )
 #'
 #' check_fail_rate(fail_rate)
@@ -193,8 +193,7 @@ check_fail_rate <- function(fail_rate) {
 
 #' A function to check the arguments `enroll_rate` and `fail_rate` used in gsDesign2
 #'
-#' @param enroll_rate Enrollment rates.
-#' @param fail_rate Failure rates.
+#' @inheritParams ahr
 #'
 #' @return `TRUE` or `FALSE`.
 #'
@@ -205,8 +204,8 @@ check_fail_rate <- function(fail_rate) {
 #' fail_rate <- define_fail_rate(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18), 
-#'   hr = c(.9, .6),
-#'   dropout_rate = .001
+#'   dropout_rate = .001,
+#'   hr = c(.9, .6)
 #' )
 #' check_enroll_rate_fail_rate(enroll_rate, fail_rate)
 check_enroll_rate_fail_rate <- function(enroll_rate, fail_rate) {

--- a/R/define.R
+++ b/R/define.R
@@ -42,14 +42,12 @@
 define_enroll_rate <- function(
     duration,
     rate,
-    stratum = "All"
-) {
-  
-  if(is.null(duration)){
+    stratum = "All") {
+  if (is.null(duration)) {
     stop("define_enroll_rate: duration variable is NULL")
   }
-  
-  if(is.null(rate)){
+
+  if (is.null(rate)) {
     stop("define_enroll_rate: rate variable is NULL")
   }
 
@@ -110,21 +108,19 @@ define_fail_rate <- function(
     fail_rate,
     dropout_rate,
     hr = 1,
-    stratum = "All"
-) {
-
-  if(is.null(duration)){
+    stratum = "All") {
+  if (is.null(duration)) {
     stop("define_enroll_rate: duration variable is NULL")
   }
-  
-  if(is.null(fail_rate)){
+
+  if (is.null(fail_rate)) {
     stop("define_enroll_rate: fail_rate variable is NULL")
   }
-  
-  if(is.null(dropout_rate)){
+
+  if (is.null(dropout_rate)) {
     stop("define_enroll_rate: dropout_rate variable is NULL")
   }
-  
+
   check_args(duration, type = c("numeric", "integer"))
   check_args(fail_rate, type = c("numeric", "integer"))
   check_args(dropout_rate, type = c("numeric", "integer"))

--- a/R/define.R
+++ b/R/define.R
@@ -43,15 +43,12 @@
 define_enroll_rate <- function(
     duration,
     rate,
-    stratum = rep("All", length(duration))) {
-  # Length of variables
-  l <- unique(c(length(duration), length(rate), length(stratum)))
+    stratum = "All"
+) {
 
-  if (length(l) > 1) stop("define_enroll_rate: length of input arguments must be the same.")
-
-  check_args(duration, length = l, type = c("numeric", "integer"))
-  check_args(rate, length = l, type = c("numeric", "integer"))
-  check_args(stratum, length = l, type = c("character"))
+  check_args(duration, type = c("numeric", "integer"))
+  check_args(rate, type = c("numeric", "integer"))
+  check_args(stratum, type = c("character"))
 
   if (any(duration < 0)) {
     stop("define_enroll_rate: enrollment duration `duration` can not be negative")
@@ -61,7 +58,7 @@ define_enroll_rate <- function(
     stop("define_enroll_rate: enrollment rate `rate` can not be negative")
   }
 
-  df <- data.frame(
+  df <- tibble::tibble(
     stratum = stratum,
     duration = duration,
     rate = rate
@@ -92,7 +89,7 @@ define_enroll_rate <- function(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
 #'   hr = c(.9, .6),
-#'   dropout_rate = rep(.001, 2)
+#'   dropout_rate = .001
 #' )
 #'
 #' # define enroll rate with stratum
@@ -100,31 +97,22 @@ define_enroll_rate <- function(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
 #'   hr = c(.9, .6),
-#'   dropout_rate = rep(.001, 2),
+#'   dropout_rate = .001,
 #'   stratum = c("low", "high")
 #' )
 define_fail_rate <- function(
     duration,
     fail_rate,
     dropout_rate,
-    hr = rep(1, length(duration)),
-    stratum = rep("All", length(duration))) {
-  # Length of variables
-  l <- unique(c(
-    length(duration),
-    length(fail_rate),
-    length(dropout_rate),
-    length(hr),
-    length(stratum)
-  ))
+    hr = 1,
+    stratum = "All"
+) {
 
-  if (length(l) > 1) stop("define_fail_rate: length of input arguments must be the same.")
-
-  check_args(duration, length = l, type = c("numeric", "integer"))
-  check_args(fail_rate, length = l, type = c("numeric", "integer"))
-  check_args(dropout_rate, length = l, type = c("numeric", "integer"))
-  check_args(hr, length = l, type = c("numeric", "integer"))
-  check_args(stratum, length = l, type = c("character"))
+  check_args(duration, type = c("numeric", "integer"))
+  check_args(fail_rate, type = c("numeric", "integer"))
+  check_args(dropout_rate, type = c("numeric", "integer"))
+  check_args(hr, type = c("numeric", "integer"))
+  check_args(stratum, type = c("character"))
 
   if (any(duration < 0)) {
     stop("define_fail_rate: enrollment duration `duration` can not be negative")
@@ -142,7 +130,7 @@ define_fail_rate <- function(
     stop("define_fail_rate: hazard ratio `hr` can not be negative")
   }
 
-  df <- data.frame(
+  df <- tibble::tibble(
     stratum = stratum,
     duration = duration,
     fail_rate = fail_rate,

--- a/R/define.R
+++ b/R/define.R
@@ -78,7 +78,7 @@ define_enroll_rate <- function(
 #' @param hr A numeric vector of hazard ratio.
 #' @param stratum A character vector of stratum name.
 #'
-#' @return An `fail_rate` data frame.
+#' @return A `fail_rate` data frame.
 #'
 #' @export
 #'

--- a/R/expected_event.R
+++ b/R/expected_event.R
@@ -30,7 +30,6 @@
 #' for stratified populations.
 #'
 #' @inheritParams ahr
-#' @param fail_rate Failure rates and dropout rates by period.
 #' @param total_duration Total follow-up from start of enrollment to data cutoff.
 #' @param simple If default (`TRUE`), return numeric expected number of events,
 #'   otherwise a tibble as described below.

--- a/R/expected_time.R
+++ b/R/expected_time.R
@@ -26,10 +26,6 @@
 #' where the enrollment, failure and dropout rates changes over time.
 #'
 #' @inheritParams ahr
-#' @param fail_rate Piecewise constant control group failure rates,
-#'   duration for each piecewise constant period,
-#'   hazard ratio for experimental vs control,
-#'   and dropout rates by stratum and time period.
 #' @param target_event The targeted number of events to be achieved.
 #' @param ratio Experimental:Control randomization ratio.
 #' @param interval An interval that is presumed to include the time at which

--- a/R/expected_time.R
+++ b/R/expected_time.R
@@ -68,9 +68,11 @@
 #' # check that result matches a finding using AHR()
 #' # Start by deriving an expected event count
 #' enroll_rate <- define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9) * 5)
-#' fail_rate <- tibble::tibble(
-#'   stratum = "All", duration = c(3, 100), fail_rate = log(2) / c(9, 18),
-#'   hr = c(.9, .6), dropout_rate = rep(.001, 2)
+#' fail_rate <- define_fail_rate(
+#'   duration = c(3, 100), 
+#'   fail_rate = log(2) / c(9, 18),
+#'   hr = c(.9, .6), 
+#'   dropout_rate = .001
 #' )
 #' total_duration <- 20
 #' xx <- ahr(enroll_rate, fail_rate, total_duration)
@@ -86,7 +88,7 @@ expected_time <- function(enroll_rate = define_enroll_rate(
                             duration = c(2, 2, 10),
                             rate = c(3, 6, 9) * 5
                           ),
-                          fail_rate = tibble::tibble(
+                          fail_rate = define_fail_rate(
                             stratum = "All",
                             duration = c(3, 100),
                             fail_rate = log(2) / c(9, 18),

--- a/R/expected_time.R
+++ b/R/expected_time.R
@@ -65,9 +65,9 @@
 #' # Start by deriving an expected event count
 #' enroll_rate <- define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9) * 5)
 #' fail_rate <- define_fail_rate(
-#'   duration = c(3, 100), 
+#'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
-#'   hr = c(.9, .6), 
+#'   hr = c(.9, .6),
 #'   dropout_rate = .001
 #' )
 #' total_duration <- 20

--- a/R/fixed_design.R
+++ b/R/fixed_design.R
@@ -44,8 +44,7 @@
 #'   "ahr",
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
-#'   fail_rate = tibble::tibble(
-#'     stratum = "All",
+#'   fail_rate = define_fail_rate(
 #'     duration = c(4, 100),
 #'     fail_rate = log(2) / 12,
 #'     hr = c(1, .6),
@@ -60,8 +59,7 @@
 #'   "lf",
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
-#'   fail_rate = tibble::tibble(
-#'     stratum = "All",
+#'   fail_rate = define_fail_rate(
 #'     duration = 100,
 #'     fail_rate = log(2) / 12,
 #'     hr = .7,
@@ -76,8 +74,7 @@
 #'   "rmst",
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
-#'   fail_rate = tibble::tibble(
-#'     stratum = "All",
+#'   fail_rate = define_fail_rate(
 #'     duration = 100,
 #'     fail_rate = log(2) / 12,
 #'     hr = .7,
@@ -93,8 +90,7 @@
 #'   "milestone",
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
-#'   fail_rate = tibble::tibble(
-#'     stratum = "All",
+#'   fail_rate = define_fail_rate(
 #'     duration = 100,
 #'     fail_rate = log(2) / 12,
 #'     hr = .7,

--- a/R/gs_design_ahr.R
+++ b/R/gs_design_ahr.R
@@ -193,9 +193,9 @@
 #' }
 gs_design_ahr <- function(enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
                           fail_rate = define_fail_rate(
-                            duration = c(3, 100), 
+                            duration = c(3, 100),
                             fail_rate = log(2) / c(9, 18),
-                            hr = c(.9, .6), 
+                            hr = c(.9, .6),
                             dropout_rate = .001
                           ),
                           alpha = 0.025, beta = 0.1,

--- a/R/gs_design_ahr.R
+++ b/R/gs_design_ahr.R
@@ -90,7 +90,6 @@
 #' To be added.
 #'
 #' @importFrom dplyr all_of mutate full_join select arrange desc
-#' @importFrom tibble tibble
 #' @importFrom gsDesign gsDesign sfLDOF
 #' @importFrom stats qnorm
 #'
@@ -193,9 +192,11 @@
 #' )
 #' }
 gs_design_ahr <- function(enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
-                          fail_rate = tibble(
-                            stratum = "All", duration = c(3, 100), fail_rate = log(2) / c(9, 18),
-                            hr = c(.9, .6), dropout_rate = rep(.001, 2)
+                          fail_rate = define_fail_rate(
+                            duration = c(3, 100), 
+                            fail_rate = log(2) / c(9, 18),
+                            hr = c(.9, .6), 
+                            dropout_rate = .001
                           ),
                           alpha = 0.025, beta = 0.1,
                           info_frac = NULL, analysis_time = 36,

--- a/R/gs_design_combo.R
+++ b/R/gs_design_combo.R
@@ -28,7 +28,6 @@
 #' @return A list with input parameters, enrollment rate, analysis, and bound.
 #'
 #' @importFrom mvtnorm GenzBretz
-#' @importFrom tibble tibble
 #'
 #' @export
 #'
@@ -37,15 +36,13 @@
 #' library(dplyr)
 #' library(mvtnorm)
 #' library(gsDesign)
-#' library(tibble)
 #'
 #' enroll_rate <- define_enroll_rate(
 #'   duration = 12,
 #'   rate = 500 / 12
 #' )
 #'
-#' fail_rate <- tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(4, 100),
 #'   fail_rate = log(2) / 15, # median survival 15 month
 #'   hr = c(1, .6),
@@ -125,8 +122,7 @@ gs_design_combo <- function(enroll_rate = define_enroll_rate(
                               duration = 12,
                               rate = 500 / 12
                             ),
-                            fail_rate = tibble(
-                              stratum = "All",
+                            fail_rate = define_fail_rate(
                               duration = c(4, 100),
                               fail_rate = log(2) / 15,
                               hr = c(1, .6),

--- a/R/gs_design_rd.R
+++ b/R/gs_design_rd.R
@@ -62,7 +62,6 @@
 #' @details
 #' To be added.
 #'
-#' @importFrom tibble tibble
 #' @importFrom gsDesign gsDesign sfLDOF
 #' @importFrom stats qnorm
 #' @importFrom dplyr mutate select arrange desc
@@ -70,7 +69,6 @@
 #' @export
 #'
 #' @examples
-#' library(tibble)
 #' library(gsDesign)
 #'
 #' # ----------------- #
@@ -78,8 +76,8 @@
 #' #------------------ #
 #' # unstratified group sequential design
 #' gs_design_rd(
-#'   p_c = tibble(stratum = "All", rate = .2),
-#'   p_e = tibble(stratum = "All", rate = .15),
+#'   p_c = tibble::tibble(stratum = "All", rate = .2),
+#'   p_e = tibble::tibble(stratum = "All", rate = .15),
 #'   info_frac = c(0.7, 1),
 #'   rd0 = 0,
 #'   alpha = .025,
@@ -98,11 +96,11 @@
 #' # ----------------- #
 #' # stratified group sequential design
 #' gs_design_rd(
-#'   p_c = tibble(
+#'   p_c = tibble::tibble(
 #'     stratum = c("biomarker positive", "biomarker negative"),
 #'     rate = c(.2, .25)
 #'   ),
-#'   p_e = tibble(
+#'   p_e = tibble::tibble(
 #'     stratum = c("biomarker positive", "biomarker negative"),
 #'     rate = c(.15, .22)
 #'   ),
@@ -111,7 +109,7 @@
 #'   alpha = .025,
 #'   beta = .1,
 #'   ratio = 1,
-#'   stratum_prev = tibble(
+#'   stratum_prev = tibble::tibble(
 #'     stratum = c("biomarker positive", "biomarker negative"),
 #'     prevalence = c(.4, .6)
 #'   ),
@@ -120,8 +118,8 @@
 #'   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
 #'   lpar = rep(-Inf, 2)
 #' )
-gs_design_rd <- function(p_c = tibble(stratum = "All", rate = .2),
-                         p_e = tibble(stratum = "All", rate = .15),
+gs_design_rd <- function(p_c = tibble::tibble(stratum = "All", rate = .2),
+                         p_e = tibble::tibble(stratum = "All", rate = .15),
                          info_frac = 1:3 / 3,
                          rd0 = 0,
                          alpha = .025,
@@ -164,7 +162,7 @@ gs_design_rd <- function(p_c = tibble(stratum = "All", rate = .2),
   x_fix <- gs_info_rd(
     p_c = p_c,
     p_e = p_e,
-    n = tibble(
+    n = tibble::tibble(
       analysis = 1,
       stratum = p_c$stratum,
       n = if (is.null(stratum_prev)) {
@@ -185,7 +183,7 @@ gs_design_rd <- function(p_c = tibble(stratum = "All", rate = .2),
   x_gs <- gs_info_rd(
     p_c = p_c,
     p_e = p_e,
-    n = tibble(
+    n = tibble::tibble(
       analysis = rep(1:k, n_strata),
       stratum = rep(p_c$stratum, each = k),
       n = if (is.null(stratum_prev)) {

--- a/R/gs_design_wlr.R
+++ b/R/gs_design_wlr.R
@@ -35,7 +35,6 @@
 #' }
 #' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
-#' @importFrom tibble tibble
 #' @importFrom dplyr all_of
 #'
 #' @export
@@ -45,15 +44,13 @@
 #' library(dplyr)
 #' library(mvtnorm)
 #' library(gsDesign)
-#' library(tibble)
 #' library(gsDesign2)
 #'
 #' # set enrollment rates
 #' enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
 #'
 #' # set failure rates
-#' fail_rate <- tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(4, 100),
 #'   fail_rate = log(2) / 15, # median survival 15 month
 #'   hr = c(1, .6),

--- a/R/gs_info_ahr.R
+++ b/R/gs_info_ahr.R
@@ -91,12 +91,11 @@ gs_info_ahr <- function(enroll_rate = define_enroll_rate(
                           duration = c(2, 2, 10),
                           rate = c(3, 6, 9)
                         ),
-                        fail_rate = tibble::tibble(
-                          stratum = "All",
+                        fail_rate = define_fail_rate(
                           duration = c(3, 100),
                           fail_rate = log(2) / c(9, 18),
                           hr = c(.9, .6),
-                          dropout_rate = rep(.001, 2)
+                          dropout_rate = .001
                         ),
                         ratio = 1, # experimental:Control randomization ratio
                         event = NULL, # event at analyses

--- a/R/gs_info_combo.R
+++ b/R/gs_info_combo.R
@@ -32,7 +32,6 @@
 #'   analysis time, sample size, number of events, ahr, delta,
 #'   sigma2, theta, and statistical information.
 #'
-#' @importFrom tibble tibble
 #'
 #' @export
 #'
@@ -42,12 +41,11 @@ gs_info_combo <- function(enroll_rate = define_enroll_rate(
                             duration = c(2, 2, 10),
                             rate = c(3, 6, 9)
                           ),
-                          fail_rate = tibble(
-                            stratum = "All",
+                          fail_rate = define_fail_rate(
                             duration = c(3, 100),
                             fail_rate = log(2) / c(9, 18),
                             hr = c(.9, .6),
-                            dropout_rate = rep(.001, 2)
+                            dropout_rate = .001
                           ),
                           ratio = 1,
                           event = NULL,

--- a/R/gs_info_combo.R
+++ b/R/gs_info_combo.R
@@ -18,8 +18,7 @@
 
 #' Information and effect size for MaxCombo test
 #'
-#' @param enroll_rate Enrollment rates.
-#' @param fail_rate Failure and dropout rates.
+#' @inheritParams ahr
 #' @param ratio Experimental:Control randomization ratio (not yet implemented).
 #' @param event Targeted events at each analysis.
 #' @param analysis_time Minimum time of analysis.

--- a/R/gs_info_rd.R
+++ b/R/gs_info_rd.R
@@ -32,20 +32,18 @@
 #'   theta0 (standardized treatment effect under null hypothesis),
 #'   and statistical information.
 #'
-#' @importFrom tibble tibble
 #'
 #' @export
 #'
 #' @examples
-#' library(tibble)
 #' # --------------------- #
 #' #      example 1        #
 #' # --------------------- #
 #' # unstratified case with H0: rd0 = 0
 #' gs_info_rd(
-#'   p_c = tibble(stratum = "All", rate = .15),
-#'   p_e = tibble(stratum = "All", rate = .1),
-#'   n = tibble(stratum = "All", n = c(100, 200, 300), analysis = 1:3),
+#'   p_c = tibble::tibble(stratum = "All", rate = .15),
+#'   p_e = tibble::tibble(stratum = "All", rate = .1),
+#'   n = tibble::tibble(stratum = "All", n = c(100, 200, 300), analysis = 1:3),
 #'   rd0 = 0,
 #'   ratio = 1
 #' )
@@ -55,9 +53,9 @@
 #' # --------------------- #
 #' # unstratified case with H0: rd0 != 0
 #' gs_info_rd(
-#'   p_c = tibble(stratum = "All", rate = .2),
-#'   p_e = tibble(stratum = "All", rate = .15),
-#'   n = tibble(stratum = "All", n = c(100, 200, 300), analysis = 1:3),
+#'   p_c = tibble::tibble(stratum = "All", rate = .2),
+#'   p_e = tibble::tibble(stratum = "All", rate = .15),
+#'   n = tibble::tibble(stratum = "All", n = c(100, 200, 300), analysis = 1:3),
 #'   rd0 = 0.005,
 #'   ratio = 1
 #' )
@@ -67,9 +65,9 @@
 #' # --------------------- #
 #' # stratified case under sample size weighting and H0: rd0 = 0
 #' gs_info_rd(
-#'   p_c = tibble(stratum = c("S1", "S2", "S3"), rate = c(.15, .2, .25)),
-#'   p_e = tibble(stratum = c("S1", "S2", "S3"), rate = c(.1, .16, .19)),
-#'   n = tibble(
+#'   p_c = tibble::tibble(stratum = c("S1", "S2", "S3"), rate = c(.15, .2, .25)),
+#'   p_e = tibble::tibble(stratum = c("S1", "S2", "S3"), rate = c(.1, .16, .19)),
+#'   n = tibble::tibble(
 #'     stratum = rep(c("S1", "S2", "S3"), each = 3),
 #'     analysis = rep(1:3, 3),
 #'     n = c(50, 100, 200, 40, 80, 160, 60, 120, 240)
@@ -84,15 +82,15 @@
 #' # --------------------- #
 #' # stratified case under inverse variance weighting and H0: rd0 = 0
 #' gs_info_rd(
-#'   p_c = tibble(
+#'   p_c = tibble::tibble(
 #'     stratum = c("S1", "S2", "S3"),
 #'     rate = c(.15, .2, .25)
 #'   ),
-#'   p_e = tibble(
+#'   p_e = tibble::tibble(
 #'     stratum = c("S1", "S2", "S3"),
 #'     rate = c(.1, .16, .19)
 #'   ),
-#'   n = tibble(
+#'   n = tibble::tibble(
 #'     stratum = rep(c("S1", "S2", "S3"), each = 3),
 #'     analysis = rep(1:3, 3),
 #'     n = c(50, 100, 200, 40, 80, 160, 60, 120, 240)
@@ -107,15 +105,15 @@
 #' # --------------------- #
 #' # stratified case under sample size weighting and H0: rd0 != 0
 #' gs_info_rd(
-#'   p_c = tibble(
+#'   p_c = tibble::tibble(
 #'     stratum = c("S1", "S2", "S3"),
 #'     rate = c(.15, .2, .25)
 #'   ),
-#'   p_e = tibble(
+#'   p_e = tibble::tibble(
 #'     stratum = c("S1", "S2", "S3"),
 #'     rate = c(.1, .16, .19)
 #'   ),
-#'   n = tibble(
+#'   n = tibble::tibble(
 #'     stratum = rep(c("S1", "S2", "S3"), each = 3),
 #'     analysis = rep(1:3, 3),
 #'     n = c(50, 100, 200, 40, 80, 160, 60, 120, 240)
@@ -130,15 +128,15 @@
 #' # --------------------- #
 #' # stratified case under inverse variance weighting and H0: rd0 != 0
 #' gs_info_rd(
-#'   p_c = tibble(
+#'   p_c = tibble::tibble(
 #'     stratum = c("S1", "S2", "S3"),
 #'     rate = c(.15, .2, .25)
 #'   ),
-#'   p_e = tibble(
+#'   p_e = tibble::tibble(
 #'     stratum = c("S1", "S2", "S3"),
 #'     rate = c(.1, .16, .19)
 #'   ),
-#'   n = tibble(
+#'   n = tibble::tibble(
 #'     stratum = rep(c("S1", "S2", "S3"), each = 3),
 #'     analysis = rep(1:3, 3),
 #'     n = c(50, 100, 200, 40, 80, 160, 60, 120, 240)
@@ -154,20 +152,20 @@
 #' # stratified case under inverse variance weighting and H0: rd0 != 0 and
 #' # rd0 difference for different statum
 #' gs_info_rd(
-#'   p_c = tibble(
+#'   p_c = tibble::tibble(
 #'     stratum = c("S1", "S2", "S3"),
 #'     rate = c(.15, .2, .25)
 #'   ),
-#'   p_e = tibble(
+#'   p_e = tibble::tibble(
 #'     stratum = c("S1", "S2", "S3"),
 #'     rate = c(.1, .16, .19)
 #'   ),
-#'   n = tibble(
+#'   n = tibble::tibble(
 #'     stratum = rep(c("S1", "S2", "S3"), each = 3),
 #'     analysis = rep(1:3, 3),
 #'     n = c(50, 100, 200, 40, 80, 160, 60, 120, 240)
 #'   ),
-#'   rd0 = tibble(
+#'   rd0 = tibble::tibble(
 #'     stratum = c("S1", "S2", "S3"),
 #'     rd0 = c(0.01, 0.02, 0.03)
 #'   ),

--- a/R/gs_info_wlr.R
+++ b/R/gs_info_wlr.R
@@ -54,15 +54,13 @@
 #' @export
 #'
 #' @examples
-#' library(tibble)
 #' library(gsDesign2)
 #'
 #' # Set enrollment rates
 #' enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
 #'
 #' # Set failure rates
-#' fail_rate <- tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(4, 100),
 #'   fail_rate = log(2) / 15, # median survival 15 month
 #'   hr = c(1, .6),
@@ -81,12 +79,11 @@ gs_info_wlr <- function(enroll_rate = define_enroll_rate(
                           duration = c(2, 2, 10),
                           rate = c(3, 6, 9)
                         ),
-                        fail_rate = tibble::tibble(
-                          stratum = "All",
+                        fail_rate = define_fail_rate(
                           duration = c(3, 100),
                           fail_rate = log(2) / c(9, 18),
                           hr = c(.9, .6),
-                          dropout_rate = rep(.001, 2)
+                          dropout_rate = .001
                         ),
                         ratio = 1, # Experimental:Control randomization ratio
                         event = NULL, # event at analyses

--- a/R/gs_power_ahr.R
+++ b/R/gs_power_ahr.R
@@ -144,8 +144,7 @@ gs_power_ahr <- function(enroll_rate = define_enroll_rate(
                            duration = c(2, 2, 10),
                            rate = c(3, 6, 9)
                          ),
-                         fail_rate = tibble(
-                           stratum = "All",
+                         fail_rate = define_fail_rate(
                            duration = c(3, 100),
                            fail_rate = log(2) / c(9, 18),
                            hr = c(.9, .6),

--- a/R/gs_power_combo.R
+++ b/R/gs_power_combo.R
@@ -38,7 +38,6 @@
 #' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
 #' @importFrom mvtnorm GenzBretz
-#' @importFrom tibble tibble
 #'
 #' @export
 #'
@@ -47,15 +46,13 @@
 #' library(mvtnorm)
 #' library(gsDesign)
 #' library(gsDesign2)
-#' library(tibble)
 #'
 #' enroll_rate <- define_enroll_rate(
 #'   duration = 12,
 #'   rate = 500 / 12
 #' )
 #'
-#' fail_rate <- tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(4, 100),
 #'   fail_rate = log(2) / 15, # median survival 15 month
 #'   hr = c(1, .6),
@@ -86,8 +83,7 @@ gs_power_combo <- function(enroll_rate = define_enroll_rate(
                              duration = 12,
                              rate = 500 / 12
                            ),
-                           fail_rate = tibble(
-                             stratum = "All",
+                           fail_rate = define_fail_rate(
                              duration = c(4, 100),
                              fail_rate = log(2) / 15,
                              hr = c(1, .6),

--- a/R/gs_power_npe.R
+++ b/R/gs_power_npe.R
@@ -117,9 +117,6 @@
 #' }
 #' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
-#' @author Keaven Anderson \email{keaven_anderson@@merck.com}
-#'
-#' @importFrom tibble tibble
 #' @importFrom stats qnorm pnorm
 #'
 #' @export

--- a/R/gs_power_wlr.R
+++ b/R/gs_power_wlr.R
@@ -32,7 +32,6 @@
 #' }
 #' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
-#' @importFrom tibble tibble
 #' @importFrom gsDesign gsDesign sfLDOF
 #' @importFrom dplyr left_join
 #'
@@ -42,7 +41,6 @@
 #' analysis, and bound.
 #'
 #' @examples
-#' library(tibble)
 #' library(gsDesign)
 #' library(gsDesign2)
 #'
@@ -50,8 +48,7 @@
 #' enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
 #'
 #' # set failure rates
-#' fail_rate <- tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(4, 100),
 #'   fail_rate = log(2) / 15, # median survival 15 month
 #'   hr = c(1, .6),

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -58,7 +58,6 @@
 #' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
 #' @importFrom dplyr last
-#' @importFrom tibble tibble
 #' @importFrom stats stepfun
 #'
 #' @export

--- a/R/rmst.R
+++ b/R/rmst.R
@@ -37,11 +37,10 @@
 #'
 #' @examples
 #' # Set enrollment rates
-#' enroll_rate <- define_enroll_rate(stratum = "All", duration = 12, rate = 500 / 12)
+#' enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
 #'
 #' # Set failure rates
-#' fail_rate <- tibble::tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(4, 100),
 #'   fail_rate = log(2) / 15, # median survival 15 month
 #'   hr = c(1, .6),

--- a/R/rmst.R
+++ b/R/rmst.R
@@ -19,7 +19,6 @@
 #' Sample Size Calculation based on RMST method
 #'
 #' @inheritParams ahr
-#' @param fail_rate Failure and dropout rates.
 #' @param analysis_time Minimum time of analysis.
 #' @param ratio Experimental:Control randomization ratio.
 #' @param alpha One-sided Type I error (strictly between 0 and 1).
@@ -110,8 +109,7 @@ fixed_design_size_rmst <- function(enroll_rate,
 
 #' Power calculation based on RMST method
 #'
-#' @param enroll_rate Enrollment rates.
-#' @param fail_rate Failure and dropout rates.
+#' @inheritParams ahr
 #' @param analysis_time Minimum time of analysis.
 #' @param ratio Experimental:Control randomization ratio.
 #' @param alpha One-sided Type I error (strictly between 0 and 1).
@@ -128,8 +126,7 @@ fixed_design_size_rmst <- function(enroll_rate,
 #' enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
 #'
 #' # Set failure rates
-#' fail_rate <- tibble::tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(4, 100),
 #'   fail_rate = log(2) / 15, # median survival 15 month
 #'   hr = c(1, .6),

--- a/R/summary.R
+++ b/R/summary.R
@@ -38,8 +38,7 @@
 #' )
 #'
 #' # Failure rates
-#' fail_rate <- tibble::tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(4, 100),
 #'   fail_rate = log(2) / 12,
 #'   hr = c(1, .6),
@@ -167,7 +166,6 @@ summary.fixed_design <- function(object, ...) {
 #' # ---------------------------- #
 #' #     design parameters        #
 #' # ---------------------------- #
-#' library(tibble)
 #' library(gsDesign)
 #' library(gsDesign2)
 #' library(dplyr)
@@ -178,8 +176,8 @@ summary.fixed_design <- function(object, ...) {
 #'   duration = 12,
 #'   rate = 1
 #' )
-#' fail_rate <- tibble(
-#'   stratum = "All", duration = c(4, 100),
+#' fail_rate <- define_fail_rate(
+#'   duration = c(4, 100),
 #'   fail_rate = log(2) / 12,
 #'   hr = c(1, .6),
 #'   dropout_rate = .001
@@ -291,8 +289,8 @@ summary.fixed_design <- function(object, ...) {
 #' # ---------------------------- #
 #' \donttest{
 #' gs_design_rd(
-#'   p_c = tibble(stratum = "All", rate = .2),
-#'   p_e = tibble(stratum = "All", rate = .15),
+#'   p_c = tibble::tibble(stratum = "All", rate = .2),
+#'   p_e = tibble::tibble(stratum = "All", rate = .15),
 #'   info_frac = c(0.7, 1),
 #'   rd0 = 0,
 #'   alpha = .025,

--- a/R/to_integer.R
+++ b/R/to_integer.R
@@ -40,7 +40,6 @@ to_integer <- function(x, ...) {
 #'
 #' @examples
 #' library(dplyr)
-#' library(tibble)
 #' library(gsDesign2)
 #'
 #' # Average hazard ratio
@@ -48,8 +47,8 @@ to_integer <- function(x, ...) {
 #' x <- fixed_design("ahr",
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
-#'   fail_rate = tibble(
-#'     stratum = "All", duration = c(4, 100),
+#'   fail_rate = define_fail_rate(
+#'     duration = c(4, 100),
 #'     fail_rate = log(2) / 12, hr = c(1, .6),
 #'     dropout_rate = .001
 #'   ),
@@ -61,9 +60,10 @@ to_integer <- function(x, ...) {
 #' x <- fixed_design("fh",
 #'   alpha = 0.025, power = 0.9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 20),
-#'   fail_rate = tibble(
-#'     stratum = "All", duration = c(4, 100),
-#'     fail_rate = log(2) / 12, hr = c(1, .6),
+#'   fail_rate = define_fail_rate(
+#'     duration = c(4, 100),
+#'     fail_rate = log(2) / 12, 
+#'     hr = c(1, .6),
 #'     dropout_rate = .001
 #'   ),
 #'   rho = 0.5, gamma = 0.5,
@@ -75,8 +75,8 @@ to_integer <- function(x, ...) {
 #' x <- fixed_design("mb",
 #'   alpha = 0.025, power = 0.9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 20),
-#'   fail_rate = tibble(
-#'     stratum = "All", duration = c(4, 100),
+#'   fail_rate = define_fail_rate(
+#'     duration = c(4, 100),
 #'     fail_rate = log(2) / 12, hr = c(1, .6),
 #'     dropout_rate = .001
 #'   ),
@@ -271,7 +271,7 @@ to_integer.gs_design <- function(x, sample_size = TRUE, ...) {
   } else if ("rd" %in% class(x)) {
     n_stratum <- length(x$input$p_c$stratum)
 
-    sample_size_new <- tibble(
+    sample_size_new <- tibble::tibble(
       analysis = 1:n_analysis,
       n = c(
         floor(x$analysis$n[1:(n_analysis - 1)] / multiply_factor),
@@ -288,7 +288,7 @@ to_integer.gs_design <- function(x, sample_size = TRUE, ...) {
 
     if (n_stratum == 1) {
       suppressMessages(
-        tbl_n <- tibble(
+        tbl_n <- tibble::tibble(
           analysis = rep(1:n_analysis, each = n_stratum),
           stratum = rep(x$input$p_c$stratum, n_analysis)
         ) %>%
@@ -296,7 +296,7 @@ to_integer.gs_design <- function(x, sample_size = TRUE, ...) {
       )
     } else {
       suppressMessages(
-        tbl_n <- tibble(
+        tbl_n <- tibble::tibble(
           analysis = rep(1:n_analysis, each = n_stratum),
           stratum = rep(x$input$p_c$stratum, n_analysis)
         ) %>%

--- a/R/to_integer.R
+++ b/R/to_integer.R
@@ -62,7 +62,7 @@ to_integer <- function(x, ...) {
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 20),
 #'   fail_rate = define_fail_rate(
 #'     duration = c(4, 100),
-#'     fail_rate = log(2) / 12, 
+#'     fail_rate = log(2) / 12,
 #'     hr = c(1, .6),
 #'     dropout_rate = .001
 #'   ),

--- a/R/utility_combo.R
+++ b/R/utility_combo.R
@@ -19,7 +19,6 @@
 #' MaxCombo group sequential utility
 #'
 #' @inheritParams ahr
-#' @param fail_rate Failure and dropout rates.
 #' @param ratio Experimental:Control randomization ratio (not yet implemented).
 #' @param fh_test Weighting tests.
 #' @param algorithm Numerical algorithms.

--- a/R/utility_wlr.R
+++ b/R/utility_wlr.R
@@ -54,12 +54,11 @@
 #'   rate = c(3, 6, 9)
 #' )
 #'
-#' fail_rate <- tibble::tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
 #'   hr = c(.9, .6),
-#'   dropout_rate = rep(.001, 2)
+#'   dropout_rate = .001
 #' )
 #'
 #' gs_create_arm(enroll_rate, fail_rate, ratio = 1)

--- a/R/wlr_weight.R
+++ b/R/wlr_weight.R
@@ -58,12 +58,11 @@
 #'   rate = c(3, 6, 9)
 #' )
 #'
-#' fail_rate <- tibble::tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
 #'   hr = c(.9, .6),
-#'   dropout_rate = rep(.001, 2)
+#'   dropout_rate = .001
 #' )
 #'
 #' gs_arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1)
@@ -100,12 +99,11 @@ wlr_weight_fh <- function(x, arm0, arm1, rho = 0, gamma = 0, tau = NULL) {
 #'   rate = c(3, 6, 9)
 #' )
 #'
-#' fail_rate <- tibble::tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
 #'   hr = c(.9, .6),
-#'   dropout_rate = rep(.001, 2)
+#'   dropout_rate = .001
 #' )
 #'
 #' gs_arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1)
@@ -129,12 +127,11 @@ wlr_weight_1 <- function(x, arm0, arm1) {
 #'   rate = c(3, 6, 9)
 #' )
 #'
-#' fail_rate <- tibble::tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
 #'   hr = c(.9, .6),
-#'   dropout_rate = rep(.001, 2)
+#'   dropout_rate = .001
 #' )
 #'
 #' gs_arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1)
@@ -163,12 +160,11 @@ wlr_weight_n <- function(x, arm0, arm1, power = 1) {
 #'   rate = c(3, 6, 9)
 #' )
 #'
-#' fail_rate <- tibble::tibble(
-#'   stratum = "All",
+#' fail_rate <- define_fail_rate(
 #'   duration = c(3, 100),
 #'   fail_rate = log(2) / c(9, 18),
 #'   hr = c(.9, .6),
-#'   dropout_rate = rep(.001, 2)
+#'   dropout_rate = .001
 #' )
 #'
 #' gs_arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1)

--- a/README.Rmd
+++ b/README.Rmd
@@ -85,8 +85,7 @@ enroll_rate <- define_enroll_rate(duration = 12, rate = 1)
 # 4 month delay in effect with HR=0.6 after
 # Low exponential dropout rate
 median_surv <- 12
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, Inf),
   fail_rate = log(2) / median_surv,
   hr = c(1, .6),

--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ enroll_rate <- define_enroll_rate(duration = 12, rate = 1)
 # 4 month delay in effect with HR=0.6 after
 # Low exponential dropout rate
 median_surv <- 12
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, Inf),
   fail_rate = log(2) / median_surv,
   hr = c(1, .6),

--- a/inst/example_run_time/timer.Rmd
+++ b/inst/example_run_time/timer.Rmd
@@ -27,8 +27,7 @@ enroll_rate <- define_enroll_rate(
   rate = 500 / 12
 )
 
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 15, # median survival 15 month
   hr = c(1, .6),

--- a/man/ahr.Rd
+++ b/man/ahr.Rd
@@ -6,8 +6,8 @@
 \usage{
 ahr(
   enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
-  fail_rate = tibble::tibble(stratum = "All", duration = c(3, 100), fail_rate =
-    log(2)/c(9, 18), hr = c(0.9, 0.6), dropout_rate = rep(0.001, 2)),
+  fail_rate = define_fail_rate(duration = c(3, 100), fail_rate = log(2)/c(9, 18), hr =
+    c(0.9, 0.6), dropout_rate = 0.001),
   total_duration = 30,
   ratio = 1,
   simple = TRUE
@@ -100,7 +100,7 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 10, 4, 4, 8),
   rate = c(5, 10, 0, 3, 6)
 )
-fail_rate <- tibble::tibble(
+fail_rate <- define_fail_rate(
   stratum = c(rep("Low", 2), rep("High", 2)),
   duration = 1,
   fail_rate = c(.1, .2, .3, .4),

--- a/man/ahr.Rd
+++ b/man/ahr.Rd
@@ -14,12 +14,9 @@ ahr(
 )
 }
 \arguments{
-\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum
-created by \code{\link[=define_enroll_rate]{define_enroll_rate()}}.}
+\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum created by \code{define_enroll_rate}.}
 
-\item{fail_rate}{Piecewise constant control group failure rates, duration
-for each piecewise constant period,
-hazard ratio for experimental vs control, and dropout rates by stratum and time period.}
+\item{fail_rate}{A \code{fail_rate} data frame with or without stratum created by \code{define_fail_rate}.}
 
 \item{total_duration}{Total follow-up from start of enrollment to data cutoff;
 this can be a single value or a vector of positive numbers.}
@@ -105,8 +102,8 @@ fail_rate <- define_fail_rate(
   stratum = c(rep("Low", 2), rep("High", 2)),
   duration = 1,
   fail_rate = c(.1, .2, .3, .4),
-  hr = c(.9, .75, .8, .6),
-  dropout_rate = .001
+  dropout_rate = .001,
+  hr = c(.9, .75, .8, .6)
 )
 ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, total_duration = c(15, 30))
 

--- a/man/as_gt.Rd
+++ b/man/as_gt.Rd
@@ -75,8 +75,7 @@ enroll_rate <- define_enroll_rate(
 )
 
 # Failure rates
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 12,
   hr = c(1, .6),

--- a/man/as_gt.Rd
+++ b/man/as_gt.Rd
@@ -78,8 +78,8 @@ enroll_rate <- define_enroll_rate(
 fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 12,
-  hr = c(1, .6),
-  dropout_rate = .001
+  dropout_rate = .001,
+  hr = c(1, .6)
 )
 
 # Study duration in months

--- a/man/define_enroll_rate.Rd
+++ b/man/define_enroll_rate.Rd
@@ -4,7 +4,7 @@
 \alias{define_enroll_rate}
 \title{Define enrollment rate}
 \usage{
-define_enroll_rate(duration, rate, stratum = rep("All", length(duration)))
+define_enroll_rate(duration, rate, stratum = "All")
 }
 \arguments{
 \item{duration}{A numeric vector of piecewise study duration interval.}

--- a/man/define_fail_rate.Rd
+++ b/man/define_fail_rate.Rd
@@ -4,13 +4,7 @@
 \alias{define_fail_rate}
 \title{Define fail rate}
 \usage{
-define_fail_rate(
-  duration,
-  fail_rate,
-  dropout_rate,
-  hr = rep(1, length(duration)),
-  stratum = rep("All", length(duration))
-)
+define_fail_rate(duration, fail_rate, dropout_rate, hr = 1, stratum = "All")
 }
 \arguments{
 \item{duration}{A numeric vector of piecewise study duration interval.}
@@ -36,7 +30,7 @@ define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = .001
 )
 
 # define enroll rate with stratum
@@ -44,7 +38,7 @@ define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
-  dropout_rate = rep(.001, 2),
+  dropout_rate = .001,
   stratum = c("low", "high")
 )
 }

--- a/man/expected_accrual.Rd
+++ b/man/expected_accrual.Rd
@@ -12,8 +12,7 @@ expected_accrual(
 \arguments{
 \item{time}{Times at which enrollment is to be computed.}
 
-\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum
-created by \code{\link[=define_enroll_rate]{define_enroll_rate()}}.}
+\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum created by \code{define_enroll_rate}.}
 }
 \value{
 A vector with expected cumulative enrollment for the specified \code{times}.

--- a/man/expected_event.Rd
+++ b/man/expected_event.Rd
@@ -13,12 +13,11 @@ expected_event(
 )
 }
 \arguments{
-\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum
-created by \code{\link[=define_enroll_rate]{define_enroll_rate()}}.}
+\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum created by \code{define_enroll_rate}.}
 
-\item{fail_rate}{Failure rates and dropout rates by period.}
+\item{fail_rate}{A \code{fail_rate} data frame with or without stratum created by \code{define_fail_rate}.}
 
-\item{total_duration}{A positive number specifying the total follow-up from start of enrollment to data cutoff.}
+\item{total_duration}{Total follow-up from start of enrollment to data cutoff.}
 
 \item{simple}{If default (\code{TRUE}), return numeric expected number of events,
 otherwise a tibble as described below.}

--- a/man/expected_event.Rd
+++ b/man/expected_event.Rd
@@ -6,8 +6,8 @@
 \usage{
 expected_event(
   enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
-  fail_rate = tibble::tibble(duration = c(3, 100), fail_rate = log(2)/c(9, 18),
-    dropout_rate = rep(0.001, 2)),
+  fail_rate = define_fail_rate(duration = c(3, 100), fail_rate = log(2)/c(9, 18),
+    dropout_rate = 0.001),
   total_duration = 25,
   simple = TRUE
 )
@@ -85,7 +85,6 @@ maximize flexibility for a variety of purposes.
 }
 
 \examples{
-library(tibble)
 library(gsDesign2)
 
 # Default arguments, simple output (total event count only)
@@ -100,7 +99,7 @@ expected_event(total_duration = .5)
 # Single time period example
 expected_event(
   enroll_rate = define_enroll_rate(duration = 10, rate = 10),
-  fail_rate = tibble(duration = 100, fail_rate = log(2) / 6, dropout_rate = .01),
+  fail_rate = define_fail_rate(duration = 100, fail_rate = log(2) / 6, dropout_rate = .01),
   total_duration = 22,
   simple = FALSE
 )
@@ -108,7 +107,7 @@ expected_event(
 # Single time period example, multiple enrollment periods
 expected_event(
   enroll_rate = define_enroll_rate(duration = c(5, 5), rate = c(10, 20)),
-  fail_rate = tibble(duration = 100, fail_rate = log(2) / 6, dropout_rate = .01),
+  fail_rate = define_fail_rate(duration = 100, fail_rate = log(2) / 6, dropout_rate = .01),
   total_duration = 22, simple = FALSE
 )
 }

--- a/man/expected_time.Rd
+++ b/man/expected_time.Rd
@@ -14,13 +14,9 @@ expected_time(
 )
 }
 \arguments{
-\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum
-created by \code{\link[=define_enroll_rate]{define_enroll_rate()}}.}
+\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum created by \code{define_enroll_rate}.}
 
-\item{fail_rate}{Piecewise constant control group failure rates,
-duration for each piecewise constant period,
-hazard ratio for experimental vs control,
-and dropout rates by stratum and time period.}
+\item{fail_rate}{A \code{fail_rate} data frame with or without stratum created by \code{define_fail_rate}.}
 
 \item{target_event}{The targeted number of events to be achieved.}
 

--- a/man/expected_time.Rd
+++ b/man/expected_time.Rd
@@ -6,7 +6,7 @@
 \usage{
 expected_time(
   enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9) * 5),
-  fail_rate = tibble::tibble(stratum = "All", duration = c(3, 100), fail_rate =
+  fail_rate = define_fail_rate(stratum = "All", duration = c(3, 100), fail_rate =
     log(2)/c(9, 18), hr = c(0.9, 0.6), dropout_rate = rep(0.001, 2)),
   target_event = 150,
   ratio = 1,
@@ -68,9 +68,11 @@ expected_time()
 # check that result matches a finding using AHR()
 # Start by deriving an expected event count
 enroll_rate <- define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9) * 5)
-fail_rate <- tibble::tibble(
-  stratum = "All", duration = c(3, 100), fail_rate = log(2) / c(9, 18),
-  hr = c(.9, .6), dropout_rate = rep(.001, 2)
+fail_rate <- define_fail_rate(
+  duration = c(3, 100), 
+  fail_rate = log(2) / c(9, 18),
+  hr = c(.9, .6), 
+  dropout_rate = .001
 )
 total_duration <- 20
 xx <- ahr(enroll_rate, fail_rate, total_duration)

--- a/man/fixed_design.Rd
+++ b/man/fixed_design.Rd
@@ -45,8 +45,7 @@ x <- fixed_design(
   "ahr",
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
-  fail_rate = tibble::tibble(
-    stratum = "All",
+  fail_rate = define_fail_rate(
     duration = c(4, 100),
     fail_rate = log(2) / 12,
     hr = c(1, .6),
@@ -61,8 +60,7 @@ x <- fixed_design(
   "lf",
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
-  fail_rate = tibble::tibble(
-    stratum = "All",
+  fail_rate = define_fail_rate(
     duration = 100,
     fail_rate = log(2) / 12,
     hr = .7,
@@ -77,8 +75,7 @@ x <- fixed_design(
   "rmst",
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
-  fail_rate = tibble::tibble(
-    stratum = "All",
+  fail_rate = define_fail_rate(
     duration = 100,
     fail_rate = log(2) / 12,
     hr = .7,
@@ -94,8 +91,7 @@ x <- fixed_design(
   "milestone",
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
-  fail_rate = tibble::tibble(
-    stratum = "All",
+  fail_rate = define_fail_rate(
     duration = 100,
     fail_rate = log(2) / 12,
     hr = .7,

--- a/man/gs_create_arm.Rd
+++ b/man/gs_create_arm.Rd
@@ -53,12 +53,11 @@ enroll_rate <- define_enroll_rate(
   rate = c(3, 6, 9)
 )
 
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = .001
 )
 
 gs_create_arm(enroll_rate, fail_rate, ratio = 1)

--- a/man/gs_design_ahr.Rd
+++ b/man/gs_design_ahr.Rd
@@ -6,8 +6,8 @@
 \usage{
 gs_design_ahr(
   enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
-  fail_rate = tibble(stratum = "All", duration = c(3, 100), fail_rate = log(2)/c(9, 18),
-    hr = c(0.9, 0.6), dropout_rate = rep(0.001, 2)),
+  fail_rate = define_fail_rate(duration = c(3, 100), fail_rate = log(2)/c(9, 18), hr =
+    c(0.9, 0.6), dropout_rate = 0.001),
   alpha = 0.025,
   beta = 0.1,
   info_frac = NULL,

--- a/man/gs_design_combo.Rd
+++ b/man/gs_design_combo.Rd
@@ -6,8 +6,8 @@
 \usage{
 gs_design_combo(
   enroll_rate = define_enroll_rate(duration = 12, rate = 500/12),
-  fail_rate = tibble(stratum = "All", duration = c(4, 100), fail_rate = log(2)/15, hr =
-    c(1, 0.6), dropout_rate = 0.001),
+  fail_rate = define_fail_rate(duration = c(4, 100), fail_rate = log(2)/15, hr = c(1,
+    0.6), dropout_rate = 0.001),
   fh_test = rbind(data.frame(rho = 0, gamma = 0, tau = -1, test = 1, analysis = 1:3,
     analysis_time = c(12, 24, 36)), data.frame(rho = c(0, 0.5), gamma = 0.5, tau = -1,
     test = 2:3, analysis = 3, analysis_time = 36)),
@@ -69,15 +69,13 @@ Group sequential design using MaxCombo test under non-proportional hazards
 library(dplyr)
 library(mvtnorm)
 library(gsDesign)
-library(tibble)
 
 enroll_rate <- define_enroll_rate(
   duration = 12,
   rate = 500 / 12
 )
 
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 15, # median survival 15 month
   hr = c(1, .6),

--- a/man/gs_design_rd.Rd
+++ b/man/gs_design_rd.Rd
@@ -5,8 +5,8 @@
 \title{Group sequential design of binary outcome measuring in risk difference}
 \usage{
 gs_design_rd(
-  p_c = tibble(stratum = "All", rate = 0.2),
-  p_e = tibble(stratum = "All", rate = 0.15),
+  p_c = tibble::tibble(stratum = "All", rate = 0.2),
+  p_e = tibble::tibble(stratum = "All", rate = 0.15),
   info_frac = 1:3/3,
   rd0 = 0,
   alpha = 0.025,
@@ -98,7 +98,6 @@ Group sequential design of binary outcome measuring in risk difference
 To be added.
 }
 \examples{
-library(tibble)
 library(gsDesign)
 
 # ----------------- #
@@ -106,8 +105,8 @@ library(gsDesign)
 #------------------ #
 # unstratified group sequential design
 gs_design_rd(
-  p_c = tibble(stratum = "All", rate = .2),
-  p_e = tibble(stratum = "All", rate = .15),
+  p_c = tibble::tibble(stratum = "All", rate = .2),
+  p_e = tibble::tibble(stratum = "All", rate = .15),
   info_frac = c(0.7, 1),
   rd0 = 0,
   alpha = .025,
@@ -126,11 +125,11 @@ gs_design_rd(
 # ----------------- #
 # stratified group sequential design
 gs_design_rd(
-  p_c = tibble(
+  p_c = tibble::tibble(
     stratum = c("biomarker positive", "biomarker negative"),
     rate = c(.2, .25)
   ),
-  p_e = tibble(
+  p_e = tibble::tibble(
     stratum = c("biomarker positive", "biomarker negative"),
     rate = c(.15, .22)
   ),
@@ -139,7 +138,7 @@ gs_design_rd(
   alpha = .025,
   beta = .1,
   ratio = 1,
-  stratum_prev = tibble(
+  stratum_prev = tibble::tibble(
     stratum = c("biomarker positive", "biomarker negative"),
     prevalence = c(.4, .6)
   ),

--- a/man/gs_design_wlr.Rd
+++ b/man/gs_design_wlr.Rd
@@ -128,15 +128,13 @@ Group sequential design using weighted log-rank test under non-proportional haza
 library(dplyr)
 library(mvtnorm)
 library(gsDesign)
-library(tibble)
 library(gsDesign2)
 
 # set enrollment rates
 enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
 
 # set failure rates
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 15, # median survival 15 month
   hr = c(1, .6),

--- a/man/gs_info_ahr.Rd
+++ b/man/gs_info_ahr.Rd
@@ -6,8 +6,8 @@
 \usage{
 gs_info_ahr(
   enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
-  fail_rate = tibble::tibble(stratum = "All", duration = c(3, 100), fail_rate =
-    log(2)/c(9, 18), hr = c(0.9, 0.6), dropout_rate = rep(0.001, 2)),
+  fail_rate = define_fail_rate(duration = c(3, 100), fail_rate = log(2)/c(9, 18), hr =
+    c(0.9, 0.6), dropout_rate = 0.001),
   ratio = 1,
   event = NULL,
   analysis_time = NULL,

--- a/man/gs_info_combo.Rd
+++ b/man/gs_info_combo.Rd
@@ -18,9 +18,9 @@ gs_info_combo(
 )
 }
 \arguments{
-\item{enroll_rate}{Enrollment rates.}
+\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum created by \code{define_enroll_rate}.}
 
-\item{fail_rate}{Failure and dropout rates.}
+\item{fail_rate}{A \code{fail_rate} data frame with or without stratum created by \code{define_fail_rate}.}
 
 \item{ratio}{Experimental:Control randomization ratio (not yet implemented).}
 

--- a/man/gs_info_combo.Rd
+++ b/man/gs_info_combo.Rd
@@ -6,8 +6,8 @@
 \usage{
 gs_info_combo(
   enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
-  fail_rate = tibble(stratum = "All", duration = c(3, 100), fail_rate = log(2)/c(9, 18),
-    hr = c(0.9, 0.6), dropout_rate = rep(0.001, 2)),
+  fail_rate = define_fail_rate(duration = c(3, 100), fail_rate = log(2)/c(9, 18), hr =
+    c(0.9, 0.6), dropout_rate = 0.001),
   ratio = 1,
   event = NULL,
   analysis_time = NULL,

--- a/man/gs_info_rd.Rd
+++ b/man/gs_info_rd.Rd
@@ -38,15 +38,14 @@ and statistical information.
 Information and effect size under risk difference
 }
 \examples{
-library(tibble)
 # --------------------- #
 #      example 1        #
 # --------------------- #
 # unstratified case with H0: rd0 = 0
 gs_info_rd(
-  p_c = tibble(stratum = "All", rate = .15),
-  p_e = tibble(stratum = "All", rate = .1),
-  n = tibble(stratum = "All", n = c(100, 200, 300), analysis = 1:3),
+  p_c = tibble::tibble(stratum = "All", rate = .15),
+  p_e = tibble::tibble(stratum = "All", rate = .1),
+  n = tibble::tibble(stratum = "All", n = c(100, 200, 300), analysis = 1:3),
   rd0 = 0,
   ratio = 1
 )
@@ -56,9 +55,9 @@ gs_info_rd(
 # --------------------- #
 # unstratified case with H0: rd0 != 0
 gs_info_rd(
-  p_c = tibble(stratum = "All", rate = .2),
-  p_e = tibble(stratum = "All", rate = .15),
-  n = tibble(stratum = "All", n = c(100, 200, 300), analysis = 1:3),
+  p_c = tibble::tibble(stratum = "All", rate = .2),
+  p_e = tibble::tibble(stratum = "All", rate = .15),
+  n = tibble::tibble(stratum = "All", n = c(100, 200, 300), analysis = 1:3),
   rd0 = 0.005,
   ratio = 1
 )
@@ -68,9 +67,9 @@ gs_info_rd(
 # --------------------- #
 # stratified case under sample size weighting and H0: rd0 = 0
 gs_info_rd(
-  p_c = tibble(stratum = c("S1", "S2", "S3"), rate = c(.15, .2, .25)),
-  p_e = tibble(stratum = c("S1", "S2", "S3"), rate = c(.1, .16, .19)),
-  n = tibble(
+  p_c = tibble::tibble(stratum = c("S1", "S2", "S3"), rate = c(.15, .2, .25)),
+  p_e = tibble::tibble(stratum = c("S1", "S2", "S3"), rate = c(.1, .16, .19)),
+  n = tibble::tibble(
     stratum = rep(c("S1", "S2", "S3"), each = 3),
     analysis = rep(1:3, 3),
     n = c(50, 100, 200, 40, 80, 160, 60, 120, 240)
@@ -85,15 +84,15 @@ gs_info_rd(
 # --------------------- #
 # stratified case under inverse variance weighting and H0: rd0 = 0
 gs_info_rd(
-  p_c = tibble(
+  p_c = tibble::tibble(
     stratum = c("S1", "S2", "S3"),
     rate = c(.15, .2, .25)
   ),
-  p_e = tibble(
+  p_e = tibble::tibble(
     stratum = c("S1", "S2", "S3"),
     rate = c(.1, .16, .19)
   ),
-  n = tibble(
+  n = tibble::tibble(
     stratum = rep(c("S1", "S2", "S3"), each = 3),
     analysis = rep(1:3, 3),
     n = c(50, 100, 200, 40, 80, 160, 60, 120, 240)
@@ -108,15 +107,15 @@ gs_info_rd(
 # --------------------- #
 # stratified case under sample size weighting and H0: rd0 != 0
 gs_info_rd(
-  p_c = tibble(
+  p_c = tibble::tibble(
     stratum = c("S1", "S2", "S3"),
     rate = c(.15, .2, .25)
   ),
-  p_e = tibble(
+  p_e = tibble::tibble(
     stratum = c("S1", "S2", "S3"),
     rate = c(.1, .16, .19)
   ),
-  n = tibble(
+  n = tibble::tibble(
     stratum = rep(c("S1", "S2", "S3"), each = 3),
     analysis = rep(1:3, 3),
     n = c(50, 100, 200, 40, 80, 160, 60, 120, 240)
@@ -131,15 +130,15 @@ gs_info_rd(
 # --------------------- #
 # stratified case under inverse variance weighting and H0: rd0 != 0
 gs_info_rd(
-  p_c = tibble(
+  p_c = tibble::tibble(
     stratum = c("S1", "S2", "S3"),
     rate = c(.15, .2, .25)
   ),
-  p_e = tibble(
+  p_e = tibble::tibble(
     stratum = c("S1", "S2", "S3"),
     rate = c(.1, .16, .19)
   ),
-  n = tibble(
+  n = tibble::tibble(
     stratum = rep(c("S1", "S2", "S3"), each = 3),
     analysis = rep(1:3, 3),
     n = c(50, 100, 200, 40, 80, 160, 60, 120, 240)
@@ -155,20 +154,20 @@ gs_info_rd(
 # stratified case under inverse variance weighting and H0: rd0 != 0 and
 # rd0 difference for different statum
 gs_info_rd(
-  p_c = tibble(
+  p_c = tibble::tibble(
     stratum = c("S1", "S2", "S3"),
     rate = c(.15, .2, .25)
   ),
-  p_e = tibble(
+  p_e = tibble::tibble(
     stratum = c("S1", "S2", "S3"),
     rate = c(.1, .16, .19)
   ),
-  n = tibble(
+  n = tibble::tibble(
     stratum = rep(c("S1", "S2", "S3"), each = 3),
     analysis = rep(1:3, 3),
     n = c(50, 100, 200, 40, 80, 160, 60, 120, 240)
   ),
-  rd0 = tibble(
+  rd0 = tibble::tibble(
     stratum = c("S1", "S2", "S3"),
     rd0 = c(0.01, 0.02, 0.03)
   ),

--- a/man/gs_info_wlr.Rd
+++ b/man/gs_info_wlr.Rd
@@ -6,8 +6,8 @@
 \usage{
 gs_info_wlr(
   enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
-  fail_rate = tibble::tibble(stratum = "All", duration = c(3, 100), fail_rate =
-    log(2)/c(9, 18), hr = c(0.9, 0.6), dropout_rate = rep(0.001, 2)),
+  fail_rate = define_fail_rate(duration = c(3, 100), fail_rate = log(2)/c(9, 18), hr =
+    c(0.9, 0.6), dropout_rate = 0.001),
   ratio = 1,
   event = NULL,
   analysis_time = NULL,
@@ -62,15 +62,13 @@ The \code{\link[=expected_time]{expected_time()}} function is used to get events
 targeted \code{analysis_time}.
 }
 \examples{
-library(tibble)
 library(gsDesign2)
 
 # Set enrollment rates
 enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
 
 # Set failure rates
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 15, # median survival 15 month
   hr = c(1, .6),

--- a/man/gs_info_wlr.Rd
+++ b/man/gs_info_wlr.Rd
@@ -17,8 +17,7 @@ gs_info_wlr(
 )
 }
 \arguments{
-\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum
-created by \code{\link[=define_enroll_rate]{define_enroll_rate()}}.}
+\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum created by \code{define_enroll_rate}.}
 
 \item{fail_rate}{Failure and dropout rates.}
 

--- a/man/gs_power_ahr.Rd
+++ b/man/gs_power_ahr.Rd
@@ -27,8 +27,7 @@ gs_power_ahr(
 )
 }
 \arguments{
-\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum
-created by \code{\link[=define_enroll_rate]{define_enroll_rate()}}.}
+\item{enroll_rate}{An \code{enroll_rate} data frame with or without stratum created by \code{define_enroll_rate}.}
 
 \item{fail_rate}{Failure and dropout rates.}
 

--- a/man/gs_power_ahr.Rd
+++ b/man/gs_power_ahr.Rd
@@ -7,8 +7,8 @@ non-proportional hazards}
 \usage{
 gs_power_ahr(
   enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
-  fail_rate = tibble(stratum = "All", duration = c(3, 100), fail_rate = log(2)/c(9, 18),
-    hr = c(0.9, 0.6), dropout_rate = rep(0.001, 2)),
+  fail_rate = define_fail_rate(duration = c(3, 100), fail_rate = log(2)/c(9, 18), hr =
+    c(0.9, 0.6), dropout_rate = rep(0.001, 2)),
   event = c(30, 40, 50),
   analysis_time = NULL,
   upper = gs_b,

--- a/man/gs_power_combo.Rd
+++ b/man/gs_power_combo.Rd
@@ -6,8 +6,8 @@
 \usage{
 gs_power_combo(
   enroll_rate = define_enroll_rate(duration = 12, rate = 500/12),
-  fail_rate = tibble(stratum = "All", duration = c(4, 100), fail_rate = log(2)/15, hr =
-    c(1, 0.6), dropout_rate = 0.001),
+  fail_rate = define_fail_rate(duration = c(4, 100), fail_rate = log(2)/15, hr = c(1,
+    0.6), dropout_rate = 0.001),
   fh_test = rbind(data.frame(rho = 0, gamma = 0, tau = -1, test = 1, analysis = 1:3,
     analysis_time = c(12, 24, 36)), data.frame(rho = c(0, 0.5), gamma = 0.5, tau = -1,
     test = 2:3, analysis = 3, analysis_time = 36)),
@@ -77,15 +77,13 @@ library(dplyr)
 library(mvtnorm)
 library(gsDesign)
 library(gsDesign2)
-library(tibble)
 
 enroll_rate <- define_enroll_rate(
   duration = 12,
   rate = 500 / 12
 )
 
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 15, # median survival 15 month
   hr = c(1, .6),

--- a/man/gs_power_npe.Rd
+++ b/man/gs_power_npe.Rd
@@ -226,6 +226,3 @@ gs_power_npe(
   lpar = -(x \%>\% filter(bound == "upper"))$z
 )
 }
-\author{
-Keaven Anderson \email{keaven_anderson@merck.com}
-}

--- a/man/gs_power_wlr.Rd
+++ b/man/gs_power_wlr.Rd
@@ -112,7 +112,6 @@ Group sequential design power using weighted log rank test under non-proportiona
 }
 
 \examples{
-library(tibble)
 library(gsDesign)
 library(gsDesign2)
 
@@ -120,8 +119,7 @@ library(gsDesign2)
 enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
 
 # set failure rates
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 15, # median survival 15 month
   hr = c(1, .6),

--- a/man/summary.Rd
+++ b/man/summary.Rd
@@ -49,8 +49,7 @@ enroll_rate <- define_enroll_rate(
 )
 
 # Failure rates
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 12,
   hr = c(1, .6),
@@ -99,7 +98,6 @@ fixed_design(
 # ---------------------------- #
 #     design parameters        #
 # ---------------------------- #
-library(tibble)
 library(gsDesign)
 library(gsDesign2)
 library(dplyr)
@@ -110,8 +108,8 @@ enroll_rate <- define_enroll_rate(
   duration = 12,
   rate = 1
 )
-fail_rate <- tibble(
-  stratum = "All", duration = c(4, 100),
+fail_rate <- define_fail_rate(
+  duration = c(4, 100),
   fail_rate = log(2) / 12,
   hr = c(1, .6),
   dropout_rate = .001
@@ -223,8 +221,8 @@ x_combo \%>\% summary()
 # ---------------------------- #
 \donttest{
 gs_design_rd(
-  p_c = tibble(stratum = "All", rate = .2),
-  p_e = tibble(stratum = "All", rate = .15),
+  p_c = tibble::tibble(stratum = "All", rate = .2),
+  p_e = tibble::tibble(stratum = "All", rate = .15),
   info_frac = c(0.7, 1),
   rd0 = 0,
   alpha = .025,

--- a/man/to_integer.Rd
+++ b/man/to_integer.Rd
@@ -31,7 +31,6 @@ Rounds sample size to an even number for equal design
 }
 \examples{
 library(dplyr)
-library(tibble)
 library(gsDesign2)
 
 # Average hazard ratio
@@ -39,8 +38,8 @@ library(gsDesign2)
 x <- fixed_design("ahr",
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
-  fail_rate = tibble(
-    stratum = "All", duration = c(4, 100),
+  fail_rate = define_fail_rate(
+    duration = c(4, 100),
     fail_rate = log(2) / 12, hr = c(1, .6),
     dropout_rate = .001
   ),
@@ -52,9 +51,10 @@ x \%>\% to_integer()
 x <- fixed_design("fh",
   alpha = 0.025, power = 0.9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 20),
-  fail_rate = tibble(
-    stratum = "All", duration = c(4, 100),
-    fail_rate = log(2) / 12, hr = c(1, .6),
+  fail_rate = define_fail_rate(
+    duration = c(4, 100),
+    fail_rate = log(2) / 12, 
+    hr = c(1, .6),
     dropout_rate = .001
   ),
   rho = 0.5, gamma = 0.5,
@@ -66,8 +66,8 @@ x \%>\% to_integer()
 x <- fixed_design("mb",
   alpha = 0.025, power = 0.9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 20),
-  fail_rate = tibble(
-    stratum = "All", duration = c(4, 100),
+  fail_rate = define_fail_rate(
+    duration = c(4, 100),
     fail_rate = log(2) / 12, hr = c(1, .6),
     dropout_rate = .001
   ),

--- a/man/wlr_weight.Rd
+++ b/man/wlr_weight.Rd
@@ -70,12 +70,11 @@ enroll_rate <- define_enroll_rate(
   rate = c(3, 6, 9)
 )
 
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = .001
 )
 
 gs_arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1)
@@ -88,12 +87,11 @@ enroll_rate <- define_enroll_rate(
   rate = c(3, 6, 9)
 )
 
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = .001
 )
 
 gs_arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1)
@@ -106,12 +104,11 @@ enroll_rate <- define_enroll_rate(
   rate = c(3, 6, 9)
 )
 
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = .001
 )
 
 gs_arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1)
@@ -124,12 +121,11 @@ enroll_rate <- define_enroll_rate(
   rate = c(3, 6, 9)
 )
 
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = .001
 )
 
 gs_arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,29 +1,28 @@
 test_event <- function(enroll_rate,
-                         fail_rate,
-                         td = 15) {
-  
+                       fail_rate,
+                       td = 15) {
   enroll_rate_1 <- enroll_rate
   enroll_rate_1$rate <- enroll_rate$rate / 2
-  
-  fail_rate_c <- fail_rate 
-  fail_rate_t <- fail_rate  
+
+  fail_rate_c <- fail_rate
+  fail_rate_t <- fail_rate
   fail_rate_t$fail_rate <- fail_rate_t$fail_rate * fail_rate_t$hr
-  
+
   event_c <- gsDesign2::expected_event(
     enroll_rate = enroll_rate_1,
     fail_rate = fail_rate_c,
     total_duration = td,
     simple = FALSE
   )
-  
+
   event_t <- gsDesign2::expected_event(
     enroll_rate = enroll_rate_1,
     fail_rate = fail_rate_t,
     total_duration = td,
     simple = FALSE
   )
-  
+
   total_e <- sum(event_c$event + event_t$event)
-  
+
   total_e
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,29 @@
+test_event <- function(enroll_rate,
+                         fail_rate,
+                         td = 15) {
+  
+  enroll_rate_1 <- enroll_rate
+  enroll_rate_1$rate <- enroll_rate$rate / 2
+  
+  fail_rate_c <- fail_rate 
+  fail_rate_t <- fail_rate  
+  fail_rate_t$fail_rate <- fail_rate_t$fail_rate * fail_rate_t$hr
+  
+  event_c <- gsDesign2::expected_event(
+    enroll_rate = enroll_rate_1,
+    fail_rate = fail_rate_c,
+    total_duration = td,
+    simple = FALSE
+  )
+  
+  event_t <- gsDesign2::expected_event(
+    enroll_rate = enroll_rate_1,
+    fail_rate = fail_rate_t,
+    total_duration = td,
+    simple = FALSE
+  )
+  
+  total_e <- sum(event_c$event + event_t$event)
+  
+  total_e
+}

--- a/tests/testthat/test-independent-AHR.R
+++ b/tests/testthat/test-independent-AHR.R
@@ -1,11 +1,10 @@
 load("fixtures/simulation_test_data.Rdata")
 
-enroll_rate <- tibble::tibble(
-  stratum = "All",
+enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 10),
   rate = c(3, 6, 9)
 )
-fail_rate <- tibble::tibble(
+fail_rate <- define_fail_rate(
   stratum = "All",
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),

--- a/tests/testthat/test-independent-AHR.R
+++ b/tests/testthat/test-independent-AHR.R
@@ -13,7 +13,6 @@ fail_rate <- define_fail_rate(
 )
 
 testthat::test_that("AHR results are consistent with simulation results for single stratum and multiple cutoff", {
-
   actual <- ahr(
     enroll_rate = enroll_rate,
     fail_rate = fail_rate,
@@ -25,7 +24,6 @@ testthat::test_that("AHR results are consistent with simulation results for sing
 })
 
 testthat::test_that("AHR results are consistent with simulation results for single stratum and single cutoff", {
-
   total_duration <- 30
   actual <- ahr(
     enroll_rate = enroll_rate,
@@ -37,7 +35,6 @@ testthat::test_that("AHR results are consistent with simulation results for sing
 })
 
 testthat::test_that("AHR results are consistent with simulation results for single stratum and multiple cutoff", {
-
   total_duration <- c(15, 30)
 
   actual <- ahr(

--- a/tests/testthat/test-independent-AHR.R
+++ b/tests/testthat/test-independent-AHR.R
@@ -1,18 +1,20 @@
 load("fixtures/simulation_test_data.Rdata")
 
+enroll_rate <- tibble::tibble(
+  stratum = "All",
+  duration = c(2, 2, 10),
+  rate = c(3, 6, 9)
+)
+fail_rate <- tibble::tibble(
+  stratum = "All",
+  duration = c(3, 100),
+  fail_rate = log(2) / c(9, 18),
+  hr = c(.9, .6),
+  dropout_rate = rep(.001, 2)
+)
+
 testthat::test_that("AHR results are consistent with simulation results for single stratum and multiple cutoff", {
-  enroll_rate <- tibble::tibble(
-    stratum = "All",
-    duration = c(2, 2, 10),
-    rate = c(3, 6, 9)
-  )
-  fail_rate <- tibble::tibble(
-    stratum = "All",
-    duration = c(3, 100),
-    fail_rate = log(2) / c(9, 18),
-    hr = c(.9, .6),
-    dropout_rate = rep(.001, 2)
-  )
+
   actual <- ahr(
     enroll_rate = enroll_rate,
     fail_rate = fail_rate,
@@ -24,18 +26,7 @@ testthat::test_that("AHR results are consistent with simulation results for sing
 })
 
 testthat::test_that("AHR results are consistent with simulation results for single stratum and single cutoff", {
-  enroll_rate <- tibble::tibble(
-    stratum = "All",
-    duration = c(2, 2, 10),
-    rate = c(3, 6, 9)
-  )
-  fail_rate <- tibble::tibble(
-    stratum = "All",
-    duration = c(3, 100),
-    fail_rate = log(2) / c(9, 18),
-    hr = c(.9, .6),
-    dropout_rate = rep(.001, 2)
-  )
+
   total_duration <- 30
   actual <- ahr(
     enroll_rate = enroll_rate,
@@ -47,16 +38,7 @@ testthat::test_that("AHR results are consistent with simulation results for sing
 })
 
 testthat::test_that("AHR results are consistent with simulation results for single stratum and multiple cutoff", {
-  enroll_rate <- define_enroll_rate(
-    duration = c(2, 2, 10),
-    rate = c(3, 6, 9)
-  )
-  fail_rate <- define_fail_rate(
-    duration = c(3, Inf),
-    fail_rate = log(2) / c(9, 18),
-    dropout_rate = rep(0.001, 2),
-    hr = c(0.9, 0.6)
-  )
+
   total_duration <- c(15, 30)
 
   actual <- ahr(

--- a/tests/testthat/test-independent-AHR.R
+++ b/tests/testthat/test-independent-AHR.R
@@ -47,17 +47,15 @@ testthat::test_that("AHR results are consistent with simulation results for sing
 })
 
 testthat::test_that("AHR results are consistent with simulation results for single stratum and multiple cutoff", {
-  enroll_rate <- tibble::tibble(
-    stratum = "All",
+  enroll_rate <- define_enroll_rate(
     duration = c(2, 2, 10),
     rate = c(3, 6, 9)
   )
-  fail_rate <- tibble::tibble(
-    stratum = "All",
+  fail_rate <- define_fail_rate(
     duration = c(3, Inf),
     fail_rate = log(2) / c(9, 18),
-    hr = c(0.9, 0.6),
-    dropout_rate = rep(0.001, 2)
+    dropout_rate = rep(0.001, 2),
+    hr = c(0.9, 0.6)
   )
   total_duration <- c(15, 30)
 

--- a/tests/testthat/test-independent-check_arg.R
+++ b/tests/testthat/test-independent-check_arg.R
@@ -10,19 +10,37 @@ test_that("check enrollments", {
 
 test_that("check fail_rate", {
   # lack duration
-  expect_warning(expect_error(check_fail_rate(tibble::tibble(fail_rate = c(0.2, 0.4), dropout_rate = 0.01))))
+  expect_warning(expect_error(
+    check_fail_rate(tibble::tibble(fail_rate = c(0.2, 0.4), dropout_rate = 0.01))
+  ))
+
   # lack fail_rate
-  expect_warning(expect_error(check_fail_rate(tibble::tibble(duration = c(2, 4), dropout_rate = 0.01))))
+  expect_warning(expect_error(
+    check_fail_rate(tibble::tibble(duration = c(2, 4), dropout_rate = 0.01))
+  ))
+
   # lack dropout_rate
-  expect_warning(expect_error(check_fail_rate(tibble::tibble(fail_rate = c(0.2, 0.4), duration = c(10, 20)))))
+  expect_warning(expect_error(
+    check_fail_rate(tibble::tibble(fail_rate = c(0.2, 0.4), duration = c(10, 20)))
+  ))
 
   # check of column `duration`
-  expect_warning(expect_error(check_fail_rate(tibble::tibble(fail_rate = c(2, 4), duration = c("a", "b"), dropout_rate = 0.01))))
-  expect_warning(expect_error(check_fail_rate(tibble::tibble(fail_rate = c(2, 4), duration = c(10, -20), dropout_rate = 0.01))))
+  expect_warning(expect_error(
+    check_fail_rate(tibble::tibble(fail_rate = c(2, 4), duration = c("a", "b"), dropout_rate = 0.01))
+  ))
+
+  expect_warning(expect_error(
+    check_fail_rate(tibble::tibble(fail_rate = c(2, 4), duration = c(10, -20), dropout_rate = 0.01))
+  ))
 
   # check of column `fail_rate`
-  expect_warning(expect_error(check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c("a", "b"), dropout_rate = 0.01))))
-  expect_warning(expect_error(check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c(2, -4), dropout_rate = 0.01))))
+  expect_warning(expect_error(
+    check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c("a", "b"), dropout_rate = 0.01))
+  ))
+
+  expect_warning(expect_error(
+    check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c(2, -4), dropout_rate = 0.01))
+  ))
 
   # check of column `hr`
   expect_warning(expect_error(

--- a/tests/testthat/test-independent-check_arg.R
+++ b/tests/testthat/test-independent-check_arg.R
@@ -1,31 +1,31 @@
 test_that("check enrollments", {
-  expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4))))
-  expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20), rate = c("a", "b"))))
-  expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20), rate = c(2, -4))))
+  expect_warning(expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4)))))
+  expect_warning(expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20), rate = c("a", "b")))))
+  expect_warning(expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20), rate = c(2, -4)))))
 
-  expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20))))
-  expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4), duration = c("a", "b"))))
-  expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4), duration = c(10, -20))))
+  expect_warning(expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20)))))
+  expect_warning(expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4), duration = c("a", "b")))))
+  expect_warning(expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4), duration = c(10, -20)))))
 })
 
 test_that("check fail_rate", {
   # lack duration
-  expect_error(check_fail_rate(tibble::tibble(fail_rate = c(0.2, 0.4), dropout_rate = 0.01)))
+  expect_warning(expect_error(check_fail_rate(tibble::tibble(fail_rate = c(0.2, 0.4), dropout_rate = 0.01))))
   # lack fail_rate
-  expect_error(check_fail_rate(tibble::tibble(duration = c(2, 4), dropout_rate = 0.01)))
+  expect_warning(expect_error(check_fail_rate(tibble::tibble(duration = c(2, 4), dropout_rate = 0.01))))
   # lack dropout_rate
-  expect_error(check_fail_rate(tibble::tibble(fail_rate = c(0.2, 0.4), duration = c(10, 20))))
+  expect_warning(expect_error(check_fail_rate(tibble::tibble(fail_rate = c(0.2, 0.4), duration = c(10, 20)))))
 
   # check of column `duration`
-  expect_error(check_fail_rate(tibble::tibble(fail_rate = c(2, 4), duration = c("a", "b"), dropout_rate = 0.01)))
-  expect_error(check_fail_rate(tibble::tibble(fail_rate = c(2, 4), duration = c(10, -20), dropout_rate = 0.01)))
+  expect_warning(expect_error(check_fail_rate(tibble::tibble(fail_rate = c(2, 4), duration = c("a", "b"), dropout_rate = 0.01))))
+  expect_warning(expect_error(check_fail_rate(tibble::tibble(fail_rate = c(2, 4), duration = c(10, -20), dropout_rate = 0.01))))
 
   # check of column `fail_rate`
-  expect_error(check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c("a", "b"), dropout_rate = 0.01)))
-  expect_error(check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c(2, -4), dropout_rate = 0.01)))
+  expect_warning(expect_error(check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c("a", "b"), dropout_rate = 0.01))))
+  expect_warning(expect_error(check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c(2, -4), dropout_rate = 0.01))))
 
   # check of column `hr`
-  expect_error(
+  expect_warning(expect_error(
     check_fail_rate(
       tibble::tibble(
         duration = c(10, 20),
@@ -33,8 +33,9 @@ test_that("check fail_rate", {
         dropout_rate = 0.01, hr = "a"
       )
     )
-  )
-  expect_error(
+  ))
+  
+  expect_warning(expect_error(
     check_fail_rate(
       tibble::tibble(
         duration = c(10, 20),
@@ -43,9 +44,10 @@ test_that("check fail_rate", {
       )
     )
   )
+  )
 
   # check of column `dropoutRate`
-  expect_error(
+  expect_warning(expect_error(
     check_fail_rate(
       tibble::tibble(
         duration = c(10, 20),
@@ -53,8 +55,9 @@ test_that("check fail_rate", {
         dropout_rate = "a", hr = 0.6
       )
     )
-  )
-  expect_error(
+  ))
+  
+  expect_warning(expect_error(
     check_fail_rate(
       tibble::tibble(
         duration = c(10, 20),
@@ -62,7 +65,7 @@ test_that("check fail_rate", {
         dropout_rate = -1, hr = 0.6
       )
     )
-  )
+  ))
 })
 
 test_that("check enrollments and fail_rate together", {

--- a/tests/testthat/test-independent-check_arg.R
+++ b/tests/testthat/test-independent-check_arg.R
@@ -34,7 +34,7 @@ test_that("check fail_rate", {
       )
     )
   ))
-  
+
   expect_warning(expect_error(
     check_fail_rate(
       tibble::tibble(
@@ -43,8 +43,7 @@ test_that("check fail_rate", {
         dropout_rate = 0.01, hr = -1
       )
     )
-  )
-  )
+  ))
 
   # check of column `dropoutRate`
   expect_warning(expect_error(
@@ -56,7 +55,7 @@ test_that("check fail_rate", {
       )
     )
   ))
-  
+
   expect_warning(expect_error(
     check_fail_rate(
       tibble::tibble(

--- a/tests/testthat/test-independent-expected_accrual.R
+++ b/tests/testthat/test-independent-expected_accrual.R
@@ -1,13 +1,9 @@
-test_eAccrual <- function(x = 0:24,
-                          enroll_rate = tibble::tibble(
-                            duration = c(3, 3, 18),
-                            rate = c(5, 10, 20)
-                          )) {
+test_eAccrual <- function(x,
+                          enroll_rate) {
   boundary <- cumsum(enroll_rate$duration)
   rate <- enroll_rate$rate
   xvals <- unique(c(x, boundary))
-  # maxlen=sum(enroll_rate$duration)
-  # xvals1=xvals[xvals<=maxlen]
+
   eAc2 <- numeric(length(xvals))
   for (t in seq_along(xvals)) {
     val <- xvals[t]
@@ -24,7 +20,7 @@ test_eAccrual <- function(x = 0:24,
           rate[3]
     }
   }
-  # eAc3=c(eAc2, rep(max(eAc2),length(x)-length(xvals1)))
+
   ind <- !is.na(match(xvals, x))
   return(eAc2[ind])
 }
@@ -34,14 +30,14 @@ testthat::test_that("expect_accrua doesn't match with the double programming e_A
   testthat::expect_equal(
     expected_accrual(
       time = 0:30,
-      enroll_rate = tibble::tibble(
+      enroll_rate = define_enroll_rate(
         duration = c(3, 13, 18),
         rate = c(5, 20, 8)
       )
     ),
     test_eAccrual(
       x = 0:30,
-      enroll_rate = tibble::tibble(
+      enroll_rate = define_enroll_rate(
         duration = c(3, 13, 18),
         rate = c(5, 20, 8)
       )
@@ -76,59 +72,11 @@ testthat::test_that("expect_accrual fail to identify a non-increasing input", {
 })
 
 
-
-testthat::test_that("expect_accrual fail to identify a non-dataframe input", {
-  enroll_rate <- as.matrix(tibble::tibble(duration = c(3, 3, 18), rate = c(5, 10, 20)))
-  expect_error(expect_message(
-    expected_accruaL(enroll_rate = enroll_rate),
-    "gsDesign2: enroll_rate in `expected_accrual()` must be a data.frame"
-  ))
-})
-
-
-testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
-  enroll_rate <- tibble::tibble(times = c(3, 3, 18), rate = c(5, 10, 20))
-  expect_error(expect_message(
-    expected_accrual(enroll_rate = enroll_rate),
-    "gsDesign2: enroll_rate in `expected_accrual()` column names must contain duration"
-  ))
-})
-
-testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
-  enroll_rate <- tibble::tibble(duration = c(3, 3, 18), freqs = c(5, 10, 20))
-  expect_error(
-    expect_message(
-      expected_accrual(enroll_rate = enroll_rate),
-      "gsDesign2: enroll_rate in `expected_accrual()` column names must contain rate"
-    )
-  )
-})
-
-
-
-testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
-  enroll_rate <- tibble::tibble(duration = c(3, 3, 18), rate = c(-5, 10, 20))
-  expect_error(expect_message(
-    expected_accruaL(enroll_rate = enroll_rate),
-    "gsDesign2: enroll_rate in `expected_accrual()` must be non-negative with at least one positive rate"
-  ))
-})
-
-
-
-testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
-  enroll_rate <- tibble::tibble(duration = c(3, 3, 18), rate = c(-15, -10, -2))
-  expect_error(expect_message(
-    expected_accrual(enroll_rate = enroll_rate),
-    "gsDesign2: enroll_rate in `expected_accrual()` must be non-negative with at least one positive rate"
-  ))
-})
-
 ## add test cases for stratified design
 testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
   x <- expected_accrual(
     time = 40,
-    enroll_rate = tibble(
+    enroll_rate = define_enroll_rate(
       stratum = c("S1", "S2"),
       duration = 33,
       rate = c(30, 30)
@@ -140,7 +88,7 @@ testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
 testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
   x <- expected_accrual(
     time = 33,
-    enroll_rate = tibble(
+    enroll_rate = define_enroll_rate(
       stratum = c("S1", "S2"),
       duration = 33,
       rate = c(30, 30)
@@ -152,7 +100,7 @@ testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
 testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
   x <- expected_accrual(
     time = 30,
-    enroll_rate = tibble(
+    enroll_rate = define_enroll_rate(
       stratum = c("S1", "S2"),
       duration = 33,
       rate = c(30, 30)
@@ -164,7 +112,7 @@ testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
 testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
   x <- expected_accrual(
     time = 10,
-    enroll_rate = tibble(
+    enroll_rate = define_enroll_rate(
       stratum = c("S1", "S2"),
       duration = 33,
       rate = c(30, 30)
@@ -176,7 +124,7 @@ testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
 testthat::test_that("expect_accrual fail to identify a non-dataframe input", {
   x <- expected_accrual(
     time = c(5, 10, 20, 33, 50),
-    enroll_rate = tibble(
+    enroll_rate = define_enroll_rate(
       stratum = c("S1", "S2"),
       duration = 33,
       rate = c(30, 30)

--- a/tests/testthat/test-independent-expected_event.R
+++ b/tests/testthat/test-independent-expected_event.R
@@ -1,19 +1,20 @@
 library(dplyr)
 
 test_that("expected events is different from gsDesign::eEvents and expected_event", {
-  enrollRates <- tibble::tibble(duration = c(2, 1, 2), rate = c(5, 10, 20))
-  failRates <- tibble::tibble(duration = c(1, 1, 1), failRate = c(.05, .02, .01), hr = 1, dropoutRate = .01)
-  totalDuration <- 20
+  enroll_rate <- define_enroll_rate(duration = c(2, 1, 2), rate = c(5, 10, 20))
+  fail_rate <- define_fail_rate(duration = c(1, 1, 1), fail_rate = c(.05, .02, .01), hr = 1, dropout_rate = .01)
+  total_duration <- 20
   testthat::expect_equal(
-    expected_event(enrollRates,
-      failRates %>% rename(fail_rate = failRate, dropout_rate = dropoutRate),
-      totalDuration,
+    expected_event(
+      enroll_rate,
+      fail_rate,
+      total_duration,
       simple = TRUE
     ),
     gsDesign::eEvents(
-      lambda = failRates$failRate, S = failRates$duration[1:(nrow(failRates) - 1)],
-      eta = failRates$dropoutRate, gamma = enrollRates$rate,
-      R = enrollRates$duration, T = totalDuration
+      lambda = fail_rate$fail_rate, S = fail_rate$duration[1:(nrow(fail_rate) - 1)],
+      eta = fail_rate$dropout_rate, gamma = enroll_rate$rate,
+      R = enroll_rate$duration, T = total_duration
     )$d,
     ignore_attr = TRUE
   )
@@ -21,13 +22,14 @@ test_that("expected events is different from gsDesign::eEvents and expected_even
 
 test_that("data frame returned from expected_event not as expected", {
   # test case from gsSurvNPH
-  enrollRates <- tibble::tibble(duration = c(1, 1, 8), rate = c(3, 2, 0))
-  failRates <- tibble::tibble(duration = c(4, Inf), failRate = c(.03, .06), dropoutRate = c(.001, .002), hr = 1)
-  totalDuration <- 7
+  enroll_rate <- define_enroll_rate(duration = c(1, 1, 8), rate = c(3, 2, 0))
+  fail_rate <- define_fail_rate(duration = c(4, Inf), fail_rate = c(.03, .06), dropout_rate = c(.001, .002), hr = 1)
+  total_duration <- 7
+  
   xx <- expected_event(
-    enrollRates,
-    failRates %>% rename(fail_rate = failRate, dropout_rate = dropoutRate),
-    totalDuration,
+    enroll_rate,
+    fail_rate,
+    total_duration,
     simple = FALSE
   ) %>%
     data.frame()
@@ -92,17 +94,22 @@ test_Event <- function(enrollRates, failRates, totalDuration) {
   return(Event)
 }
 
-enrollRates <- tibble::tibble(
+enroll_rate <- define_enroll_rate(
   duration = c(50),
   rate = c(10)
 )
-failRates <- tibble::tibble(
+
+fail_rate <- define_fail_rate(
   duration = c(10, 20, 10),
-  failRate = log(2) / c(5, 10, 5),
-  dropoutRate = c(0.1, 0.2, 0),
+  fail_rate = log(2) / c(5, 10, 5),
+  dropout_rate = c(0.1, 0.2, 0),
   hr = 1
 )
-totalDuration <- 5
+fail_rate$failRate <- fail_rate$fail_rate
+fail_rate$dropoutRate <- fail_rate$dropout_rate
+failRates <- fail_rate
+
+total_duration <- 5
 simple <- TRUE
 
 ### test1:with mutiple failrates, short FU
@@ -110,11 +117,12 @@ testthat::test_that(
   "expected events is different from double-programmed vs expected_event, with mutiple failrates, short FU",
   {
     testthat::expect_equal(
-      test_Event(enrollRates, failRates, totalDuration),
+      test_Event(enroll_rate, fail_rate, total_duration),
       expected_event(
-        enrollRates,
-        failRates %>% rename(fail_rate = failRate, dropout_rate = dropoutRate),
-        totalDuration, simple
+        enroll_rate,
+        fail_rate,
+        total_duration, 
+        simple
       )
     )
   }
@@ -123,13 +131,14 @@ testthat::test_that(
 ### test2:with mutiple failrates, long FU
 testthat::test_that("expected events is different from double-programmed vs expected_event,
                     with mutiple failrates, long FU", {
-  totalDuration <- 80
+  total_duration <- 80
   testthat::expect_equal(
-    test_Event(enrollRates, failRates, totalDuration),
+    test_Event(enroll_rate, fail_rate, total_duration),
     expected_event(
-      enrollRates,
-      failRates %>% rename(fail_rate = failRate, dropout_rate = dropoutRate),
-      totalDuration, simple
+      enroll_rate,
+      fail_rate,
+      total_duration, 
+      simple
     )
   )
 })
@@ -137,23 +146,29 @@ testthat::test_that("expected events is different from double-programmed vs expe
 ### test3:with mutiple failrates and with multiple enrollment duration
 testthat::test_that("expected events is different from double-programmed vs expected_event,
                     with mutiple enrollment duration", {
-  enrollRates <- tibble::tibble(
+  enrollRates <- define_enroll_rate(
     duration = c(50, 10),
     rate = c(10, 5)
   )
-  failRates <- tibble::tibble(
+  failRates <- define_fail_rate(
     duration = c(10, 20, 10),
-    failRate = log(2) / c(5, 10, 5),
-    dropoutRate = c(0.1, 0.2, 0),
+    fail_rate = log(2) / c(5, 10, 5),
+    dropout_rate = c(0.1, 0.2, 0),
     hr = 1
   )
-  totalDuration <- 80
+  
+  fail_rate$failRate <- fail_rate$fail_rate
+  fail_rate$dropoutRate <- fail_rate$dropout_rate
+  failRates <- fail_rate
+  
+  total_duration <- 80
   testthat::expect_equal(
-    test_Event(enrollRates, failRates, totalDuration),
+    test_Event(enroll_rate, fail_rate, total_duration),
     expected_event(
-      enrollRates,
-      failRates %>% rename(fail_rate = failRate, dropout_rate = dropoutRate),
-      totalDuration, simple
+      enroll_rate,
+      fail_rate,
+      total_duration, 
+      simple
     )
   )
 })

--- a/tests/testthat/test-independent-expected_event.R
+++ b/tests/testthat/test-independent-expected_event.R
@@ -25,7 +25,7 @@ test_that("data frame returned from expected_event not as expected", {
   enroll_rate <- define_enroll_rate(duration = c(1, 1, 8), rate = c(3, 2, 0))
   fail_rate <- define_fail_rate(duration = c(4, Inf), fail_rate = c(.03, .06), dropout_rate = c(.001, .002), hr = 1)
   total_duration <- 7
-  
+
   xx <- expected_event(
     enroll_rate,
     fail_rate,
@@ -121,7 +121,7 @@ testthat::test_that(
       expected_event(
         enroll_rate,
         fail_rate,
-        total_duration, 
+        total_duration,
         simple
       )
     )
@@ -137,7 +137,7 @@ testthat::test_that("expected events is different from double-programmed vs expe
     expected_event(
       enroll_rate,
       fail_rate,
-      total_duration, 
+      total_duration,
       simple
     )
   )
@@ -156,18 +156,18 @@ testthat::test_that("expected events is different from double-programmed vs expe
     dropout_rate = c(0.1, 0.2, 0),
     hr = 1
   )
-  
+
   fail_rate$failRate <- fail_rate$fail_rate
   fail_rate$dropoutRate <- fail_rate$dropout_rate
   failRates <- fail_rate
-  
+
   total_duration <- 80
   testthat::expect_equal(
     test_Event(enroll_rate, fail_rate, total_duration),
     expected_event(
       enroll_rate,
       fail_rate,
-      total_duration, 
+      total_duration,
       simple
     )
   )

--- a/tests/testthat/test-independent-expected_time.R
+++ b/tests/testthat/test-independent-expected_time.R
@@ -4,7 +4,7 @@
 #     duration = c(2, 2, 10),
 #     rate = c(3, 6, 9) * 5
 #   )
-# 
+#
 #   failRates <- tibble::tibble(
 #     Stratum = "All",
 #     duration = c(3, 100),
@@ -14,14 +14,14 @@
 #   )
 #   targetEvents <- 150
 #   interval <- c(.01, 100)
-# 
+#
 #   t1 <- expected_time(
 #     enroll_rate = enrollRates %>% dplyr::rename(stratum = Stratum),
 #     fail_rate = failRates %>% dplyr::rename(stratum = Stratum, fail_rate = failRate, dropout_rate = dropoutRate),
 #     target_event = targetEvents,
 #     interval = interval
 #   )
-# 
+#
 #   testthat::expect_equal(
 #     t1$event,
 #     test_tEvents(
@@ -31,7 +31,7 @@
 #     )
 #   )
 # })
-# 
+#
 # testthat::test_that("expected_time does not euqal to AHR's result", {
 #   enrollRates <- tibble::tibble(
 #     Stratum = "All",
@@ -53,7 +53,7 @@
 #     target_event = targetEvents,
 #     interval = interval
 #   )
-# 
+#
 #   testthat::expect_equal(
 #     t1$event,
 #     ahr(

--- a/tests/testthat/test-independent-expected_time.R
+++ b/tests/testthat/test-independent-expected_time.R
@@ -21,7 +21,6 @@ t1 <- expected_time(
 )
 
 testthat::test_that("expected_time equal to test_event result", {
-
   testthat::expect_equal(
     t1$event,
     test_event(
@@ -30,11 +29,9 @@ testthat::test_that("expected_time equal to test_event result", {
       td = t1$time
     )
   )
-}
-)
+})
 
 testthat::test_that("expected_time euqal to AHR's result", {
-
   testthat::expect_equal(
     t1$event,
     ahr(

--- a/tests/testthat/test-independent-expected_time.R
+++ b/tests/testthat/test-independent-expected_time.R
@@ -1,100 +1,45 @@
-# Compare the results of `expected_time()` with `expected_event()` directly
-test_tEvents <- function(
-    enrollRates = tibble::tibble(
-      Stratum = "All",
-      duration = c(2, 2, 10),
-      rate = c(3, 6, 9) * 5
-    ),
-    failRates = tibble::tibble(
-      Stratum = "All",
-      duration = c(3, 100),
-      failRate = log(2) / c(9, 18),
-      hr = c(.9, .6),
-      dropoutRate = rep(.001, 2)
-    ),
-    td = 14.9) {
-  enrollRates_1 <- enrollRates
-  enrollRates_1$rate <- enrollRates$rate / 2
-  failRatesc <- failRates[, c("duration", "failRate", "dropoutRate")]
-  failRatest <- failRatesc
-  failRatest$failRate <- failRates$failRate * failRates$hr
-  eventc <- expected_event(
-    enroll_rate = enrollRates_1 %>% dplyr::rename(stratum = Stratum),
-    fail_rate = failRatesc %>% dplyr::rename(fail_rate = failRate, dropout_rate = dropoutRate),
-    total_duration = td,
-    simple = FALSE
-  )
-  eventt <- expected_event(
-    enroll_rate = enrollRates_1 %>% dplyr::rename(stratum = Stratum),
-    fail_rate = failRatest %>% dplyr::rename(fail_rate = failRate, dropout_rate = dropoutRate),
-    total_duration = td,
-    simple = FALSE
-  )
-  totale <- sum(eventc$event + eventt$event)
-  return(totale)
-}
+enroll_rate <- define_enroll_rate(
+  duration = c(2, 2, 10),
+  rate = c(3, 6, 9) * 5
+)
 
-testthat::test_that("expected_time does not equal to eEvent_df's result", {
-  enrollRates <- tibble::tibble(
-    Stratum = "All",
-    duration = c(2, 2, 10),
-    rate = c(3, 6, 9) * 5
-  )
+fail_rate <- define_fail_rate(
+  duration = c(3, 100),
+  fail_rate = log(2) / c(9, 18),
+  dropout_rate = rep(.001, 2),
+  hr = c(.9, .6)
+)
 
-  failRates <- tibble::tibble(
-    Stratum = "All",
-    duration = c(3, 100),
-    failRate = log(2) / c(9, 18),
-    hr = c(.9, .6),
-    dropoutRate = rep(.001, 2)
-  )
-  targetEvents <- 150
-  interval <- c(.01, 100)
+target_event <- 150
+interval <- c(.01, 100)
 
-  t1 <- expected_time(
-    enroll_rate = enrollRates %>% dplyr::rename(stratum = Stratum),
-    fail_rate = failRates %>% dplyr::rename(stratum = Stratum, fail_rate = failRate, dropout_rate = dropoutRate),
-    target_event = targetEvents,
-    interval = interval
-  )
+t1 <- expected_time(
+  enroll_rate = enroll_rate,
+  fail_rate = fail_rate,
+  target_event = target_event,
+  interval = interval
+)
+
+testthat::test_that("expected_time equal to test_event result", {
 
   testthat::expect_equal(
     t1$event,
-    test_tEvents(
-      enrollRates = enrollRates,
-      failRates = failRates,
+    test_event(
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
       td = t1$time
     )
   )
-})
+}
+)
 
-testthat::test_that("expected_time does not euqal to AHR's result", {
-  enrollRates <- tibble::tibble(
-    Stratum = "All",
-    duration = c(2, 2, 10),
-    rate = c(3, 6, 9) * 5
-  )
-  failRates <- tibble::tibble(
-    Stratum = "All",
-    duration = c(3, 100),
-    failRate = log(2) / c(9, 18),
-    hr = c(.9, .6),
-    dropoutRate = rep(.001, 2)
-  )
-  targetEvents <- 150
-  interval <- c(.01, 100)
-  t1 <- expected_time(
-    enroll_rate = enrollRates %>% dplyr::rename(stratum = Stratum),
-    fail_rate = failRates %>% dplyr::rename(stratum = Stratum, fail_rate = failRate, dropout_rate = dropoutRate),
-    target_event = targetEvents,
-    interval = interval
-  )
+testthat::test_that("expected_time euqal to AHR's result", {
 
   testthat::expect_equal(
     t1$event,
     ahr(
-      enroll_rate = enrollRates %>% dplyr::rename(stratum = Stratum),
-      fail_rate = failRates %>% dplyr::rename(stratum = Stratum, fail_rate = failRate, dropout_rate = dropoutRate),
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
       total_duration = t1$time,
       ratio = 1,
       simple = TRUE

--- a/tests/testthat/test-independent-fixed_design.R
+++ b/tests/testthat/test-independent-fixed_design.R
@@ -1,17 +1,15 @@
 # Enrollment rate
-enroll_rate <- tibble::tibble(
-  stratum = "All",
+enroll_rate <- define_enroll_rate(
   duration = 18,
   rate = 20
 )
 
 # Failure rates
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 12,
-  hr = c(1, .6),
-  dropout_rate = .001
+  dropout_rate = .001,
+  hr = c(1, .6)
 )
 
 # Study duration in months

--- a/tests/testthat/test-independent-gs_design_ahr.R
+++ b/tests/testthat/test-independent-gs_design_ahr.R
@@ -45,17 +45,15 @@ testthat::test_that("compare results with AHR in the situation of single analysi
 testthat::test_that(
   "compare results with gsDesign2::AHR in the situation with IF and multiple analysis times specified",
   {
-    enroll_rate <- tibble::tibble(
-      stratum = "All",
+    enroll_rate <- define_enroll_rate(
       duration = c(2, 2, 10),
       rate = c(3, 6, 9)
     )
-    fail_rate <- tibble::tibble(
-      stratum = "All",
+    fail_rate <- define_fail_rate(
       duration = c(3, 100),
       fail_rate = log(2) / c(9, 18),
-      hr = c(0.9, 0.6),
-      dropout_rate = rep(0.001, 2)
+      dropout_rate = rep(0.001, 2),
+      hr = c(0.9, 0.6)
     )
     total_duration <- c(12, 25, 36)
     analysis_time <- total_duration

--- a/tests/testthat/test-independent-gs_design_ahr.R
+++ b/tests/testthat/test-independent-gs_design_ahr.R
@@ -1,13 +1,11 @@
 # Test 1: compare results with AHR ####
 
 testthat::test_that("compare results with AHR in the situation of single analysis", {
-  enroll_rate <- tibble::tibble(
-    stratum = "All",
+  enroll_rate <- define_enroll_rate(
     duration = c(2, 2, 10),
     rate = c(3, 6, 9)
   )
-  fail_rate <- tibble::tibble(
-    stratum = "All",
+  fail_rate <- define_fail_rate(
     duration = c(3, 100),
     fail_rate = log(2) / c(9, 18),
     hr = c(0.9, 0.6),

--- a/tests/testthat/test-independent-gs_design_combo.R
+++ b/tests/testthat/test-independent-gs_design_combo.R
@@ -1,6 +1,6 @@
 # load("fixtures/sim_gsd_pMaxCombo_exp1_H0_test.Rdata")
 # load("fixtures/sim_gsd_pMaxCombo_exp1_H1_test.Rdata")
-# 
+#
 # ratio <- 1
 # algorithm <- GenzBretz(
 #   maxpts = 1e5,
@@ -13,7 +13,7 @@
 #   duration = 12,
 #   rate = 500 / 12
 # )
-# 
+#
 # failRates <- tibble::tibble(
 #   stratum = "All",
 #   duration = c(4, 100),
@@ -21,7 +21,7 @@
 #   hr = c(1, .6),
 #   dropoutRate = 0.001
 # )
-# 
+#
 # fh_test <- rbind(
 #   data.frame(
 #     rho = 0,
@@ -40,7 +40,7 @@
 #     analysis_time = 36
 #   )
 # )
-# 
+#
 # x <- gsDesign::gsSurv(
 #   k = 3,
 #   test.type = 4,
@@ -63,8 +63,8 @@
 #   minfup = 24,
 #   ratio = 1
 # )
-# 
-# 
+#
+#
 # # User defined boundary
 # gs_design_combo_test1 <- gs_design_combo(enrollRates,
 #   failRates %>% dplyr::rename(fail_rate = failRate, dropout_rate = dropoutRate),
@@ -76,7 +76,7 @@
 #   upar = x$upper$bound,
 #   lpar = x$lower$bound
 # )
-# 
+#
 # #### Boundary derived by spending function testing
 # gs_design_combo_test2 <- gs_design_combo(enrollRates,
 #   failRates %>% dplyr::rename(fail_rate = failRate, dropout_rate = dropoutRate),
@@ -90,7 +90,7 @@
 #   lower = gs_spending_combo,
 #   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2), # beta spending
 # )
-# 
+#
 # test_tEvents <- function(enrollRates = tibble::tibble(
 #                            stratum = "All",
 #                            duration = c(2, 2, 10),
@@ -124,14 +124,14 @@
 #   totale <- sum(eventc$event + eventt$event)
 #   return(totale)
 # }
-# 
+#
 # testthat::test_that("calculate analysis number as planed", {
 #   expect_equal(max(fh_test$analysis), max(gs_design_combo_test2$analysis$analysis))
 # })
 # testthat::test_that("calculate analysisTimes as planed", {
 #   expect_equal(unique(fh_test$analysis_time), unique(gs_design_combo_test2$analysis$time))
 # })
-# 
+#
 # for (i in 1:max(fh_test$analysis)) {
 #   testthat::test_that("calculate N and each analysis Events N as planed", {
 #     event <- test_tEvents(
@@ -144,7 +144,7 @@
 #     expect_equal(event * N / enrollsum, unique(gs_design_combo_test2$analysis$event)[i], tolerance = 0.01)
 #   })
 # }
-# 
+#
 # testthat::test_that("calculate probability under alternative", {
 #   expect_equal(
 #     1 - beta,
@@ -152,7 +152,7 @@
 #     tolerance = 0.0001
 #   )
 # })
-# 
+#
 # testthat::test_that("calculate probability under null", {
 #   expect_equal(
 #     alpha,

--- a/tests/testthat/test-independent-gs_info_ahr.R
+++ b/tests/testthat/test-independent-gs_info_ahr.R
@@ -1,13 +1,11 @@
 # Test 1: independent test using AHR to check outputs of gs_info_ahr ####
 
 testthat::test_that("results match if only put in targeted analysis times", {
-  enroll_rate <- tibble::tibble(
-    stratum = "All",
+  enroll_rate <- define_enroll_rate(
     duration = c(2, 2, 10),
     rate = c(3, 6, 9)
   )
-  fail_rate <- tibble::tibble(
-    stratum = "All",
+  fail_rate <- define_fail_rate(
     duration = c(3, 100),
     fail_rate = log(2) / c(9, 18),
     hr = c(0.9, 0.6),

--- a/tests/testthat/test-independent-gs_info_ahr.R
+++ b/tests/testthat/test-independent-gs_info_ahr.R
@@ -12,7 +12,6 @@ fail_rate <- define_fail_rate(
 # Test 1: independent test using AHR to check outputs of gs_info_ahr ####
 
 testthat::test_that("results match if only put in targeted analysis times", {
-
   total_duration <- c(18, 27, 36)
 
   testthat::expect_equal(
@@ -31,7 +30,6 @@ testthat::test_that("results match if only put in targeted analysis times", {
 
 
 testthat::test_that("results match if only put in targeted events", {
-
   event <- c(30, 40, 50)
 
   out1 <- gs_info_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, event = event)
@@ -55,7 +53,6 @@ testthat::test_that("results match if only put in targeted events", {
 
 
 testthat::test_that("results match if put in both analysis time and targeted events", {
- 
   event <- c(30, 40, 50)
   analysis_time <- c(16, 19, 26)
 

--- a/tests/testthat/test-independent-gs_info_ahr.R
+++ b/tests/testthat/test-independent-gs_info_ahr.R
@@ -1,16 +1,18 @@
+enroll_rate <- define_enroll_rate(
+  duration = c(2, 2, 10),
+  rate = c(3, 6, 9)
+)
+fail_rate <- define_fail_rate(
+  duration = c(3, 100),
+  fail_rate = log(2) / c(9, 18),
+  hr = c(0.9, 0.6),
+  dropout_rate = 0.001
+)
+
 # Test 1: independent test using AHR to check outputs of gs_info_ahr ####
 
 testthat::test_that("results match if only put in targeted analysis times", {
-  enroll_rate <- define_enroll_rate(
-    duration = c(2, 2, 10),
-    rate = c(3, 6, 9)
-  )
-  fail_rate <- define_fail_rate(
-    duration = c(3, 100),
-    fail_rate = log(2) / c(9, 18),
-    hr = c(0.9, 0.6),
-    dropout_rate = rep(0.001, 2)
-  )
+
   total_duration <- c(18, 27, 36)
 
   testthat::expect_equal(
@@ -29,18 +31,7 @@ testthat::test_that("results match if only put in targeted analysis times", {
 
 
 testthat::test_that("results match if only put in targeted events", {
-  enroll_rate <- tibble::tibble(
-    stratum = "All",
-    duration = c(2, 2, 10),
-    rate = c(3, 6, 9)
-  )
-  fail_rate <- tibble::tibble(
-    stratum = "All",
-    duration = c(3, 100),
-    fail_rate = log(2) / c(9, 18),
-    hr = c(0.9, 0.6),
-    dropout_rate = rep(0.001, 2)
-  )
+
   event <- c(30, 40, 50)
 
   out1 <- gs_info_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, event = event)
@@ -64,18 +55,7 @@ testthat::test_that("results match if only put in targeted events", {
 
 
 testthat::test_that("results match if put in both analysis time and targeted events", {
-  enroll_rate <- tibble::tibble(
-    stratum = "All",
-    duration = c(2, 2, 10),
-    rate = c(3, 6, 9)
-  )
-  fail_rate <- tibble::tibble(
-    stratum = "All",
-    duration = c(3, 100),
-    fail_rate = log(2) / c(9, 18),
-    hr = c(0.9, 0.6),
-    dropout_rate = rep(0.001, 2)
-  )
+ 
   event <- c(30, 40, 50)
   analysis_time <- c(16, 19, 26)
 

--- a/tests/testthat/test-independent-gs_info_combo.R
+++ b/tests/testthat/test-independent-gs_info_combo.R
@@ -1,17 +1,15 @@
 rho <- c(1, 1, 0, 0)
 gamma <- c(0, 1, 0, 1)
 tau <- c(-1, -1, -1, -1)
-enroll_rate <- tibble::tibble(
-  stratum = "All",
+enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 30),
   rate = c(3, 6, 9)
 )
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
-  hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = rep(.001, 2),
+  hr = c(.9, .6)
 )
 info_combo <- gsDesign2::gs_info_combo(
   enroll_rate = enroll_rate,

--- a/tests/testthat/test-independent-gs_power_ahr.R
+++ b/tests/testthat/test-independent-gs_power_ahr.R
@@ -48,13 +48,11 @@ y <- gsBoundSummary(x,
 
 testthat::test_that("under same number of events, compare the power", {
   out <- gs_power_ahr(
-    enroll_rate = tibble::tibble(
-      stratum = "All",
+    enroll_rate = define_enroll_rate(
       duration = c(2, 2, 2, 6),
       rate = c(6, 12, 18, 24)
     ),
-    fail_rate = tibble::tibble(
-      stratum = "All",
+    fail_rate = define_fail_rate(
       duration = 1,
       fail_rate = log(2) / 9,
       hr = 0.65,
@@ -78,17 +76,15 @@ testthat::test_that("under same number of events, compare the power", {
 
 testthat::test_that("under same power setting, compare the number of events", {
   out <- gs_power_ahr(
-    enroll_rate = tibble::tibble(
-      stratum = "All",
+    enroll_rate = define_enroll_rate(
       duration = c(2, 2, 2, 6),
       rate = c(6, 12, 18, 24)
     ),
-    fail_rate = tibble::tibble(
-      stratum = "All",
+    fail_rate = define_fail_rate(
       duration = 1,
       fail_rate = log(2) / 9,
-      hr = 0.65,
-      dropout_rate = 0.001
+      dropout_rate = 0.001,
+      hr = 0.65
     ),
     ratio = 1,
     event = NULL,

--- a/tests/testthat/test-independent-gs_power_combo.R
+++ b/tests/testthat/test-independent-gs_power_combo.R
@@ -1,34 +1,3 @@
-test_tEvents <- function(enroll_rate,
-                         fail_rate,
-                         td = 15) {
-  
-  enroll_rate_1 <- enroll_rate
-  enroll_rate_1$rate <- enroll_rate$rate / 2
-  
-  fail_rate_c <- fail_rate 
-  fail_rate_t <- fail_rate  
-  fail_rate_t$fail_rate <- fail_rate_t$fail_rate * fail_rate_t$hr
-  
-  event_c <- gsDesign2::expected_event(
-    enroll_rate = enroll_rate_1,
-    fail_rate = fail_rate_c,
-    total_duration = td,
-    simple = FALSE
-  )
-
-  event_t <- gsDesign2::expected_event(
-    enroll_rate = enroll_rate_1,
-    fail_rate = fail_rate_t,
-    total_duration = td,
-    simple = FALSE
-  )
-
-  total_e <- sum(event_c$event + event_t$event)
-  
-  total_e
-}
-
-
 enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
 
 fail_rate <- define_fail_rate(
@@ -77,7 +46,7 @@ test_that("calculate analysisTimes as planed", {
 
 for (i in 1:max(fh_test$analysis)) {
   test_that("calculate N and each analysis Events N as planed", {
-    event <- test_tEvents(
+    event <- test_event(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
       td = unique(fh_test$analysis_time)[i]
@@ -108,7 +77,7 @@ test_that("calculate analysisTimes as planed", {
 
 for (i in 1:max(fh_test$analysis)) {
   test_that("calculate N and each analysis Events N as planed", {
-    event <- test_tEvents(
+    event <- test_event(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
       td = unique(fh_test$analysis_time)[i]

--- a/tests/testthat/test-independent-gs_power_combo.R
+++ b/tests/testthat/test-independent-gs_power_combo.R
@@ -1,49 +1,41 @@
-test_tEvents <- function(
-    enrollRates = tibble::tibble(
-      Stratum = "All",
-      duration = c(2, 2, 10),
-      rate = c(3, 6, 9) * 5
-    ),
-    failRates = tibble::tibble(
-      Stratum = "All",
-      duration = c(3, 100),
-      failRate = log(2) / c(9, 18),
-      hr = c(.9, .6),
-      dropoutRate = rep(.001, 2)
-    ),
-    td = 15) {
-  enrollRates_1 <- enrollRates
-  enrollRates_1$rate <- enrollRates$rate / 2
-  failRatesc <- failRates[, c("duration", "failRate", "dropoutRate")]
-  failRatest <- failRatesc
-  failRatest$failRate <- failRates$failRate * failRates$hr
-
-  eventc <- gsDesign2::expected_event(
-    enroll_rate = enrollRates_1,
-    fail_rate = failRatesc %>% dplyr::rename(fail_rate = failRate, dropout_rate = dropoutRate),
+test_tEvents <- function(enroll_rate,
+                         fail_rate,
+                         td = 15) {
+  
+  enroll_rate_1 <- enroll_rate
+  enroll_rate_1$rate <- enroll_rate$rate / 2
+  
+  fail_rate_c <- fail_rate 
+  fail_rate_t <- fail_rate  
+  fail_rate_t$fail_rate <- fail_rate_t$fail_rate * fail_rate_t$hr
+  
+  event_c <- gsDesign2::expected_event(
+    enroll_rate = enroll_rate_1,
+    fail_rate = fail_rate_c,
     total_duration = td,
     simple = FALSE
   )
 
-  eventt <- gsDesign2::expected_event(
-    enroll_rate = enrollRates_1,
-    fail_rate = failRatest %>% dplyr::rename(fail_rate = failRate, dropout_rate = dropoutRate),
+  event_t <- gsDesign2::expected_event(
+    enroll_rate = enroll_rate_1,
+    fail_rate = fail_rate_t,
     total_duration = td,
     simple = FALSE
   )
 
-  totale <- sum(eventc$event + eventt$event)
-  return(totale)
+  total_e <- sum(event_c$event + event_t$event)
+  
+  total_e
 }
 
-enrollRates <- tibble::tibble(Stratum = "All", duration = 12, rate = 500 / 12)
 
-failRates <- tibble::tibble(
-  Stratum = "All",
+enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
+
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
-  failRate = log(2) / 15, # Median survival 15 month
-  hr = c(1, .6),
-  dropoutRate = 0.001
+  fail_rate = log(2) / 15, # median survival 15 month
+  dropout_rate = 0.001,
+  hr = c(1, .6)
 )
 
 fh_test <- rbind(
@@ -65,66 +57,60 @@ fh_test <- rbind(
   )
 )
 
-# User-defined bound
+# User defined bound
 gs_power_combo_test1 <- gsDesign2::gs_power_combo(
-  enroll_rate = enrollRates %>% dplyr::rename(stratum = Stratum),
-  fail_rate = failRates %>% dplyr::rename(
-    stratum = Stratum,
-    fail_rate = failRate,
-    dropout_rate = dropoutRate
-  ),
+  enroll_rate = enroll_rate,
+  fail_rate = fail_rate,
   fh_test = fh_test,
   upper = gs_b, upar = c(3, 2, 1),
   lower = gs_b, lpar = c(-1, 0, 1)
 )
 
-test_that("calculate analysis number as planned", {
+test_that("calculate analysis number as planed", {
   expect_equal(max(fh_test$analysis), max(gs_power_combo_test1$analysis$analysis))
 })
 
-test_that("calculate analysisTimes as planned", {
+test_that("calculate analysisTimes as planed", {
   expect_equal(unique(fh_test$analysis_time), unique(gs_power_combo_test1$analysis$time))
 })
 
+
 for (i in 1:max(fh_test$analysis)) {
-  test_that("calculate N and each analysis Events N as planned", {
+  test_that("calculate N and each analysis Events N as planed", {
     event <- test_tEvents(
-      enrollRates = enrollRates,
-      failRates = failRates,
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
       td = unique(fh_test$analysis_time)[i]
     )
     expect_equal(event, unique(gs_power_combo_test1$analysis$event)[i], tolerance = 0.01)
   })
 }
 
+
 # Minimal Information Fraction derived bound
 gs_power_combo_test2 <- gsDesign2::gs_power_combo(
-  enroll_rate = enrollRates %>% dplyr::rename(stratum = Stratum),
-  fail_rate = failRates %>% dplyr::rename(
-    stratum = Stratum,
-    fail_rate = failRate,
-    dropout_rate = dropoutRate
-  ),
-  fh_test = fh_test,
-  upper = gsDesign2::gs_spending_combo,
+  enroll_rate = enroll_rate,
+  fail_rate = fail_rate,
+  fh_test,
+  upper = gs_spending_combo,
   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
-  lower = gsDesign2::gs_spending_combo,
+  lower = gs_spending_combo,
   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2)
 )
 
-test_that("calculate analysis number as planned", {
+test_that("calculate analysis number as planed", {
   expect_equal(max(fh_test$analysis), max(gs_power_combo_test2$analysis$analysis))
 })
 
-test_that("calculate analysisTimes as planned", {
+test_that("calculate analysisTimes as planed", {
   expect_equal(unique(fh_test$analysis_time), unique(gs_power_combo_test2$analysis$time))
 })
 
 for (i in 1:max(fh_test$analysis)) {
-  test_that("calculate N and each analysis Events N as planned", {
+  test_that("calculate N and each analysis Events N as planed", {
     event <- test_tEvents(
-      enrollRates = enrollRates,
-      failRates = failRates,
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
       td = unique(fh_test$analysis_time)[i]
     )
     expect_equal(event, unique(gs_power_combo_test2$analysis$event)[i], tolerance = 0.01)

--- a/tests/testthat/test-independent-gs_power_combo.R
+++ b/tests/testthat/test-independent-gs_power_combo.R
@@ -16,28 +16,28 @@
 #   failRatesc <- failRates[, c("duration", "failRate", "dropoutRate")]
 #   failRatest <- failRatesc
 #   failRatest$failRate <- failRates$failRate * failRates$hr
-# 
+#
 #   eventc <- gsDesign2::expected_event(
 #     enroll_rate = enrollRates_1,
 #     fail_rate = failRatesc %>% dplyr::rename(fail_rate = failRate, dropout_rate = dropoutRate),
 #     total_duration = td,
 #     simple = FALSE
 #   )
-# 
+#
 #   eventt <- gsDesign2::expected_event(
 #     enroll_rate = enrollRates_1,
 #     fail_rate = failRatest %>% dplyr::rename(fail_rate = failRate, dropout_rate = dropoutRate),
 #     total_duration = td,
 #     simple = FALSE
 #   )
-# 
+#
 #   totale <- sum(eventc$event + eventt$event)
 #   return(totale)
 # }
-# 
-# 
+#
+#
 # enrollRates <- tibble::tibble(Stratum = "All", duration = 12, rate = 500 / 12)
-# 
+#
 # failRates <- tibble::tibble(
 #   Stratum = "All",
 #   duration = c(4, 100),
@@ -45,7 +45,7 @@
 #   hr = c(1, .6),
 #   dropoutRate = 0.001
 # )
-# 
+#
 # fh_test <- rbind(
 #   data.frame(
 #     rho = 0,
@@ -64,7 +64,7 @@
 #     analysis_time = 36
 #   )
 # )
-# 
+#
 # # User defined bound
 # gs_power_combo_test1 <- gsDesign2::gs_power_combo(
 #   enrollRates = enrollRates %>% dplyr::rename(stratum = Stratum),
@@ -73,16 +73,16 @@
 #   upper = gs_b, upar = c(3, 2, 1),
 #   lower = gs_b, lpar = c(-1, 0, 1)
 # )
-# 
+#
 # test_that("calculate analysis number as planed", {
 #   expect_equal(max(fh_test$analysis), max(gs_power_combo_test1$analysis$analysis))
 # })
-# 
+#
 # test_that("calculate analysisTimes as planed", {
 #   expect_equal(unique(fh_test$analysis_time), unique(gs_power_combo_test1$analysis$time))
 # })
-# 
-# 
+#
+#
 # for (i in 1:max(fh_test$analysis)) {
 #   test_that("calculate N and each analysis Events N as planed", {
 #     event <- test_tEvents(
@@ -93,8 +93,8 @@
 #     expect_equal(event, unique(gs_power_combo_test1$analysis$event)[i], tolerance = 0.01)
 #   })
 # }
-# 
-# 
+#
+#
 # # Minimal Information Fraction derived bound
 # gs_power_combo_test2 <- gsDesign2::gs_power_combo(enrollRates %>% dplyr::rename(stratum = Stratum),
 #   failRates %>% dplyr::rename(stratum = Stratum, fail_rate = failRate, dropout_rate = dropoutRate),
@@ -104,15 +104,15 @@
 #   lower = gs_spending_combo,
 #   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2)
 # )
-# 
+#
 # test_that("calculate analysis number as planed", {
 #   expect_equal(max(fh_test$analysis), max(gs_power_combo_test2$analysis$analysis))
 # })
-# 
+#
 # test_that("calculate analysisTimes as planed", {
 #   expect_equal(unique(fh_test$analysis_time), unique(gs_power_combo_test2$analysis$time))
 # })
-# 
+#
 # for (i in 1:max(fh_test$analysis)) {
 #   test_that("calculate N and each analysis Events N as planed", {
 #     event <- test_tEvents(

--- a/tests/testthat/test-independent-rmst.R
+++ b/tests/testthat/test-independent-rmst.R
@@ -1,14 +1,13 @@
 test_that("given sample size, the output power arrives at the target", {
   # set enrollment rates
-  enroll_rate <- tibble::tibble(stratum = "All", duration = 12, rate = 500 / 12)
+  enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
 
   # set failure rates
-  fail_rate <- tibble::tibble(
-    stratum = "All",
+  fail_rate <- define_fail_rate(
     duration = c(4, 100),
     fail_rate = log(2) / 15, # median survival 15 month
-    hr = c(1, .6),
-    dropout_rate = 0.001
+    dropout_rate = 0.001,
+    hr = c(1, .6)
   )
 
   # output from gsDesign2

--- a/tests/testthat/test-independent-utility_combo.R
+++ b/tests/testthat/test-independent-utility_combo.R
@@ -45,17 +45,15 @@ rho <- c(1, 1, 0, 0)
 gamma <- c(0, 1, 0, 1)
 tau <- c(-1, -1, -1, -1)
 
-enroll_rate <- tibble::tibble(
-  stratum = "All",
+enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 30),
   rate = c(3, 6, 9)
 )
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
-  hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = rep(.001, 2),
+  hr = c(.9, .6)
 )
 arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1, total_time = 1e6)
 delta <- gsDesign2:::gs_delta_combo(
@@ -103,17 +101,15 @@ for (i in 1:4) {
 rho <- c(1, 1, 0, 0)
 gamma <- c(0, 1, 0, 1)
 tau <- c(-1, -1, -1, -1)
-enroll_rate <- tibble::tibble(
-  stratum = "All",
+enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 30),
   rate = c(3, 6, 9)
 )
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
-  hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = rep(.001, 2),
+  hr = c(.9, .6)
 )
 info_combo <- gsDesign2:::gs_info_combo(
   enroll_rate = enroll_rate,
@@ -149,17 +145,15 @@ upper <- 0.4
 rho <- c(1, 1, 0, 0)
 gamma <- c(0, 1, 0, 1)
 tau <- c(-1, -1, -1, -1)
-enroll_rate <- tibble::tibble(
-  stratum = "All",
+enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 30),
   rate = c(3, 6, 9)
 )
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
-  hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = rep(.001, 2),
+  hr = c(.9, .6)
 )
 arm <- gs_create_arm(
   enroll_rate = enroll_rate,
@@ -216,17 +210,15 @@ upper <- c(0.3, 0.4)
 rho <- c(1, 1, 0, 0)
 gamma <- c(0, 1, 0, 1)
 tau <- c(-1, -1, -1, -1)
-enroll_rate <- tibble::tibble(
-  stratum = "All",
+enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 30),
   rate = c(3, 6, 9)
 )
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
-  hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = rep(.001, 2),
+  hr = c(.9, .6)
 )
 arm <- gs_create_arm(
   enroll_rate = enroll_rate,
@@ -307,17 +299,16 @@ rho <- c(1, 1, 0, 0)
 gamma <- c(0, 1, 0, 1)
 tau <- c(-1, -1, -1, -1)
 
-enroll_rate <- tibble::tibble(
+enroll_rate <- define_enroll_rate(
   stratum = "All",
   duration = c(2, 2, 10),
   rate = c(3, 6, 9)
 )
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
-  hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = rep(.001, 2),
+  hr = c(.9, .6)
 )
 arm <- gs_create_arm(
   enroll_rate = enroll_rate,
@@ -360,17 +351,15 @@ test_that("pmvnorm_comb calculate p for One test for all group or lower bound is
 
 # test gs_utility_combo
 ##### log-rank multiple analysis#####
-enroll_rate <- tibble::tibble(
-  stratum = "All",
+enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 30),
   rate = c(3, 6, 9)
 )
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
-  hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = rep(.001, 2),
+  hr = c(.9, .6)
 )
 analysis_time <- c(12, 24, 36)
 n_analysis <- length(analysis_time)
@@ -428,17 +417,15 @@ test_that("gs_utility_combo output correct correlation matrix as gs_info_combo",
 
 
 ##### multiple test analysis#####
-enroll_rate <- tibble::tibble(
-  stratum = "All",
+enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 30),
   rate = c(3, 6, 9)
 )
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
-  hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = rep(.001, 2),
+  hr = c(.9, .6)
 )
 analysis_time <- 36
 n_analysis <- length(analysis_time)

--- a/tests/testthat/test-independent-wlr_weight.R
+++ b/tests/testthat/test-independent-wlr_weight.R
@@ -3,17 +3,15 @@ test_that("test wlr_weight_1", {
 })
 
 test_that("test wlr_weight_n", {
-  enroll_rate <- tibble::tibble(
-    stratum = "All",
+  enroll_rate <- define_enroll_rate(
     duration = c(2, 2, 30),
     rate = c(3, 6, 9)
   )
-  fail_rate <- tibble::tibble(
-    stratum = "All",
+  fail_rate <- define_fail_rate(
     duration = c(3, 100),
     fail_rate = log(2) / c(9, 18),
-    hr = c(.9, .6),
-    dropout_rate = rep(.001, 2)
+    dropout_rate = rep(.001, 2),
+    hr = c(.9, .6)
   )
   total_time <- 36
   analysis_time <- 12

--- a/tests/testthat/test-independent_test_gs_design_wlr.R
+++ b/tests/testthat/test-independent_test_gs_design_wlr.R
@@ -14,17 +14,15 @@ test_that("Validate the function based on examples with simulation results", {
     R = c(12), S = NULL,
     T = 36, minfup = 24, ratio = 1
   )
-  enroll_rate <- tibble::tibble(
-    stratum = "All",
+  enroll_rate <- define_enroll_rate(
     duration = 12,
     rate = 500 / 12
   )
-  fail_rate <- tibble::tibble(
-    stratum = "All",
+  fail_rate <- define_fail_rate(
     duration = c(4, 100),
     fail_rate = log(2) / 15, # Median survival 15 month
-    hr = c(1, 0.6),
-    dropout_rate = 0.001
+    dropout_rate = 0.001,
+    hr = c(1, 0.6)
   )
   ## Randomization Ratio is 1:1
   ratio <- 1

--- a/tests/testthat/test-independent_test_gs_info_wlr.R
+++ b/tests/testthat/test-independent_test_gs_info_wlr.R
@@ -1,14 +1,13 @@
 # weighted log rank test with 3 options of weights
 test_that("Validate the function based on examples with individual functions", {
   # Enrollments
-  enroll_rate <- tibble::tibble(stratum = "All", duration = 12, rate = 500 / 12)
+  enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
   # fail_rate
-  fail_rate <- tibble::tibble(
-    stratum = "All",
+  fail_rate <- define_fail_rate(
     duration = c(4, 100),
     fail_rate = log(2) / 15, # Median survival 15 months
-    hr = c(1, .6), # Delay effect after 4 months
-    dropout_rate = 0.001
+    dropout_rate = 0.001,
+    hr = c(1, .6) # Delay effect after 4 months
   )
   ## Randomization Ratio is 1:1
   ratio <- 1

--- a/tests/testthat/test-independent_test_gs_power_wlr.R
+++ b/tests/testthat/test-independent_test_gs_power_wlr.R
@@ -1,15 +1,13 @@
 test_that("Check using gs_info_wlr and gs_power_npe", {
-  enroll_rate <- tibble::tibble(
-    stratum = "All",
+  enroll_rate <- define_enroll_rate(
     duration = 12,
     rate = 500 / 12
   )
-  fail_rate <- tibble::tibble(
-    stratum = "All",
+  fail_rate <- define_fail_rate(
     duration = c(4, 100),
     fail_rate = log(2) / 15, # Median survival 15 months
-    hr = c(1, .6), # Delay effect after 4 months
-    dropout_rate = 0.001
+    dropout_rate = 0.001,
+    hr = c(1, .6) # Delay effect after 4 months
   )
   ## Randomization Ratio is 1:1
   ratio <- 1

--- a/tests/testthat/test-independent_test_wlr_weight.R
+++ b/tests/testthat/test-independent_test_wlr_weight.R
@@ -1,13 +1,12 @@
 # weighted log rank test with 3 options of weights
 
 test_that("Validate the function based on simple calculation", {
-  enroll_rate <- tibble::tibble(stratum = "All", duration = 12, rate = 500 / 12)
-  fail_rate <- tibble::tibble(
-    stratum = "All",
+  enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
+  fail_rate <- define_fail_rate(
     duration = c(4, 100),
     fail_rate = log(2) / 15, # Median survival 15 months
-    hr = c(1, .6), # Delay effect after 4 months
-    dropout_rate = 0.001
+    dropout_rate = 0.001,
+    hr = c(1, .6) # Delay effect after 4 months
   )
   # Define study design object in each arm
   gs_arm <- gs_create_arm(

--- a/vignettes/articles/story-ahr-under-nph.Rmd
+++ b/vignettes/articles/story-ahr-under-nph.Rmd
@@ -118,12 +118,11 @@ enroll_rate <- define_enroll_rate(
   rate = c(3, 6, 9)
 )
 
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
-  hr = c(1, .55),
-  dropout_rate = .001
+  dropout_rate = .001,
+  hr = c(1, .55)
 )
 
 total_duration <- 30
@@ -306,12 +305,12 @@ enroll_rate <- define_enroll_rate(
   rate = c((1:4) / 3, (1:4) / 2, (1:4) / 6)
 )
 
-fail_rate <- tibble::tibble(
+fail_rate <- define_fail_rate(
   stratum = c("High", "Moderate", "Low"),
   duration = 100,
   fail_rate = log(2) / c(6, 9, 100),
-  hr = c(1.2, 1 / 3, 1),
-  dropout_rate = .001
+  dropout_rate = .001,
+  hr = c(1.2, 1 / 3, 1)
 )
 
 total_duration <- 36

--- a/vignettes/articles/story-compare-power-delay-effect.Rmd
+++ b/vignettes/articles/story-compare-power-delay-effect.Rmd
@@ -40,8 +40,7 @@ We consider a delayed effect scenario where
 
 ```{r}
 enroll_rate <- define_enroll_rate(duration = 12, rate = 1)
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(6, 100),
   fail_rate = log(2) / 15,
   hr = c(1, .6),
@@ -196,7 +195,6 @@ Now we consider an alternate scenario where the placebo group starts with the sa
 ```{r}
 enroll_rate <- define_enroll_rate(duration = 12, rate = 1)
 fail_rate <- tibble(
-  stratum = "All",
   duration = c(6, 10, 100),
   # In Scenario 1: fail_rate = log(2) / 15,
   fail_rate = log(2) / c(15, 15, 30),

--- a/vignettes/articles/story-compare-power-delay-effect.Rmd
+++ b/vignettes/articles/story-compare-power-delay-effect.Rmd
@@ -23,7 +23,6 @@ knitr::opts_chunk$set(echo = TRUE)
 library(gt)
 library(dplyr)
 library(tidyr)
-library(tibble)
 library(ggplot2)
 library(gsDesign)
 library(gsDesign2)
@@ -195,13 +194,13 @@ Now we consider an alternate scenario where the placebo group starts with the sa
 
 ```{r}
 enroll_rate <- define_enroll_rate(duration = 12, rate = 1)
-fail_rate <- tibble(
+fail_rate <- define_fail_rate(
   duration = c(6, 10, 100),
   # In Scenario 1: fail_rate = log(2) / 15,
   fail_rate = log(2) / c(15, 15, 30),
+  dropout_rate = 0.001,
   # In Scenario 1: hr = c(1, .6)
-  hr = c(1, .6, .85),
-  dropout_rate = 0.001
+  hr = c(1, .6, .85)
 )
 enroll_rate %>%
   gt() %>%

--- a/vignettes/articles/story-compute-expected-events.Rmd
+++ b/vignettes/articles/story-compute-expected-events.Rmd
@@ -279,7 +279,7 @@ Next, we examine by the periods defined by `fail_rate`:
 ```{r}
 expected_event(
   enroll_rate = define_enroll_rate(duration = c(1, 1), rate = c(3, 2)),
-  fail_rate = tibble(duration = c(4, 3), fail_rate = c(.03, .06), dropout_rate = c(.001, .002)),
+  fail_rate = define_fail_rate(duration = c(4, 3), fail_rate = c(.03, .06), dropout_rate = c(.001, .002)),
   total_duration = 7,
   simple = FALSE
 )

--- a/vignettes/articles/story-design-with-ahr.Rmd
+++ b/vignettes/articles/story-design-with-ahr.Rmd
@@ -64,8 +64,7 @@ We will later assume a similar ramp-up period with 24 months expected enrollment
 
 ```{r}
 # Set the enrollment table of totally 24 month
-enroll24 <- tibble(
-  stratum = rep("All", 4), # un-stratified
+enroll24 <- define_enroll_rate(
   duration = c(rep(2, 3), 18), # 6 month ramp-up of enrollment, 24 months enrollment time target
   rate = 1:4 # ratio of the enrollment rate
 )
@@ -73,8 +72,7 @@ enroll24 <- tibble(
 enroll24$rate <- enroll24$rate * 100 / sum(enroll24$duration * enroll24$rate)
 
 # Set the enrollment table for 18 month expected enrollment
-enroll18 <- tibble(
-  stratum = rep("All", 4), # un-stratified
+enroll18 <- define_enroll_rate(
   duration = c(rep(2, 3), 12), # 6 month ramp-up of enrollment, 18 months enrollment time target
   rate = 1:4 # ratio of the enrollment rate
 )

--- a/vignettes/articles/story-design-with-spending.Rmd
+++ b/vignettes/articles/story-design-with-spending.Rmd
@@ -66,8 +66,7 @@ Moreover, we assume the hazard ratio (HR) of the first 3 month is 0.9 and therea
 We also assume the the survival time follow a piecewise exponential distribution with a median of 8 month for the first 3 months and 14 month thereafter.
 
 ```{r}
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(8, 14),
   hr = c(.9, .6),

--- a/vignettes/articles/story-nph-futility.Rmd
+++ b/vignettes/articles/story-nph-futility.Rmd
@@ -44,8 +44,8 @@ enroll_rate <- define_enroll_rate(duration = 12, rate = 680 / 12)
 ## Censoring rate is 0
 fail_rate <- define_fail_rate(
   duration = c(3, 100),
-  fail_rate = -log(.5) / 12, 
-  hr = c(1, .693), 
+  fail_rate = -log(.5) / 12,
+  hr = c(1, .693),
   dropout_rate = 0
 )
 ## Study duration was 34.8 in Korn & Freidlin Table 1

--- a/vignettes/articles/story-nph-futility.Rmd
+++ b/vignettes/articles/story-nph-futility.Rmd
@@ -41,9 +41,11 @@ enroll_rate <- define_enroll_rate(duration = 12, rate = 680 / 12)
 ## Control exponential with median of 12 mos
 ## Delayed effect with HR = 1 for 3 months and HR = .693 thereafter
 ## Censoring rate is 0
-fail_rate <- tibble(
-  stratum = "All", duration = c(3, 100),
-  fail_rate = -log(.5) / 12, hr = c(1, .693), dropout_rate = 0
+fail_rate <- define_fail_rate(
+  duration = c(3, 100),
+  fail_rate = -log(.5) / 12, 
+  hr = c(1, .693), 
+  dropout_rate = 0
 )
 ## Study duration was 34.8 in Korn & Freidlin Table 1
 ## We change to 34.86 here to obtain 512 expected events more precisely

--- a/vignettes/articles/story-spending-time-example.Rmd
+++ b/vignettes/articles/story-spending-time-example.Rmd
@@ -94,8 +94,7 @@ enroll_rate <- define_enroll_rate(
 )
 
 # failure rate
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100), # hazard ratio of 1 for the first 4 months and a hazard ratio of 0.6 thereafter
   hr = c(1, .6),
   fail_rate = log(2) / m, # exponential distribution
@@ -344,8 +343,7 @@ enroll_rate <- define_enroll_rate(
 )
 
 # failure rate
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   hr = c(1, .6),
   fail_rate = log(2) / m,
@@ -615,7 +613,7 @@ For this case, we assume proportional hazards within negative (HR = 0.8) and pos
 m <- 12
 
 # the enrollment rate of both subgroup and population is the same
-enroll_rate <- tibble(
+enroll_rate <- define_enroll_rate(
   stratum = c("Positive", "Negative"),
   duration = 12,
   rate = 20
@@ -623,7 +621,7 @@ enroll_rate <- tibble(
 
 # the hazard ratio in the biomarker positive subgroup will be assumed to be 0.6,
 # and in the negative population 0.8.
-fail_rate <- tibble(
+fail_rate <-define_fail_rate(
   stratum = c("Positive", "Negative"),
   hr = c(0.6, 0.8),
   duration = 100,

--- a/vignettes/articles/story-spending-time-example.Rmd
+++ b/vignettes/articles/story-spending-time-example.Rmd
@@ -622,7 +622,7 @@ enroll_rate <- define_enroll_rate(
 
 # the hazard ratio in the biomarker positive subgroup will be assumed to be 0.6,
 # and in the negative population 0.8.
-fail_rate <-define_fail_rate(
+fail_rate <- define_fail_rate(
   stratum = c("Positive", "Negative"),
   hr = c(0.6, 0.8),
   duration = 100,

--- a/vignettes/articles/story-summarize-designs.Rmd
+++ b/vignettes/articles/story-summarize-designs.Rmd
@@ -62,8 +62,7 @@ enroll_rate <- define_enroll_rate(
   duration = 12,
   rate = 30
 )
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 12,
   hr = c(1, .6),

--- a/vignettes/articles/usage-ahr.Rmd
+++ b/vignettes/articles/usage-ahr.Rmd
@@ -56,7 +56,7 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 10, 4, 4, 8),
   rate = c(5, 10, 0, 3, 6)
 )
-fail_rate <-define_fail_rate(
+fail_rate <- define_fail_rate(
   stratum = c(rep("Low", 2), rep("High", 2)),
   duration = 1,
   fail_rate = c(.1, .2, .3, .4),

--- a/vignettes/articles/usage-ahr.Rmd
+++ b/vignettes/articles/usage-ahr.Rmd
@@ -34,8 +34,7 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 10, 4, 4, 8),
   rate = c(5, 10, 0, 3, 6)
 )
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = 1,
   fail_rate = c(.1, .2, .3, .4),
   hr = c(.9, .75, .8, .6),
@@ -56,7 +55,7 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 10, 4, 4, 8),
   rate = c(5, 10, 0, 3, 6)
 )
-fail_rate <- tibble(
+fail_rate <-define_fail_rate(
   stratum = c(rep("Low", 2), rep("High", 2)),
   duration = 1,
   fail_rate = c(.1, .2, .3, .4),
@@ -79,8 +78,7 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 10, 4),
   rate = c(5, 10, 0)
 )
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = 1,
   fail_rate = c(.1, .2),
   hr = c(.9, .75),
@@ -215,8 +213,7 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 10, 4),
   rate = c(5, 10, 0)
 )
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = 1,
   fail_rate = c(.1, .2),
   hr = c(.9, .75),

--- a/vignettes/articles/usage-expected-event.Rmd
+++ b/vignettes/articles/usage-expected-event.Rmd
@@ -43,7 +43,7 @@ Here the `df` in `expected_event()` is short for data frame, since its output is
 
 ```{r}
 enroll_rate <- define_enroll_rate(duration = 10, rate = 10)
-fail_rate <- tibble(duration = 100, fail_rate = log(2) / 6, dropout_rate = .01)
+fail_rate <- define_fail_rate(duration = 100, fail_rate = log(2) / 6, dropout_rate = .01)
 total_duration <- 22
 
 expected_event(
@@ -58,7 +58,7 @@ expected_event(
 
 ```{r}
 enroll_rate <- define_enroll_rate(duration = c(5, 5), rate = c(10, 20))
-fail_rate <- tibble(duration = 100, fail_rate = log(2) / 6, dropout_rate = .01)
+fail_rate <- define_fail_rate(duration = 100, fail_rate = log(2) / 6, dropout_rate = .01)
 total_duration <- 22
 
 expected_event(
@@ -73,7 +73,7 @@ expected_event(
 
 ```{r}
 enroll_rate <- define_enroll_rate(duration = 10, rate = 10)
-fail_rate <- tibble(
+fail_rate <- define_fail_rate(
   duration = c(20, 80),
   fail_rate = c(log(2) / 6, log(2) / 4),
   dropout_rate = .01
@@ -92,7 +92,7 @@ expected_event(
 
 ```{r}
 enroll_rate <- define_enroll_rate(duration = 10, rate = 10)
-fail_rate <- tibble(duration = 100, fail_rate = log(2) / 6, dropout_rate = .01)
+fail_rate <- define_fail_rate(duration = 100, fail_rate = log(2) / 6, dropout_rate = .01)
 total_duration <- c(2, 22)
 
 try(expected_event(
@@ -131,7 +131,7 @@ plot(sf_enroll_rate,
 **Step 3:** set the failure rates and dropout rates.
 
 ```{r}
-fail_rate <- tibble(
+fail_rate <- define_fail_rate(
   duration = c(20, 80),
   failRate = c(0.1, 0.2),
   dropout_rate = .01

--- a/vignettes/articles/usage-expected-event.Rmd
+++ b/vignettes/articles/usage-expected-event.Rmd
@@ -20,7 +20,6 @@ knitr::opts_chunk$set(fig.width = 5, fig.height = 4, fig.align = "center")
 
 ```{r, message=FALSE, warning=FALSE}
 library(gt)
-library(tibble)
 library(dplyr)
 library(testthat)
 library(gsDesign2)
@@ -119,7 +118,7 @@ plot(sf_enroll_rate,
 ```{r}
 fail_rate <- define_fail_rate(
   duration = c(20, 80),
-  failRate = c(0.1, 0.2),
+  fail_rate = c(0.1, 0.2),
   dropout_rate = .01
 )
 
@@ -128,7 +127,7 @@ time_start_fail <- c(0, cumsum(fail_rate$duration))
 
 # plot the piecewise failure rates
 sf_fail_rate <- stepfun(time_start_fail,
-  c(0, fail_rate$failRate, last(fail_rate$failRate)),
+  c(0, fail_rate$fail_rate, last(fail_rate$fail_rate)),
   right = FALSE
 )
 plot(sf_fail_rate,
@@ -217,7 +216,7 @@ df_1 %>%
 df_2 <- tibble(
   endFail = cumsum(fail_rate$duration),
   startEnroll = total_duration - endFail,
-  failRate = fail_rate$failRate,
+  failRate = fail_rate$fail_rate,
   dropoutRate = fail_rate$dropout_rate
 )
 ```

--- a/vignettes/articles/usage-expected-time.Rmd
+++ b/vignettes/articles/usage-expected-time.Rmd
@@ -66,7 +66,7 @@ enroll_rate <- define_enroll_rate(
 )
 fail_rate <- define_fail_rate(
   duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), 
+  fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
   dropout_rate = rep(.001, 2)
 )
@@ -109,7 +109,7 @@ enroll_rate <- define_enroll_rate(
 )
 fail_rate <- define_fail_rate(
   duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), 
+  fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
   dropout_rate = .001
 )

--- a/vignettes/articles/usage-expected-time.Rmd
+++ b/vignettes/articles/usage-expected-time.Rmd
@@ -39,8 +39,7 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 10),
   rate = c(3, 6, 9) * 5
 )
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18), hr = c(.9, .6),
   dropout_rate = rep(.001, 2)
@@ -64,10 +63,10 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 10),
   rate = c(3, 6, 9) * 5
 )
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), hr = c(.9, .6),
+  fail_rate = log(2) / c(9, 18), 
+  hr = c(.9, .6),
   dropout_rate = rep(.001, 2)
 )
 ratio <- 1
@@ -107,11 +106,11 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 10),
   rate = c(3, 6, 9) * 5
 )
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  fail_rate = log(2) / c(9, 18), 
+  hr = c(.9, .6),
+  dropout_rate = .001
 )
 ratio <- 1
 target_event <- 200

--- a/vignettes/articles/usage-fixed-design.Rmd
+++ b/vignettes/articles/usage-fixed-design.Rmd
@@ -46,8 +46,7 @@ enroll_rate <- define_enroll_rate(
 )
 
 # Failure rates
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 12,
   hr = c(1, .6),

--- a/vignettes/articles/usage-fixed-design.Rmd
+++ b/vignettes/articles/usage-fixed-design.Rmd
@@ -18,7 +18,6 @@ vignette: |
 ---
 
 ```{r, message=FALSE, warning=FALSE}
-library(tibble)
 library(gt)
 library(gsDesign)
 library(gsDesign2)

--- a/vignettes/articles/usage-gs-info-ahr.Rmd
+++ b/vignettes/articles/usage-gs-info-ahr.Rmd
@@ -20,7 +20,6 @@ knitr::opts_chunk$set(fig.width = 5, fig.height = 4, fig.align = "center")
 
 ```{r, message=FALSE, warning=FALSE}
 library(gt)
-library(tibble)
 library(dplyr)
 library(testthat)
 library(gsDesign2)

--- a/vignettes/articles/usage-gs-info-ahr.Rmd
+++ b/vignettes/articles/usage-gs-info-ahr.Rmd
@@ -48,7 +48,7 @@ enroll_rate <- define_enroll_rate(
 )
 fail_rate <- define_fail_rate(
   duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), 
+  fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
   dropout_rate = .001
 )
@@ -71,7 +71,7 @@ enroll_rate <- define_enroll_rate(
 )
 fail_rate <- define_fail_rate(
   duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), 
+  fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
   dropout_rate = .001
 )
@@ -98,7 +98,7 @@ enroll_rate <- define_enroll_rate(
 )
 fail_rate <- define_fail_rate(
   duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), 
+  fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
   dropout_rate = .001
 )
@@ -169,7 +169,7 @@ enroll_rate <- define_enroll_rate(
 )
 fail_rate <- define_fail_rate(
   duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), 
+  fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
   dropout_rate = .001
 )

--- a/vignettes/articles/usage-gs-info-ahr.Rmd
+++ b/vignettes/articles/usage-gs-info-ahr.Rmd
@@ -45,10 +45,11 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 10),
   rate = c(3, 6, 9) * 5
 )
-fail_rate <- tibble(
-  stratum = "All", duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+fail_rate <- define_fail_rate(
+  duration = c(3, 100),
+  fail_rate = log(2) / c(9, 18), 
+  hr = c(.9, .6),
+  dropout_rate = .001
 )
 ratio <- 1
 
@@ -67,10 +68,11 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 10),
   rate = c(3, 6, 9) * 5
 )
-fail_rate <- tibble(
-  stratum = "All", duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+fail_rate <- define_fail_rate(
+  duration = c(3, 100),
+  fail_rate = log(2) / c(9, 18), 
+  hr = c(.9, .6),
+  dropout_rate = .001
 )
 ratio <- 1
 
@@ -93,10 +95,11 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 10),
   rate = c(3, 6, 9) * 5
 )
-fail_rate <- tibble(
-  stratum = "All", duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+fail_rate <- define_fail_rate(
+  duration = c(3, 100),
+  fail_rate = log(2) / c(9, 18), 
+  hr = c(.9, .6),
+  dropout_rate = .001
 )
 ratio <- 1
 
@@ -127,10 +130,11 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 10),
   rate = c(3, 6, 9) * 5
 )
-fail_rate <- tibble(
-  stratum = "All", duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+fail_rate <- define_fail_rate(
+  duration = c(3, 100),
+  fail_rate = log(2) / c(9, 18),
+  hr = c(.9, .6),
+  dropout_rate = .001
 )
 ratio <- 1
 analysis_time <- c(10, 15, 20)
@@ -162,10 +166,11 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 10),
   rate = c(3, 6, 9) * 5
 )
-fail_rate <- tibble(
-  stratum = "All", duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18), hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+fail_rate <- define_fail_rate(
+  duration = c(3, 100),
+  fail_rate = log(2) / c(9, 18), 
+  hr = c(.9, .6),
+  dropout_rate = .001
 )
 ratio <- 1
 events <- c(70, 150, 200)
@@ -207,12 +212,11 @@ enroll_rate <- define_enroll_rate(
   duration = c(2, 2, 10),
   rate = c(3, 6, 9) * 5
 )
-fail_rate <- tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(3, 100),
   fail_rate = log(2) / c(9, 18),
   hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
+  dropout_rate = .001
 )
 ratio <- 1
 analysis_time <- c(10, 15, 20)

--- a/vignettes/articles/usage-summary-as-gt.Rmd
+++ b/vignettes/articles/usage-summary-as-gt.Rmd
@@ -65,8 +65,7 @@ enroll_rate <- define_enroll_rate(
   rate = 1
 )
 
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, 100),
   fail_rate = log(2) / 12,
   hr = c(1, .6),

--- a/vignettes/articles/usage-summary-as-gt.Rmd
+++ b/vignettes/articles/usage-summary-as-gt.Rmd
@@ -27,7 +27,6 @@ knitr::opts_chunk$set(
 
 ```{r, message=FALSE, warning=FALSE}
 library(dplyr)
-library(tibble)
 library(gt)
 library(gsDesign2)
 ```

--- a/vignettes/gsDesign2.Rmd
+++ b/vignettes/gsDesign2.Rmd
@@ -104,8 +104,7 @@ Finally, we assume a low $0.001$ exponential dropout rate per month for both tre
 ```{r}
 median_surv <- 12
 
-fail_rate <- tibble::tibble(
-  stratum = "All",
+fail_rate <- define_fail_rate(
   duration = c(4, Inf),
   fail_rate = log(2) / median_surv,
   hr = c(1, .6),


### PR DESCRIPTION
- using `define_fail_rate` to replace `tibble` as input. 