### PR TITLE
Update pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -19,6 +19,8 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR updates the pkgdown workflow to the latest version from upstream by running

```r
usethis::use_github_action("pkgdown")
```

All other workflows are up-to-date.