### PR TITLE
Improve fixed design documentation

### DIFF
--- a/R/ahr.R
+++ b/R/ahr.R
@@ -97,18 +97,19 @@
 #'   hr = c(.9, .75, .8, .6)
 #' )
 #' ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, total_duration = c(15, 30))
-ahr <- function(enroll_rate = define_enroll_rate(
-                  duration = c(2, 2, 10),
-                  rate = c(3, 6, 9)
-                ),
-                fail_rate = define_fail_rate(
-                  duration = c(3, 100),
-                  fail_rate = log(2) / c(9, 18),
-                  hr = c(.9, .6),
-                  dropout_rate = .001
-                ),
-                total_duration = 30,
-                ratio = 1) {
+ahr <- function(
+    enroll_rate = define_enroll_rate(
+      duration = c(2, 2, 10),
+      rate = c(3, 6, 9)
+    ),
+    fail_rate = define_fail_rate(
+      duration = c(3, 100),
+      fail_rate = log(2) / c(9, 18),
+      hr = c(.9, .6),
+      dropout_rate = .001
+    ),
+    total_duration = 30,
+    ratio = 1) {
   res <- pw_info(
     enroll_rate = enroll_rate,
     fail_rate = fail_rate,

--- a/R/expected_event.R
+++ b/R/expected_event.R
@@ -213,14 +213,18 @@ expected_event <- function(
     arrange(start_fail) %>%
     # compute expected events as nbar in a sub-interval
     mutate(
-      d = ifelse(fail_rate_var == 0, 0, big_q * (1 - q) * fail_rate_var / (fail_rate_var + dropout_rate_var)),
-      nbar = ifelse(fail_rate_var == 0,
+      d = ifelse(
+        fail_rate_var == 0,
+        0,
+        big_q * (1 - q) * fail_rate_var / (fail_rate_var + dropout_rate_var)
+      ),
+      nbar = ifelse(
+        fail_rate_var == 0,
         0,
         big_g * d +
           (fail_rate_var * big_q * enroll_rate_var) /
             (fail_rate_var + dropout_rate_var) *
-            (duration - (1 - q) /
-              (fail_rate_var + dropout_rate_var))
+            (duration - (1 - q) / (fail_rate_var + dropout_rate_var))
       )
     )
 

--- a/R/expected_event.R
+++ b/R/expected_event.R
@@ -110,17 +110,18 @@
 #'   fail_rate = define_fail_rate(duration = 100, fail_rate = log(2) / 6, dropout_rate = .01),
 #'   total_duration = 22, simple = FALSE
 #' )
-expected_event <- function(enroll_rate = define_enroll_rate(
-                             duration = c(2, 2, 10),
-                             rate = c(3, 6, 9)
-                           ),
-                           fail_rate = define_fail_rate(
-                             duration = c(3, 100),
-                             fail_rate = log(2) / c(9, 18),
-                             dropout_rate = .001
-                           ),
-                           total_duration = 25,
-                           simple = TRUE) {
+expected_event <- function(
+    enroll_rate = define_enroll_rate(
+      duration = c(2, 2, 10),
+      rate = c(3, 6, 9)
+    ),
+    fail_rate = define_fail_rate(
+      duration = c(3, 100),
+      fail_rate = log(2) / c(9, 18),
+      dropout_rate = .001
+    ),
+    total_duration = 25,
+    simple = TRUE) {
   # ----------------------------#
   #    check input values       #
   # ----------------------------#

--- a/R/expected_time.R
+++ b/R/expected_time.R
@@ -80,20 +80,21 @@
 #'   target_event = xx$event, interval = c(.5, 1.5) * xx$time
 #' )
 #' }
-expected_time <- function(enroll_rate = define_enroll_rate(
-                            duration = c(2, 2, 10),
-                            rate = c(3, 6, 9) * 5
-                          ),
-                          fail_rate = define_fail_rate(
-                            stratum = "All",
-                            duration = c(3, 100),
-                            fail_rate = log(2) / c(9, 18),
-                            hr = c(.9, .6),
-                            dropout_rate = rep(.001, 2)
-                          ),
-                          target_event = 150,
-                          ratio = 1,
-                          interval = c(.01, 100)) {
+expected_time <- function(
+    enroll_rate = define_enroll_rate(
+      duration = c(2, 2, 10),
+      rate = c(3, 6, 9) * 5
+    ),
+    fail_rate = define_fail_rate(
+      stratum = "All",
+      duration = c(3, 100),
+      fail_rate = log(2) / c(9, 18),
+      hr = c(.9, .6),
+      dropout_rate = rep(.001, 2)
+    ),
+    target_event = 150,
+    ratio = 1,
+    interval = c(.01, 100)) {
   # ----------------------------#
   #    check inputs             #
   # ----------------------------#

--- a/R/fixed_design_ahr.R
+++ b/R/fixed_design_ahr.R
@@ -34,7 +34,8 @@
 #'
 #' @examples
 #' library(dplyr)
-#' # example 1: given power and compute sample size
+#'
+#' # Example 1: given power and compute sample size
 #' x <- fixed_design_ahr(
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -47,7 +48,8 @@
 #'   study_duration = 36
 #' )
 #' x %>% summary()
-#' # example 2: given sample size and compute power
+#'
+#' # Example 2: given sample size and compute power
 #' x <- fixed_design_ahr(
 #'   alpha = .025,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/R/fixed_design_ahr.R
+++ b/R/fixed_design_ahr.R
@@ -62,14 +62,14 @@
 #'   study_duration = 36
 #' )
 #' x %>% summary()
-fixed_design_ahr <- function(enroll_rate,
-                             fail_rate,
-                             alpha = 0.025,
-                             power = NULL,
-                             ratio = 1,
-                             study_duration = 36,
-                             event = NULL
-                             ) {
+fixed_design_ahr <- function(
+    enroll_rate,
+    fail_rate,
+    alpha = 0.025,
+    power = NULL,
+    ratio = 1,
+    study_duration = 36,
+    event = NULL) {
   # --------------------------------------------- #
   #     check inputs                              #
   # --------------------------------------------- #
@@ -118,7 +118,7 @@ fixed_design_ahr <- function(enroll_rate,
   y <- list(
     input = input, enroll_rate = d$enroll_rate,
     fail_rate = d$fail_rate, analysis = ans, design = "ahr"
-    )
+  )
   class(y) <- c("fixed_design", class(y))
   return(y)
 }

--- a/R/fixed_design_fh.R
+++ b/R/fixed_design_fh.R
@@ -66,14 +66,15 @@
 #'   rho = 1, gamma = 1
 #' )
 #' x %>% summary()
-fixed_design_fh <- function(alpha = 0.025,
-                            power = NULL,
-                            ratio = 1,
-                            study_duration = 36,
-                            enroll_rate,
-                            fail_rate,
-                            rho = 0,
-                            gamma = 0) {
+fixed_design_fh <- function(
+    alpha = 0.025,
+    power = NULL,
+    ratio = 1,
+    study_duration = 36,
+    enroll_rate,
+    fail_rate,
+    rho = 0,
+    gamma = 0) {
   # --------------------------------------------- #
   #     check inputs                              #
   # --------------------------------------------- #
@@ -110,7 +111,8 @@ fixed_design_fh <- function(alpha = 0.025,
       ratio = ratio,
       weight = weight,
       analysis_time = study_duration,
-      event = NULL)
+      event = NULL
+    )
   } else {
     d <- gs_design_wlr(
       alpha = alpha, beta = 1 - power,

--- a/R/fixed_design_fh.R
+++ b/R/fixed_design_fh.R
@@ -16,10 +16,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#' Fixed design using Fleming-Harrington method method (Farrington and Manning 1990).
+#' Fixed design using Fleming-Harrington method
+#'
 #' Computes fixed design sample size (given power) or power (given sample size)
-#' for Fleming-Harrington method method.
+#' for Fleming-Harrington method (Farrington and Manning, 1990).
 #' Returns a list with a basic summary.
+#'
 #' @inheritParams gs_design_wlr
 #' @inheritParams gs_power_wlr
 #' @param power Power (`NULL` to compute power or strictly between 0
@@ -27,13 +29,15 @@
 #' @param study_duration Study duration.
 #' @param rho test parameter in Fleming-Harrington method.
 #' @param gamma test parameter in Fleming-Harrington method.
+#'
 #' @return A table.
 #'
 #' @export
 #'
 #' @examples
 #' library(dplyr)
-#' # example 1: given power and compute sample size
+#'
+#' # Example 1: given power and compute sample size
 #' x <- fixed_design_fh(
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -47,7 +51,8 @@
 #'   rho = 1, gamma = 1
 #' )
 #' x %>% summary()
-#' # example 2: given sample size and compute power
+#'
+#' # Example 2: given sample size and compute power
 #' x <- fixed_design_fh(
 #'   alpha = .025,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/R/fixed_design_lf.R
+++ b/R/fixed_design_lf.R
@@ -16,21 +16,27 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#' Fixed design using Lachin-Foulkes method (Farrington and Manning 1990).
+#' Fixed design using Lachin-Foulkes method
+#'
 #' Computes fixed design sample size (given power) or power (given sample size)
-#' for Lachin-Foulkes method method.
+#' for Lachin-Foulkes method (Lachin and Foulkes, 1986).
 #' Returns a list with a basic summary.
+#'
 #' @param alpha One-sided Type I error (strictly between 0 and 1).
 #' @param power Power (`NULL` to compute power or strictly between 0
 #'   and `1 - alpha` otherwise).
 #' @param ratio Experimental:Control randomization ratio.
 #' @param study_duration Study duration.
 #' @inheritParams gs_design_ahr
+#'
 #' @return A table.
+#'
 #' @export
+#'
 #' @examples
 #' library(dplyr)
-#' # example 1: given power and compute sample size
+#'
+#' # Example 1: given power and compute sample size
 #' x <- fixed_design_lf(
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -43,7 +49,8 @@
 #'   study_duration = 36
 #' )
 #' x %>% summary()
-#' # example 2: given sample size and compute power
+#'
+#' # Example 2: given sample size and compute power
 #' x <- fixed_design_fh(
 #'   alpha = .025,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/R/fixed_design_lf.R
+++ b/R/fixed_design_lf.R
@@ -63,13 +63,13 @@
 #'   study_duration = 36
 #' )
 #' x %>% summary()
-fixed_design_lf <- function(alpha = 0.025,
-                            power = NULL,
-                            ratio = 1,
-                            study_duration = 36,
-                            enroll_rate,
-                            fail_rate
-                            ) {
+fixed_design_lf <- function(
+    alpha = 0.025,
+    power = NULL,
+    ratio = 1,
+    study_duration = 36,
+    enroll_rate,
+    fail_rate) {
   # --------------------------------------------- #
   #     check inputs                              #
   # --------------------------------------------- #

--- a/R/fixed_design_maxcombo.R
+++ b/R/fixed_design_maxcombo.R
@@ -68,15 +68,16 @@
 #'   rho = c(0, 0.5), gamma = c(0, 0), tau = c(-1, -1)
 #' )
 #' x %>% summary()
-fixed_design_maxcombo <- function(alpha = 0.025,
-                                  power = NULL,
-                                  ratio = 1,
-                                  study_duration = 36,
-                                  enroll_rate,
-                                  fail_rate,
-                                  rho = c(0, 0, 1),
-                                  gamma = c(0, 1, 0),
-                                  tau = rep(-1, 3)) {
+fixed_design_maxcombo <- function(
+    alpha = 0.025,
+    power = NULL,
+    ratio = 1,
+    study_duration = 36,
+    enroll_rate,
+    fail_rate,
+    rho = c(0, 0, 1),
+    gamma = c(0, 1, 0),
+    tau = rep(-1, 3)) {
   # --------------------------------------------- #
   #     check inputs                              #
   # --------------------------------------------- #
@@ -100,7 +101,7 @@ fixed_design_maxcombo <- function(alpha = 0.025,
     rho = rho,
     gamma = gamma,
     tau = tau
-    ) %>%
+  ) %>%
     mutate(test = seq(1, length(rho)), analysis = 1, analysis_time = study_duration)
   # check if power is NULL or not
   if (is.null(power)) {

--- a/R/fixed_design_maxcombo.R
+++ b/R/fixed_design_maxcombo.R
@@ -16,10 +16,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#' Fixed design using maxcombo method.
+#' Fixed design using MaxCombo method
+#'
 #' Computes fixed design sample size (given power) or power (given sample size)
-#' for maxcombo method.
+#' for MaxCombo method.
 #' Returns a list with a basic summary.
+#'
 #' @param alpha One-sided Type I error (strictly between 0 and 1).
 #' @param power Power (`NULL` to compute power or strictly between 0
 #'   and `1 - alpha` otherwise).
@@ -29,11 +31,15 @@
 #' @param gamma A vector of numbers paring with rho and tau for maxcombo test.
 #' @param tau A vector of numbers paring with gamma and rho for maxcombo test.
 #' @inheritParams gs_design_combo
+#'
 #' @return A table.
+#'
 #' @export
+#'
 #' @examples
 #' library(dplyr)
-#' # example 1: given power and compute sample size
+#'
+#' # Example 1: given power and compute sample size
 #' x <- fixed_design_maxcombo(
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -47,7 +53,8 @@
 #'   rho = c(0, 0.5), gamma = c(0, 0), tau = c(-1, -1)
 #' )
 #' x %>% summary()
-#' # example 2: given sample size and compute power
+#'
+#' # Example 2: given sample size and compute power
 #' x <- fixed_design_maxcombo(
 #'   alpha = .025,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/R/fixed_design_mb.R
+++ b/R/fixed_design_mb.R
@@ -66,13 +66,14 @@
 #'   tau = 4
 #' )
 #' x %>% summary()
-fixed_design_mb <- function(alpha = 0.025,
-                            power = NULL,
-                            ratio = 1,
-                            study_duration = 36,
-                            enroll_rate,
-                            fail_rate,
-                            tau = 6) {
+fixed_design_mb <- function(
+    alpha = 0.025,
+    power = NULL,
+    ratio = 1,
+    study_duration = 36,
+    enroll_rate,
+    fail_rate,
+    tau = 6) {
   # --------------------------------------------- #
   #     check inputs                              #
   # --------------------------------------------- #
@@ -106,7 +107,8 @@ fixed_design_mb <- function(alpha = 0.025,
       upper = gs_b, upar = qnorm(1 - alpha),
       lower = gs_b, lpar = -Inf,
       analysis_time = study_duration,
-      event = NULL)
+      event = NULL
+    )
   } else {
     d <- gs_design_wlr(
       alpha = alpha,
@@ -117,7 +119,8 @@ fixed_design_mb <- function(alpha = 0.025,
       weight = weight,
       upper = gs_b, upar = qnorm(1 - alpha),
       lower = gs_b, lpar = -Inf,
-      analysis_time = study_duration)
+      analysis_time = study_duration
+    )
   }
   # get the output of MB
   ans <- tibble::tibble(
@@ -131,7 +134,8 @@ fixed_design_mb <- function(alpha = 0.025,
   )
   y <- list(
     input = input, enroll_rate = d$enroll_rate, fail_rate = d$fail_rate, analysis = ans,
-    design = "mb", design_par = list(tau = tau))
+    design = "mb", design_par = list(tau = tau)
+  )
   class(y) <- c("fixed_design", class(y))
   return(y)
 }

--- a/R/fixed_design_mb.R
+++ b/R/fixed_design_mb.R
@@ -16,12 +16,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#' Computes fixed design sample size for Magirr-Burman method.
-#' Returns a tibble with a basic summary.
-#' Fixed design using Magirr-Burman method.
+#' Fixed design using Magirr-Burman method
+#'
 #' Computes fixed design sample size (given power) or power (given sample size)
 #' for Magirr-Burman method.
 #' Returns a list with a basic summary.
+#'
 #' @inheritParams gs_design_wlr
 #' @inheritParams gs_power_wlr
 #' @param power Power (`NULL` to compute power or strictly between 0
@@ -29,11 +29,15 @@
 #' @param ratio Experimental:Control randomization ratio.
 #' @param study_duration Study duration.
 #' @param tau Test parameter of Magirr-Burman method.
+#'
 #' @return A table.
+#'
 #' @export
+#'
 #' @examples
 #' library(dplyr)
-#' # example 1: given power and compute sample size
+#'
+#' # Example 1: given power and compute sample size
 #' x <- fixed_design_mb(
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -47,7 +51,8 @@
 #'   tau = 4
 #' )
 #' x %>% summary()
-#' # example 2: given sample size and compute power
+#'
+#' # Example 2: given sample size and compute power
 #' x <- fixed_design_mb(
 #'   alpha = .025,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/R/fixed_design_milestone.R
+++ b/R/fixed_design_milestone.R
@@ -37,7 +37,7 @@
 #' @examples
 #' library(dplyr)
 #'
-#'# Example 1: given power and compute sample size
+#' # Example 1: given power and compute sample size
 #' x <- fixed_design_milestone(
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -66,13 +66,14 @@
 #'   tau = 18
 #' )
 #' x %>% summary()
-fixed_design_milestone <- function(alpha = 0.025,
-                                   power = NULL,
-                                   ratio = 1,
-                                   enroll_rate,
-                                   fail_rate,
-                                   study_duration = 36,
-                                   tau = NULL) {
+fixed_design_milestone <- function(
+    alpha = 0.025,
+    power = NULL,
+    ratio = 1,
+    enroll_rate,
+    fail_rate,
+    study_duration = 36,
+    tau = NULL) {
   # --------------------------------------------- #
   #     check inputs                              #
   # --------------------------------------------- #
@@ -101,14 +102,16 @@ fixed_design_milestone <- function(alpha = 0.025,
       enroll_rate = enroll_rate, fail_rate = fail_rate,
       analysis_time = study_duration,
       test = "survival_difference",
-      tau = tau)
+      tau = tau
+    )
   } else {
     d <- fixed_design_size_rmst(
       alpha = alpha, beta = 1 - power, ratio = ratio,
       enroll_rate = enroll_rate, fail_rate = fail_rate,
       analysis_time = study_duration,
       test = "survival_difference",
-      tau = tau)
+      tau = tau
+    )
   }
   # get the output of MaxCombo
   ans <- tibble::tibble(

--- a/R/fixed_design_milestone.R
+++ b/R/fixed_design_milestone.R
@@ -16,10 +16,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#' Fixed design using milestone method (Yung and Liu 2020).
+#' Fixed design using milestone method
+#'
 #' Computes fixed design sample size (given power) or power (given sample size)
-#' for milestone method.
+#' for milestone method (Yung and Liu, 2020).
 #' Returns a list with a basic summary.
+#'
 #' @inheritParams gs_design_ahr
 #' @param alpha One-sided Type I error (strictly between 0 and 1).
 #' @param power Power (`NULL` to compute power or strictly between 0
@@ -27,11 +29,15 @@
 #' @param ratio Experimental:Control randomization ratio.
 #' @param study_duration Study duration.
 #' @param tau Test parameter of milestone method.
+#'
 #' @return A table.
+#'
 #' @export
+#'
 #' @examples
 #' library(dplyr)
-#'# example 1: given power and compute sample size
+#'
+#'# Example 1: given power and compute sample size
 #' x <- fixed_design_milestone(
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -45,7 +51,8 @@
 #'   tau = 18
 #' )
 #' x %>% summary()
-#' # example 2: given sample size and compute power
+#'
+#' # Example 2: given sample size and compute power
 #' x <- fixed_design_milestone(
 #'   alpha = .025,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/R/fixed_design_rd.R
+++ b/R/fixed_design_rd.R
@@ -42,21 +42,24 @@
 #' # Example 1: given power and compute sample size
 #' x <- fixed_design_rd(
 #'   alpha = 0.025, power = 0.9, p_c = .15, p_e = .1,
-#'   rd0 = 0, ratio = 1)
+#'   rd0 = 0, ratio = 1
+#' )
 #' x %>% summary()
 #'
 #' # Example 2: given sample size and compute power
 #' x <- fixed_design_rd(
 #'   alpha = 0.025, power = NULL, p_c = .15, p_e = .1,
-#'   rd0 = 0, n = 2000, ratio = 1)
+#'   rd0 = 0, n = 2000, ratio = 1
+#' )
 #' x %>% summary()
-fixed_design_rd <- function(alpha = 0.025,
-                            power = NULL,
-                            ratio = 1,
-                            p_c,
-                            p_e,
-                            rd0 = 0,
-                            n = NULL) {
+fixed_design_rd <- function(
+    alpha = 0.025,
+    power = NULL,
+    ratio = 1,
+    p_c,
+    p_e,
+    rd0 = 0,
+    n = NULL) {
   # --------------------------------------------- #
   #     check inputs                              #
   # --------------------------------------------- #

--- a/R/fixed_design_rd.R
+++ b/R/fixed_design_rd.R
@@ -16,10 +16,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#' Fixed design for binary outcome measuring in risk difference (Mehrotra and Railkar 2000).
+#' Fixed design for binary outcome measuring in risk difference
+#'
 #' Computes fixed design sample size (given power) or power (given sample size)
-#' for binary outcome measuring in risk difference.
+#' for binary outcome measuring in risk difference (Mehrotra and Railkar, 2000).
 #' Returns a list with a basic summary.
+#'
 #' @param alpha One-sided Type I error (strictly between 0 and 1).
 #' @param power Power (`NULL` to compute power or strictly between 0
 #'   and `1 - alpha` otherwise).
@@ -29,16 +31,21 @@
 #' @param n Sample size. If NULL with power input, the sample size will be
 #' computed to achieve the targeted power
 #' @param ratio Experimental:Control randomization ratio.
+#'
 #' @return A table.
+#'
 #' @export
+#'
 #' @examples
 #' library(dplyr)
-#' # example 1: given power and compute sample size
+#'
+#' # Example 1: given power and compute sample size
 #' x <- fixed_design_rd(
 #'   alpha = 0.025, power = 0.9, p_c = .15, p_e = .1,
 #'   rd0 = 0, ratio = 1)
 #' x %>% summary()
-#' # example 2: given sample size and compute power
+#'
+#' # Example 2: given sample size and compute power
 #' x <- fixed_design_rd(
 #'   alpha = 0.025, power = NULL, p_c = .15, p_e = .1,
 #'   rd0 = 0, n = 2000, ratio = 1)

--- a/R/fixed_design_rmst.R
+++ b/R/fixed_design_rmst.R
@@ -66,13 +66,14 @@
 #'   tau = 18
 #' )
 #' x %>% summary()
-fixed_design_rmst <- function(alpha = 0.025,
-                              power = NULL,
-                              ratio = 1,
-                              study_duration = 36,
-                              enroll_rate,
-                              fail_rate,
-                              tau = NULL) {
+fixed_design_rmst <- function(
+    alpha = 0.025,
+    power = NULL,
+    ratio = 1,
+    study_duration = 36,
+    enroll_rate,
+    fail_rate,
+    tau = NULL) {
   # --------------------------------------------- #
   #     check inputs                              #
   # --------------------------------------------- #

--- a/R/fixed_design_rmst.R
+++ b/R/fixed_design_rmst.R
@@ -16,10 +16,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#' Fixed design using RMST method (Yung and Liu 2020).
+#' Fixed design using RMST method
+#'
 #' Computes fixed design sample size (given power) or power (given sample size)
-#' for RMST methods.
+#' for RMST methods (Yung and Liu, 2020).
 #' Returns a list with a basic summary.
+#'
 #' @inheritParams gs_design_ahr
 #' @param alpha One-sided Type I error (strictly between 0 and 1).
 #' @param power Power (`NULL` to compute power or strictly between 0
@@ -27,11 +29,15 @@
 #' @param ratio Experimental:Control randomization ratio.
 #' @param study_duration Study duration.
 #' @param tau Test parameter in RMST.
+#'
 #' @return A table.
+#'
 #' @export
+#'
 #' @examples
 #' library(dplyr)
-#' # example 1: given power and compute sample size
+#'
+#' # Example 1: given power and compute sample size
 #' x <- fixed_design_rmst(
 #'   alpha = .025, power = .9,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -45,7 +51,8 @@
 #'   tau = 18
 #' )
 #' x %>% summary()
-#' # example 2: given sample size and compute power
+#'
+#' # Example 2: given sample size and compute power
 #' x <- fixed_design_rmst(
 #'   alpha = .025,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/R/gs_design_ahr.R
+++ b/R/gs_design_ahr.R
@@ -191,31 +191,35 @@
 #'   lpar = rep(-Inf, 3)
 #' )
 #' }
-gs_design_ahr <- function(enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
-                          fail_rate = define_fail_rate(
-                            duration = c(3, 100),
-                            fail_rate = log(2) / c(9, 18),
-                            hr = c(.9, .6),
-                            dropout_rate = .001
-                          ),
-                          alpha = 0.025, beta = 0.1,
-                          info_frac = NULL, analysis_time = 36,
-                          ratio = 1, binding = FALSE,
-                          upper = gs_b,
-                          upar = gsDesign::gsDesign(
-                            k = 3, test.type = 1,
-                            n.I = c(.25, .75, 1),
-                            sfu = sfLDOF, sfupar = NULL
-                          )$upper$bound,
-                          lower = gs_b,
-                          lpar = c(qnorm(.1), -Inf, -Inf),
-                          h1_spending = TRUE,
-                          test_upper = TRUE,
-                          test_lower = TRUE,
-                          info_scale = c("h0_h1_info", "h0_info", "h1_info"),
-                          r = 18,
-                          tol = 1e-6,
-                          interval = c(.01, 100)) {
+gs_design_ahr <- function(
+    enroll_rate = define_enroll_rate(
+      duration = c(2, 2, 10),
+      rate = c(3, 6, 9)
+    ),
+    fail_rate = define_fail_rate(
+      duration = c(3, 100),
+      fail_rate = log(2) / c(9, 18),
+      hr = c(.9, .6),
+      dropout_rate = .001
+    ),
+    alpha = 0.025, beta = 0.1,
+    info_frac = NULL, analysis_time = 36,
+    ratio = 1, binding = FALSE,
+    upper = gs_b,
+    upar = gsDesign::gsDesign(
+      k = 3, test.type = 1,
+      n.I = c(.25, .75, 1),
+      sfu = sfLDOF, sfupar = NULL
+    )$upper$bound,
+    lower = gs_b,
+    lpar = c(qnorm(.1), -Inf, -Inf),
+    h1_spending = TRUE,
+    test_upper = TRUE,
+    test_lower = TRUE,
+    info_scale = c("h0_h1_info", "h0_info", "h1_info"),
+    r = 18,
+    tol = 1e-6,
+    interval = c(.01, 100)) {
   # --------------------------------------------- #
   #     initialization                             #
   # --------------------------------------------- #

--- a/R/gs_design_ahr.R
+++ b/R/gs_design_ahr.R
@@ -233,11 +233,8 @@ gs_design_ahr <- function(
   # --------------------------------------------- #
   check_analysis_time(analysis_time)
   check_info_frac(info_frac)
-  if ((length(analysis_time) > 1) &&
-    (length(info_frac) > 1) &&
-    (length(info_frac) != length(analysis_time))) {
-    stop("gs_design_ahr() info_frac and analysis_time
-         must have the same length if both have length > 1!")
+  if ((length(analysis_time) > 1) && (length(info_frac) > 1) && (length(info_frac) != length(analysis_time))) {
+    stop("gs_design_ahr() info_frac and analysis_time must have the same length if both have length > 1.")
   }
 
   # --------------------------------------------- #

--- a/R/gs_design_combo.R
+++ b/R/gs_design_combo.R
@@ -118,39 +118,40 @@
 #'   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2), # beta spending
 #' )
 #' }
-gs_design_combo <- function(enroll_rate = define_enroll_rate(
-                              duration = 12,
-                              rate = 500 / 12
-                            ),
-                            fail_rate = define_fail_rate(
-                              duration = c(4, 100),
-                              fail_rate = log(2) / 15,
-                              hr = c(1, .6),
-                              dropout_rate = 0.001
-                            ),
-                            fh_test = rbind(
-                              data.frame(
-                                rho = 0, gamma = 0, tau = -1,
-                                test = 1, analysis = 1:3,
-                                analysis_time = c(12, 24, 36)
-                              ),
-                              data.frame(
-                                rho = c(0, 0.5), gamma = 0.5, tau = -1,
-                                test = 2:3, analysis = 3,
-                                analysis_time = 36
-                              )
-                            ),
-                            ratio = 1,
-                            alpha = 0.025,
-                            beta = 0.2,
-                            binding = FALSE,
-                            upper = gs_b,
-                            upar = c(3, 2, 1),
-                            lower = gs_b,
-                            lpar = c(-1, 0, 1),
-                            algorithm = mvtnorm::GenzBretz(maxpts = 1e5, abseps = 1e-5),
-                            n_upper_bound = 1e3,
-                            ...) {
+gs_design_combo <- function(
+    enroll_rate = define_enroll_rate(
+      duration = 12,
+      rate = 500 / 12
+    ),
+    fail_rate = define_fail_rate(
+      duration = c(4, 100),
+      fail_rate = log(2) / 15,
+      hr = c(1, .6),
+      dropout_rate = 0.001
+    ),
+    fh_test = rbind(
+      data.frame(
+        rho = 0, gamma = 0, tau = -1,
+        test = 1, analysis = 1:3,
+        analysis_time = c(12, 24, 36)
+      ),
+      data.frame(
+        rho = c(0, 0.5), gamma = 0.5, tau = -1,
+        test = 2:3, analysis = 3,
+        analysis_time = 36
+      )
+    ),
+    ratio = 1,
+    alpha = 0.025,
+    beta = 0.2,
+    binding = FALSE,
+    upper = gs_b,
+    upar = c(3, 2, 1),
+    lower = gs_b,
+    lpar = c(-1, 0, 1),
+    algorithm = mvtnorm::GenzBretz(maxpts = 1e5, abseps = 1e-5),
+    n_upper_bound = 1e3,
+    ...) {
   # get the number of analysis/test
   n_analysis <- length(unique(fh_test$analysis))
   n_test <- max(fh_test$test)

--- a/R/gs_design_npe.R
+++ b/R/gs_design_npe.R
@@ -491,9 +491,11 @@ gs_design_npe <- function(
   # combine probability under H0 and H1
   suppressMessages(
     ans <- ans_h1 %>%
-      full_join(ans_h0 %>%
-        select(analysis, bound, probability) %>%
-        dplyr::rename(probability0 = probability))
+      full_join(
+        ans_h0 %>%
+          select(analysis, bound, probability) %>%
+          dplyr::rename(probability0 = probability)
+      )
   )
 
   ans <- ans %>% select(analysis, bound, z, probability, probability0, theta, info_frac, info, info0, info1)

--- a/R/gs_design_npe.R
+++ b/R/gs_design_npe.R
@@ -252,15 +252,15 @@
 #'   upar = (xx %>% filter(bound == "upper"))$z,
 #'   lpar = -(xx %>% filter(bound == "upper"))$z
 #' )
-#'
-gs_design_npe <- function(theta = .1, theta0 = NULL, theta1 = NULL, # 3 theta
-                          info = 1, info0 = NULL, info1 = NULL, # 3 info
-                          info_scale = c("h0_h1_info", "h0_info", "h1_info"),
-                          alpha = 0.025, beta = .1,
-                          upper = gs_b, upar = qnorm(.975),
-                          lower = gs_b, lpar = -Inf,
-                          test_upper = TRUE, test_lower = TRUE, binding = FALSE,
-                          r = 18, tol = 1e-6) {
+gs_design_npe <- function(
+    theta = .1, theta0 = NULL, theta1 = NULL, # 3 theta
+    info = 1, info0 = NULL, info1 = NULL, # 3 info
+    info_scale = c("h0_h1_info", "h0_info", "h1_info"),
+    alpha = 0.025, beta = .1,
+    upper = gs_b, upar = qnorm(.975),
+    lower = gs_b, lpar = -Inf,
+    test_upper = TRUE, test_lower = TRUE, binding = FALSE,
+    r = 18, tol = 1e-6) {
   # --------------------------------------------- #
   #     check & set up parameters                 #
   # --------------------------------------------- #

--- a/R/gs_design_wlr.R
+++ b/R/gs_design_wlr.R
@@ -109,33 +109,34 @@
 #'   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2),
 #'   analysis_time = c(12, 24, 36)
 #' )
-gs_design_wlr <- function(enroll_rate = define_enroll_rate(
-                            duration = c(2, 2, 10),
-                            rate = c(3, 6, 9)
-                          ),
-                          fail_rate = tibble(
-                            stratum = "All", duration = c(3, 100),
-                            fail_rate = log(2) / c(9, 18), hr = c(.9, .6),
-                            dropout_rate = rep(.001, 2)
-                          ),
-                          weight = wlr_weight_fh, approx = "asymptotic",
-                          alpha = 0.025, beta = 0.1, ratio = 1,
-                          info_frac = NULL,
-                          info_scale = c("h0_h1_info", "h0_info", "h1_info"),
-                          analysis_time = 36,
-                          binding = FALSE,
-                          upper = gs_b,
-                          upar = gsDesign(
-                            k = 3, test.type = 1,
-                            n.I = c(.25, .75, 1), sfu = sfLDOF, sfupar = NULL
-                          )$upper$bound,
-                          lower = gs_b,
-                          lpar = c(qnorm(.1), -Inf, -Inf),
-                          test_upper = TRUE,
-                          test_lower = TRUE,
-                          h1_spending = TRUE,
-                          r = 18, tol = 1e-6,
-                          interval = c(.01, 100)) {
+gs_design_wlr <- function(
+    enroll_rate = define_enroll_rate(
+      duration = c(2, 2, 10),
+      rate = c(3, 6, 9)
+    ),
+    fail_rate = tibble(
+      stratum = "All", duration = c(3, 100),
+      fail_rate = log(2) / c(9, 18), hr = c(.9, .6),
+      dropout_rate = rep(.001, 2)
+    ),
+    weight = wlr_weight_fh, approx = "asymptotic",
+    alpha = 0.025, beta = 0.1, ratio = 1,
+    info_frac = NULL,
+    info_scale = c("h0_h1_info", "h0_info", "h1_info"),
+    analysis_time = 36,
+    binding = FALSE,
+    upper = gs_b,
+    upar = gsDesign(
+      k = 3, test.type = 1,
+      n.I = c(.25, .75, 1), sfu = sfLDOF, sfupar = NULL
+    )$upper$bound,
+    lower = gs_b,
+    lpar = c(qnorm(.1), -Inf, -Inf),
+    test_upper = TRUE,
+    test_lower = TRUE,
+    h1_spending = TRUE,
+    r = 18, tol = 1e-6,
+    interval = c(.01, 100)) {
   # --------------------------------------------- #
   #     check input values                        #
   # --------------------------------------------- #
@@ -145,9 +146,7 @@ gs_design_wlr <- function(enroll_rate = define_enroll_rate(
   if (min(analysis_time - dplyr::lag(analysis_time, def = 0)) <= 0) stop(msg)
   msg <- "gs_design_wlr(): info_frac must be a positive
   number or positive increasing sequence on (0, 1] with final value of 1"
-  if (is.null(info_frac)) {
-    info_frac <- 1
-  }
+  if (is.null(info_frac)) info_frac <- 1
   if (!is.vector(info_frac, mode = "numeric")) stop(msg)
   if (min(info_frac - dplyr::lag(info_frac, def = 0)) <= 0) stop(msg)
   if (max(info_frac) != 1) stop(msg)

--- a/R/gs_info_ahr.R
+++ b/R/gs_info_ahr.R
@@ -87,20 +87,21 @@
 #' gs_info_ahr(event = c(30, 40, 50), analysis_time = c(16, 19, 26))
 #' gs_info_ahr(event = c(30, 40, 50), analysis_time = c(14, 20, 24))
 #' }
-gs_info_ahr <- function(enroll_rate = define_enroll_rate(
-                          duration = c(2, 2, 10),
-                          rate = c(3, 6, 9)
-                        ),
-                        fail_rate = define_fail_rate(
-                          duration = c(3, 100),
-                          fail_rate = log(2) / c(9, 18),
-                          hr = c(.9, .6),
-                          dropout_rate = .001
-                        ),
-                        ratio = 1, # experimental:Control randomization ratio
-                        event = NULL, # event at analyses
-                        analysis_time = NULL, # times of analyses
-                        interval = c(.01, 100)) {
+gs_info_ahr <- function(
+    enroll_rate = define_enroll_rate(
+      duration = c(2, 2, 10),
+      rate = c(3, 6, 9)
+    ),
+    fail_rate = define_fail_rate(
+      duration = c(3, 100),
+      fail_rate = log(2) / c(9, 18),
+      hr = c(.9, .6),
+      dropout_rate = .001
+    ),
+    ratio = 1, # experimental:Control randomization ratio
+    event = NULL, # event at analyses
+    analysis_time = NULL, # times of analyses
+    interval = c(.01, 100)) {
   # ----------------------------#
   #    check input values       #
   # ----------------------------#

--- a/R/gs_info_combo.R
+++ b/R/gs_info_combo.R
@@ -31,28 +31,28 @@
 #'   analysis time, sample size, number of events, ahr, delta,
 #'   sigma2, theta, and statistical information.
 #'
-#'
 #' @export
 #'
 #' @examples
 #' gs_info_combo(rho = c(0, 0.5), gamma = c(0.5, 0), analysis_time = c(12, 24))
-gs_info_combo <- function(enroll_rate = define_enroll_rate(
-                            duration = c(2, 2, 10),
-                            rate = c(3, 6, 9)
-                          ),
-                          fail_rate = define_fail_rate(
-                            duration = c(3, 100),
-                            fail_rate = log(2) / c(9, 18),
-                            hr = c(.9, .6),
-                            dropout_rate = .001
-                          ),
-                          ratio = 1,
-                          event = NULL,
-                          analysis_time = NULL,
-                          rho,
-                          gamma,
-                          tau = rep(-1, length(rho)),
-                          approx = "asymptotic") {
+gs_info_combo <- function(
+    enroll_rate = define_enroll_rate(
+      duration = c(2, 2, 10),
+      rate = c(3, 6, 9)
+    ),
+    fail_rate = define_fail_rate(
+      duration = c(3, 100),
+      fail_rate = log(2) / c(9, 18),
+      hr = c(.9, .6),
+      dropout_rate = .001
+    ),
+    ratio = 1,
+    event = NULL,
+    analysis_time = NULL,
+    rho,
+    gamma,
+    tau = rep(-1, length(rho)),
+    approx = "asymptotic") {
   weight <- get_combo_weight(rho, gamma, tau)
 
   info <- lapply(weight, function(x) {

--- a/R/gs_info_rd.R
+++ b/R/gs_info_rd.R
@@ -172,23 +172,23 @@
 #'   ratio = 1,
 #'   weight = "invar_h1"
 #' )
-#'
-gs_info_rd <- function(p_c = tibble::tibble(
-                         stratum = "All",
-                         rate = .2
-                       ),
-                       p_e = tibble::tibble(
-                         stratum = "All",
-                         rate = .15
-                       ),
-                       n = tibble::tibble(
-                         stratum = "All",
-                         n = c(100, 200, 300),
-                         analysis = 1:3
-                       ),
-                       rd0 = 0,
-                       ratio = 1,
-                       weight = c("unstratified", "ss", "invar_h0", "invar_h1")) {
+gs_info_rd <- function(
+    p_c = tibble::tibble(
+      stratum = "All",
+      rate = .2
+    ),
+    p_e = tibble::tibble(
+      stratum = "All",
+      rate = .15
+    ),
+    n = tibble::tibble(
+      stratum = "All",
+      n = c(100, 200, 300),
+      analysis = 1:3
+    ),
+    rd0 = 0,
+    ratio = 1,
+    weight = c("unstratified", "ss", "invar_h0", "invar_h1")) {
   n_analysis <- max(n$analysis)
   weight <- match.arg(weight)
 

--- a/R/gs_info_wlr.R
+++ b/R/gs_info_wlr.R
@@ -75,22 +75,23 @@
 #'   enroll_rate = enroll_rate, fail_rate = fail_rate,
 #'   event = event, analysis_time = analysis_time
 #' )
-gs_info_wlr <- function(enroll_rate = define_enroll_rate(
-                          duration = c(2, 2, 10),
-                          rate = c(3, 6, 9)
-                        ),
-                        fail_rate = define_fail_rate(
-                          duration = c(3, 100),
-                          fail_rate = log(2) / c(9, 18),
-                          hr = c(.9, .6),
-                          dropout_rate = .001
-                        ),
-                        ratio = 1, # Experimental:Control randomization ratio
-                        event = NULL, # event at analyses
-                        analysis_time = NULL, # Times of analyses
-                        weight = wlr_weight_fh,
-                        approx = "asymptotic",
-                        interval = c(.01, 100)) {
+gs_info_wlr <- function(
+    enroll_rate = define_enroll_rate(
+      duration = c(2, 2, 10),
+      rate = c(3, 6, 9)
+    ),
+    fail_rate = define_fail_rate(
+      duration = c(3, 100),
+      fail_rate = log(2) / c(9, 18),
+      hr = c(.9, .6),
+      dropout_rate = .001
+    ),
+    ratio = 1, # Experimental:Control randomization ratio
+    event = NULL, # Event at analyses
+    analysis_time = NULL, # Times of analyses
+    weight = wlr_weight_fh,
+    approx = "asymptotic",
+    interval = c(.01, 100)) {
   if (is.null(analysis_time) && is.null(event)) {
     stop("gs_info_wlr(): One of event and analysis_time must be a numeric value or vector with increasing values!")
   }

--- a/R/gs_power_ahr.R
+++ b/R/gs_power_ahr.R
@@ -242,13 +242,17 @@ gs_power_ahr <- function(
     analysis <- x %>%
       select(analysis, time, event, ahr) %>%
       mutate(n = expected_accrual(time = x$time, enroll_rate = enroll_rate)) %>%
-      left_join(y_h1 %>%
-        select(analysis, info, info_frac, theta) %>%
-        unique()) %>%
-      left_join(y_h0 %>%
-        select(analysis, info, info_frac) %>%
-        dplyr::rename(info0 = info, info_frac0 = info_frac) %>%
-        unique()) %>%
+      left_join(
+        y_h1 %>%
+          select(analysis, info, info_frac, theta) %>%
+          unique()
+      ) %>%
+      left_join(
+        y_h0 %>%
+          select(analysis, info, info_frac) %>%
+          dplyr::rename(info0 = info, info_frac0 = info_frac) %>%
+          unique()
+      ) %>%
       select(analysis, time, n, event, ahr, theta, info, info0, info_frac, info_frac0) %>%
       arrange(analysis)
   )

--- a/R/gs_power_ahr.R
+++ b/R/gs_power_ahr.R
@@ -140,37 +140,38 @@
 #'   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
 #' )
 #' }
-gs_power_ahr <- function(enroll_rate = define_enroll_rate(
-                           duration = c(2, 2, 10),
-                           rate = c(3, 6, 9)
-                         ),
-                         fail_rate = define_fail_rate(
-                           duration = c(3, 100),
-                           fail_rate = log(2) / c(9, 18),
-                           hr = c(.9, .6),
-                           dropout_rate = rep(.001, 2)
-                         ),
-                         event = c(30, 40, 50),
-                         analysis_time = NULL,
-                         upper = gs_b,
-                         upar = gsDesign(
-                           k = length(event),
-                           test.type = 1,
-                           n.I = event,
-                           maxn.IPlan = max(event),
-                           sfu = sfLDOF,
-                           sfupar = NULL
-                         )$upper$bound,
-                         lower = gs_b,
-                         lpar = c(qnorm(.1), rep(-Inf, 2)),
-                         test_lower = TRUE,
-                         test_upper = TRUE,
-                         ratio = 1,
-                         binding = FALSE,
-                         info_scale = c("h0_h1_info", "h0_info", "h1_info"),
-                         r = 18,
-                         tol = 1e-6,
-                         interval = c(.01, 100)) {
+gs_power_ahr <- function(
+    enroll_rate = define_enroll_rate(
+      duration = c(2, 2, 10),
+      rate = c(3, 6, 9)
+    ),
+    fail_rate = define_fail_rate(
+      duration = c(3, 100),
+      fail_rate = log(2) / c(9, 18),
+      hr = c(.9, .6),
+      dropout_rate = rep(.001, 2)
+    ),
+    event = c(30, 40, 50),
+    analysis_time = NULL,
+    upper = gs_b,
+    upar = gsDesign(
+      k = length(event),
+      test.type = 1,
+      n.I = event,
+      maxn.IPlan = max(event),
+      sfu = sfLDOF,
+      sfupar = NULL
+    )$upper$bound,
+    lower = gs_b,
+    lpar = c(qnorm(.1), rep(-Inf, 2)),
+    test_lower = TRUE,
+    test_upper = TRUE,
+    ratio = 1,
+    binding = FALSE,
+    info_scale = c("h0_h1_info", "h0_info", "h1_info"),
+    r = 18,
+    tol = 1e-6,
+    interval = c(.01, 100)) {
   # Get the number of analysis
   n_analysis <- max(length(event), length(analysis_time), na.rm = TRUE)
 

--- a/R/gs_power_combo.R
+++ b/R/gs_power_combo.R
@@ -79,34 +79,35 @@
 #'   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2)
 #' )
 #' }
-gs_power_combo <- function(enroll_rate = define_enroll_rate(
-                             duration = 12,
-                             rate = 500 / 12
-                           ),
-                           fail_rate = define_fail_rate(
-                             duration = c(4, 100),
-                             fail_rate = log(2) / 15,
-                             hr = c(1, .6),
-                             dropout_rate = 0.001
-                           ),
-                           fh_test = rbind(
-                             data.frame(
-                               rho = 0, gamma = 0, tau = -1, test = 1,
-                               analysis = 1:3, analysis_time = c(12, 24, 36)
-                             ),
-                             data.frame(
-                               rho = c(0, 0.5), gamma = 0.5, tau = -1, test = 2:3,
-                               analysis = 3, analysis_time = 36
-                             )
-                           ),
-                           ratio = 1,
-                           binding = FALSE,
-                           upper = gs_b,
-                           upar = c(3, 2, 1),
-                           lower = gs_b,
-                           lpar = c(-1, 0, 1),
-                           algorithm = GenzBretz(maxpts = 1e5, abseps = 1e-5),
-                           ...) {
+gs_power_combo <- function(
+    enroll_rate = define_enroll_rate(
+      duration = 12,
+      rate = 500 / 12
+    ),
+    fail_rate = define_fail_rate(
+      duration = c(4, 100),
+      fail_rate = log(2) / 15,
+      hr = c(1, .6),
+      dropout_rate = 0.001
+    ),
+    fh_test = rbind(
+      data.frame(
+        rho = 0, gamma = 0, tau = -1, test = 1,
+        analysis = 1:3, analysis_time = c(12, 24, 36)
+      ),
+      data.frame(
+        rho = c(0, 0.5), gamma = 0.5, tau = -1, test = 2:3,
+        analysis = 3, analysis_time = 36
+      )
+    ),
+    ratio = 1,
+    binding = FALSE,
+    upper = gs_b,
+    upar = c(3, 2, 1),
+    lower = gs_b,
+    lpar = c(-1, 0, 1),
+    algorithm = GenzBretz(maxpts = 1e5, abseps = 1e-5),
+    ...) {
   # Currently only support user-defined lower and upper bound
   stopifnot(identical(upper, gs_b) | identical(upper, gs_spending_combo))
   stopifnot(identical(lower, gs_b) | identical(lower, gs_spending_combo))

--- a/R/gs_power_rd.R
+++ b/R/gs_power_rd.R
@@ -349,13 +349,17 @@ gs_power_rd <- function(
   suppressMessages(
     analysis <- x %>%
       select(analysis, n, rd, rd0, theta1, theta0) %>%
-      left_join(y_h1 %>%
-        select(analysis, info, info_frac) %>%
-        unique()) %>%
-      left_join(y_h0 %>%
-        select(analysis, info, info_frac) %>%
-        dplyr::rename(info0 = info, info_frac0 = info_frac) %>%
-        unique()) %>%
+      left_join(
+        y_h1 %>%
+          select(analysis, info, info_frac) %>%
+          unique()
+      ) %>%
+      left_join(
+        y_h0 %>%
+          select(analysis, info, info_frac) %>%
+          dplyr::rename(info0 = info, info_frac0 = info_frac) %>%
+          unique()
+      ) %>%
       select(analysis, n, rd, rd0, theta1, theta0, info, info0, info_frac, info_frac0)
   )
 

--- a/R/gs_power_rd.R
+++ b/R/gs_power_rd.R
@@ -239,32 +239,33 @@
 #'   upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
 #'   lpar = c(qnorm(.1), rep(-Inf, 2))
 #' )
-gs_power_rd <- function(p_c = tibble::tibble(
-                          stratum = "All",
-                          rate = .2
-                        ),
-                        p_e = tibble::tibble(
-                          stratum = "All",
-                          rate = .15
-                        ),
-                        n = tibble::tibble(
-                          stratum = "All",
-                          n = c(40, 50, 60),
-                          analysis = 1:3
-                        ),
-                        rd0 = 0,
-                        ratio = 1,
-                        weight = c("unstratified", "ss", "invar_h1", "invar_h0"),
-                        upper = gs_b,
-                        lower = gs_b,
-                        upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
-                        lpar = c(qnorm(.1), rep(-Inf, 2)),
-                        info_scale = c("h0_h1_info", "h0_info", "h1_info"),
-                        binding = FALSE,
-                        test_upper = TRUE,
-                        test_lower = TRUE,
-                        r = 18,
-                        tol = 1e-6) {
+gs_power_rd <- function(
+    p_c = tibble::tibble(
+      stratum = "All",
+      rate = .2
+    ),
+    p_e = tibble::tibble(
+      stratum = "All",
+      rate = .15
+    ),
+    n = tibble::tibble(
+      stratum = "All",
+      n = c(40, 50, 60),
+      analysis = 1:3
+    ),
+    rd0 = 0,
+    ratio = 1,
+    weight = c("unstratified", "ss", "invar_h1", "invar_h0"),
+    upper = gs_b,
+    lower = gs_b,
+    upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, sfupar = NULL)$upper$bound,
+    lpar = c(qnorm(.1), rep(-Inf, 2)),
+    info_scale = c("h0_h1_info", "h0_info", "h1_info"),
+    binding = FALSE,
+    test_upper = TRUE,
+    test_lower = TRUE,
+    r = 18,
+    tol = 1e-6) {
   # get the number of analysis
   n_analysis <- max(n$analysis)
   # get the info_scale

--- a/R/pw_info.R
+++ b/R/pw_info.R
@@ -105,13 +105,13 @@ pw_info <- function(
     enroll_rate = define_enroll_rate(
       duration = c(2, 2, 10),
       rate = c(3, 6, 9)
-      ),
+    ),
     fail_rate = define_fail_rate(
       duration = c(3, 100),
       fail_rate = log(2) / c(9, 18),
       hr = c(.9, .6),
       dropout_rate = .001
-      ),
+    ),
     total_duration = 30,
     ratio = 1) {
   # ----------------------------#

--- a/R/utility_wlr.R
+++ b/R/utility_wlr.R
@@ -62,10 +62,11 @@
 #' )
 #'
 #' gs_create_arm(enroll_rate, fail_rate, ratio = 1)
-gs_create_arm <- function(enroll_rate,
-                          fail_rate,
-                          ratio,
-                          total_time = 1e6) {
+gs_create_arm <- function(
+    enroll_rate,
+    fail_rate,
+    ratio,
+    total_time = 1e6) {
   n_stratum <- length(unique(enroll_rate$stratum))
   if (n_stratum > 1) {
     stop("Only one stratum is supported")
@@ -175,12 +176,13 @@ prob_event.arm <- function(arm, tmin = 0, tmax = arm$total_time) {
 }
 
 #' @noRd
-gs_delta_wlr <- function(arm0,
-                         arm1,
-                         tmax = NULL,
-                         weight = wlr_weight_fh,
-                         approx = "asymptotic",
-                         normalization = FALSE) {
+gs_delta_wlr <- function(
+    arm0,
+    arm1,
+    tmax = NULL,
+    weight = wlr_weight_fh,
+    approx = "asymptotic",
+    normalization = FALSE) {
   if (is.null(tmax)) {
     tmax <- arm0$total_time
   }

--- a/R/utility_wlr.R
+++ b/R/utility_wlr.R
@@ -191,8 +191,7 @@ gs_delta_wlr <- function(
   p0 <- 1 - p1
 
   if (approx == "event_driven") {
-    if (sum(arm0$surv_shape != arm1$surv_shape) > 0 ||
-      length(unique(arm1$surv_scale / arm0$surv_scale)) > 1) {
+    if (sum(arm0$surv_shape != arm1$surv_shape) > 0 || length(unique(arm1$surv_scale / arm0$surv_scale)) > 1) {
       stop("gs_delta_wlr(): Hazard is not proportional over time.", call. = FALSE)
     } else if (any(wlr_weight_fh(seq(0, tmax, length.out = 10), arm0, arm1) != "1")) {
       stop("gs_delta_wlr(): Weight must equal `1` when `approx = 'event_driven'.", call. = FALSE)

--- a/man/fixed_design_ahr.Rd
+++ b/man/fixed_design_ahr.Rd
@@ -40,7 +40,8 @@ Returns a list with a basic summary.
 }
 \examples{
 library(dplyr)
-# example 1: given power and compute sample size
+
+# Example 1: given power and compute sample size
 x <- fixed_design_ahr(
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -53,7 +54,8 @@ x <- fixed_design_ahr(
   study_duration = 36
 )
 x \%>\% summary()
-# example 2: given sample size and compute power
+
+# Example 2: given sample size and compute power
 x <- fixed_design_ahr(
   alpha = .025,
   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/man/fixed_design_fh.Rd
+++ b/man/fixed_design_fh.Rd
@@ -2,10 +2,7 @@
 % Please edit documentation in R/fixed_design_fh.R
 \name{fixed_design_fh}
 \alias{fixed_design_fh}
-\title{Fixed design using Fleming-Harrington method method (Farrington and Manning 1990).
-Computes fixed design sample size (given power) or power (given sample size)
-for Fleming-Harrington method method.
-Returns a list with a basic summary.}
+\title{Fixed design using Fleming-Harrington method}
 \usage{
 fixed_design_fh(
   alpha = 0.025,
@@ -40,14 +37,14 @@ and \code{1 - alpha} otherwise).}
 A table.
 }
 \description{
-Fixed design using Fleming-Harrington method method (Farrington and Manning 1990).
 Computes fixed design sample size (given power) or power (given sample size)
-for Fleming-Harrington method method.
+for Fleming-Harrington method (Farrington and Manning, 1990).
 Returns a list with a basic summary.
 }
 \examples{
 library(dplyr)
-# example 1: given power and compute sample size
+
+# Example 1: given power and compute sample size
 x <- fixed_design_fh(
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -61,7 +58,8 @@ x <- fixed_design_fh(
   rho = 1, gamma = 1
 )
 x \%>\% summary()
-# example 2: given sample size and compute power
+
+# Example 2: given sample size and compute power
 x <- fixed_design_fh(
   alpha = .025,
   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/man/fixed_design_lf.Rd
+++ b/man/fixed_design_lf.Rd
@@ -2,10 +2,7 @@
 % Please edit documentation in R/fixed_design_lf.R
 \name{fixed_design_lf}
 \alias{fixed_design_lf}
-\title{Fixed design using Lachin-Foulkes method (Farrington and Manning 1990).
-Computes fixed design sample size (given power) or power (given sample size)
-for Lachin-Foulkes method method.
-Returns a list with a basic summary.}
+\title{Fixed design using Lachin-Foulkes method}
 \usage{
 fixed_design_lf(
   alpha = 0.025,
@@ -34,14 +31,14 @@ and \code{1 - alpha} otherwise).}
 A table.
 }
 \description{
-Fixed design using Lachin-Foulkes method (Farrington and Manning 1990).
 Computes fixed design sample size (given power) or power (given sample size)
-for Lachin-Foulkes method method.
+for Lachin-Foulkes method (Lachin and Foulkes, 1986).
 Returns a list with a basic summary.
 }
 \examples{
 library(dplyr)
-# example 1: given power and compute sample size
+
+# Example 1: given power and compute sample size
 x <- fixed_design_lf(
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -54,7 +51,8 @@ x <- fixed_design_lf(
   study_duration = 36
 )
 x \%>\% summary()
-# example 2: given sample size and compute power
+
+# Example 2: given sample size and compute power
 x <- fixed_design_fh(
   alpha = .025,
   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/man/fixed_design_maxcombo.Rd
+++ b/man/fixed_design_maxcombo.Rd
@@ -2,10 +2,7 @@
 % Please edit documentation in R/fixed_design_maxcombo.R
 \name{fixed_design_maxcombo}
 \alias{fixed_design_maxcombo}
-\title{Fixed design using maxcombo method.
-Computes fixed design sample size (given power) or power (given sample size)
-for maxcombo method.
-Returns a list with a basic summary.}
+\title{Fixed design using MaxCombo method}
 \usage{
 fixed_design_maxcombo(
   alpha = 0.025,
@@ -43,14 +40,14 @@ and \code{1 - alpha} otherwise).}
 A table.
 }
 \description{
-Fixed design using maxcombo method.
 Computes fixed design sample size (given power) or power (given sample size)
-for maxcombo method.
+for MaxCombo method.
 Returns a list with a basic summary.
 }
 \examples{
 library(dplyr)
-# example 1: given power and compute sample size
+
+# Example 1: given power and compute sample size
 x <- fixed_design_maxcombo(
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -64,7 +61,8 @@ x <- fixed_design_maxcombo(
   rho = c(0, 0.5), gamma = c(0, 0), tau = c(-1, -1)
 )
 x \%>\% summary()
-# example 2: given sample size and compute power
+
+# Example 2: given sample size and compute power
 x <- fixed_design_maxcombo(
   alpha = .025,
   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/man/fixed_design_mb.Rd
+++ b/man/fixed_design_mb.Rd
@@ -2,12 +2,7 @@
 % Please edit documentation in R/fixed_design_mb.R
 \name{fixed_design_mb}
 \alias{fixed_design_mb}
-\title{Computes fixed design sample size for Magirr-Burman method.
-Returns a tibble with a basic summary.
-Fixed design using Magirr-Burman method.
-Computes fixed design sample size (given power) or power (given sample size)
-for Magirr-Burman method.
-Returns a list with a basic summary.}
+\title{Fixed design using Magirr-Burman method}
 \usage{
 fixed_design_mb(
   alpha = 0.025,
@@ -39,16 +34,14 @@ and \code{1 - alpha} otherwise).}
 A table.
 }
 \description{
-Computes fixed design sample size for Magirr-Burman method.
-Returns a tibble with a basic summary.
-Fixed design using Magirr-Burman method.
 Computes fixed design sample size (given power) or power (given sample size)
 for Magirr-Burman method.
 Returns a list with a basic summary.
 }
 \examples{
 library(dplyr)
-# example 1: given power and compute sample size
+
+# Example 1: given power and compute sample size
 x <- fixed_design_mb(
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -62,7 +55,8 @@ x <- fixed_design_mb(
   tau = 4
 )
 x \%>\% summary()
-# example 2: given sample size and compute power
+
+# Example 2: given sample size and compute power
 x <- fixed_design_mb(
   alpha = .025,
   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/man/fixed_design_milestone.Rd
+++ b/man/fixed_design_milestone.Rd
@@ -2,10 +2,7 @@
 % Please edit documentation in R/fixed_design_milestone.R
 \name{fixed_design_milestone}
 \alias{fixed_design_milestone}
-\title{Fixed design using milestone method (Yung and Liu 2020).
-Computes fixed design sample size (given power) or power (given sample size)
-for milestone method.
-Returns a list with a basic summary.}
+\title{Fixed design using milestone method}
 \usage{
 fixed_design_milestone(
   alpha = 0.025,
@@ -37,14 +34,14 @@ and \code{1 - alpha} otherwise).}
 A table.
 }
 \description{
-Fixed design using milestone method (Yung and Liu 2020).
 Computes fixed design sample size (given power) or power (given sample size)
-for milestone method.
+for milestone method (Yung and Liu, 2020).
 Returns a list with a basic summary.
 }
 \examples{
 library(dplyr)
-# example 1: given power and compute sample size
+
+# Example 1: given power and compute sample size
 x <- fixed_design_milestone(
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -58,7 +55,8 @@ x <- fixed_design_milestone(
   tau = 18
 )
 x \%>\% summary()
-# example 2: given sample size and compute power
+
+# Example 2: given sample size and compute power
 x <- fixed_design_milestone(
   alpha = .025,
   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/man/fixed_design_rd.Rd
+++ b/man/fixed_design_rd.Rd
@@ -2,10 +2,7 @@
 % Please edit documentation in R/fixed_design_rd.R
 \name{fixed_design_rd}
 \alias{fixed_design_rd}
-\title{Fixed design for binary outcome measuring in risk difference (Mehrotra and Railkar 2000).
-Computes fixed design sample size (given power) or power (given sample size)
-for binary outcome measuring in risk difference.
-Returns a list with a basic summary.}
+\title{Fixed design for binary outcome measuring in risk difference}
 \usage{
 fixed_design_rd(
   alpha = 0.025,
@@ -38,19 +35,20 @@ computed to achieve the targeted power}
 A table.
 }
 \description{
-Fixed design for binary outcome measuring in risk difference (Mehrotra and Railkar 2000).
 Computes fixed design sample size (given power) or power (given sample size)
-for binary outcome measuring in risk difference.
+for binary outcome measuring in risk difference (Mehrotra and Railkar, 2000).
 Returns a list with a basic summary.
 }
 \examples{
 library(dplyr)
-# example 1: given power and compute sample size
+
+# Example 1: given power and compute sample size
 x <- fixed_design_rd(
   alpha = 0.025, power = 0.9, p_c = .15, p_e = .1,
   rd0 = 0, ratio = 1)
 x \%>\% summary()
-# example 2: given sample size and compute power
+
+# Example 2: given sample size and compute power
 x <- fixed_design_rd(
   alpha = 0.025, power = NULL, p_c = .15, p_e = .1,
   rd0 = 0, n = 2000, ratio = 1)

--- a/man/fixed_design_rd.Rd
+++ b/man/fixed_design_rd.Rd
@@ -45,12 +45,14 @@ library(dplyr)
 # Example 1: given power and compute sample size
 x <- fixed_design_rd(
   alpha = 0.025, power = 0.9, p_c = .15, p_e = .1,
-  rd0 = 0, ratio = 1)
+  rd0 = 0, ratio = 1
+)
 x \%>\% summary()
 
 # Example 2: given sample size and compute power
 x <- fixed_design_rd(
   alpha = 0.025, power = NULL, p_c = .15, p_e = .1,
-  rd0 = 0, n = 2000, ratio = 1)
+  rd0 = 0, n = 2000, ratio = 1
+)
 x \%>\% summary()
 }

--- a/man/fixed_design_rmst.Rd
+++ b/man/fixed_design_rmst.Rd
@@ -2,10 +2,7 @@
 % Please edit documentation in R/fixed_design_rmst.R
 \name{fixed_design_rmst}
 \alias{fixed_design_rmst}
-\title{Fixed design using RMST method (Yung and Liu 2020).
-Computes fixed design sample size (given power) or power (given sample size)
-for RMST methods.
-Returns a list with a basic summary.}
+\title{Fixed design using RMST method}
 \usage{
 fixed_design_rmst(
   alpha = 0.025,
@@ -37,14 +34,14 @@ and \code{1 - alpha} otherwise).}
 A table.
 }
 \description{
-Fixed design using RMST method (Yung and Liu 2020).
 Computes fixed design sample size (given power) or power (given sample size)
-for RMST methods.
+for RMST methods (Yung and Liu, 2020).
 Returns a list with a basic summary.
 }
 \examples{
 library(dplyr)
-# example 1: given power and compute sample size
+
+# Example 1: given power and compute sample size
 x <- fixed_design_rmst(
   alpha = .025, power = .9,
   enroll_rate = define_enroll_rate(duration = 18, rate = 1),
@@ -58,7 +55,8 @@ x <- fixed_design_rmst(
   tau = 18
 )
 x \%>\% summary()
-# example 2: given sample size and compute power
+
+# Example 2: given sample size and compute power
 x <- fixed_design_rmst(
   alpha = .025,
   enroll_rate = define_enroll_rate(duration = 18, rate = 20),

--- a/man/gs_design_npe.Rd
+++ b/man/gs_design_npe.Rd
@@ -277,7 +277,6 @@ gs_power_npe(
   upar = (xx \%>\% filter(bound == "upper"))$z,
   lpar = -(xx \%>\% filter(bound == "upper"))$z
 )
-
 }
 \author{
 Keaven Anderson \email{keaven_anderson@merck.com}

--- a/man/gs_info_rd.Rd
+++ b/man/gs_info_rd.Rd
@@ -174,5 +174,4 @@ gs_info_rd(
   ratio = 1,
   weight = "invar_h1"
 )
-
 }

--- a/tests/testthat/test-double_programming_ppwe.R
+++ b/tests/testthat/test-double_programming_ppwe.R
@@ -1,6 +1,10 @@
-test_ppwe <- function(x = 0:20,
-                      failRates = tibble::tibble(duration = c(3, 100), rate = log(2) / c(9, 18)),
-                      lower.tail = FALSE) {
+test_ppwe <- function(
+    x = 0:20,
+    failRates = tibble::tibble(
+      duration = c(3, 100),
+      rate = log(2) / c(9, 18)
+    ),
+    lower.tail = FALSE) {
   boundary <- cumsum(failRates$duration)
   rate <- failRates$rate
   xvals <- unique(c(x, boundary))
@@ -47,12 +51,13 @@ test_ppwe <- function(x = 0:20,
 
 # Double programming of ppwe when there are 3 steps of failure rates.
 # The method is a simple extention of test_ppwe.
-test_2_ppwe <- function(x = 0:20,
-                        failRates = tibble::tibble(
-                          duration = c(3, 20, 100),
-                          rate = log(2) / c(9, 12, 18)
-                        ),
-                        lower.tail = FALSE) {
+test_2_ppwe <- function(
+    x = 0:20,
+    failRates = tibble::tibble(
+      duration = c(3, 20, 100),
+      rate = log(2) / c(9, 12, 18)
+    ),
+    lower.tail = FALSE) {
   boundary <- cumsum(failRates$duration)
   rate <- failRates$rate
   xvals <- unique(c(x, boundary))
@@ -81,8 +86,6 @@ test_2_ppwe <- function(x = 0:20,
     return(surv[ind])
   }
 }
-
-
 
 testthat::test_that("ppwe is incorrect when there are 2-step fail rates", {
   testthat::expect_equal(
@@ -116,7 +119,6 @@ testthat::test_that("ppwe is incorrect if varable x is longer than the max durat
   )
 })
 
-
 testthat::test_that("ppwe is incorrect when there are 3-step fail rates", {
   testthat::expect_equal(
     ppwe(
@@ -133,10 +135,7 @@ testthat::test_that("ppwe is incorrect when there are 3-step fail rates", {
   )
 })
 
-
-## add the following test case
-
-
+# Add the following test case
 
 testthat::test_that("ppwe fail to identify a non-numerical input", {
   x <- c(0:20, "NA")
@@ -153,7 +152,6 @@ testthat::test_that("ppwe fail to identify a negative input", {
     "gsDesign2: x in `ppwe()` must be a strictly increasing non-negative numeric vector"
   ))
 })
-
 
 testthat::test_that("ppwe fail to identify a non-increasing input", {
   x <- 20:1

--- a/tests/testthat/test-double_programming_ppwe.R
+++ b/tests/testthat/test-double_programming_ppwe.R
@@ -69,11 +69,9 @@ test_2_ppwe <- function(
     } else if (val <= boundary[2]) {
       H[t] <- boundary[1] * rate[1] + (val - boundary[1]) * rate[2]
     } else if (val <= boundary[3]) {
-      H[t] <- boundary[1] * rate[1] + (boundary[2] - boundary[1]) * rate[2] + (val -
-        boundary[3]) * rate[3]
+      H[t] <- boundary[1] * rate[1] + (boundary[2] - boundary[1]) * rate[2] + (val - boundary[3]) * rate[3]
     } else {
-      H[t] <- boundary[1] * rate[1] + (boundary[2] - boundary[1]) * rate[2] + (boundary[3] -
-        boundary[2]) * rate[3]
+      H[t] <- boundary[1] * rate[1] + (boundary[2] - boundary[1]) * rate[2] + (boundary[3] - boundary[2]) * rate[3]
     }
   }
   surv <- exp(-H)

--- a/tests/testthat/test-independent-expected_accrual.R
+++ b/tests/testthat/test-independent-expected_accrual.R
@@ -15,15 +15,13 @@ test_eAccrual <- function(x, enroll_rate) {
         (boundary[2] - boundary[1]) * rate[2] + (val - boundary[2]) * rate[3]
     } else {
       eAc2[t] <- boundary[1] * rate[1] +
-        (boundary[2] - boundary[1]) * rate[2] + (boundary[3] - boundary[2]) *
-          rate[3]
+        (boundary[2] - boundary[1]) * rate[2] + (boundary[3] - boundary[2]) * rate[3]
     }
   }
 
   ind <- !is.na(match(xvals, x))
   return(eAc2[ind])
 }
-
 
 testthat::test_that("expect_accrua doesn't match with the double programming e_Acurral function", {
   testthat::expect_equal(
@@ -44,7 +42,6 @@ testthat::test_that("expect_accrua doesn't match with the double programming e_A
   )
 })
 
-
 testthat::test_that("expect_accrual fail to identify a non-numerical input", {
   x <- c(0:20, "NA")
   expect_error(expect_message(
@@ -61,7 +58,6 @@ testthat::test_that("expect_accrual fail to identify a negative input", {
   ))
 })
 
-
 testthat::test_that("expect_accrual fail to identify a non-increasing input", {
   x <- 20:1
   expect_error(expect_message(
@@ -70,8 +66,7 @@ testthat::test_that("expect_accrual fail to identify a non-increasing input", {
   ))
 })
 
-
-## add test cases for stratified design
+# Add test cases for stratified design
 testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
   x <- expected_accrual(
     time = 40,

--- a/tests/testthat/test-independent-expected_event.R
+++ b/tests/testthat/test-independent-expected_event.R
@@ -129,46 +129,50 @@ testthat::test_that(
 )
 
 ### test2:with mutiple failrates, long FU
-testthat::test_that("expected events is different from double-programmed vs expected_event,
-                    with mutiple failrates, long FU", {
-  total_duration <- 80
-  testthat::expect_equal(
-    test_Event(enroll_rate, fail_rate, total_duration),
-    expected_event(
-      enroll_rate,
-      fail_rate,
-      total_duration,
-      simple
+testthat::test_that(
+  "expected events is different from double-programmed vs expected_event, with mutiple failrates, long FU",
+  {
+    total_duration <- 80
+    testthat::expect_equal(
+      test_Event(enroll_rate, fail_rate, total_duration),
+      expected_event(
+        enroll_rate,
+        fail_rate,
+        total_duration,
+        simple
+      )
     )
-  )
-})
+  }
+)
 
 ### test3:with mutiple failrates and with multiple enrollment duration
-testthat::test_that("expected events is different from double-programmed vs expected_event,
-                    with mutiple enrollment duration", {
-  enrollRates <- define_enroll_rate(
-    duration = c(50, 10),
-    rate = c(10, 5)
-  )
-  failRates <- define_fail_rate(
-    duration = c(10, 20, 10),
-    fail_rate = log(2) / c(5, 10, 5),
-    dropout_rate = c(0.1, 0.2, 0),
-    hr = 1
-  )
-
-  fail_rate$failRate <- fail_rate$fail_rate
-  fail_rate$dropoutRate <- fail_rate$dropout_rate
-  failRates <- fail_rate
-
-  total_duration <- 80
-  testthat::expect_equal(
-    test_Event(enroll_rate, fail_rate, total_duration),
-    expected_event(
-      enroll_rate,
-      fail_rate,
-      total_duration,
-      simple
+testthat::test_that(
+  "expected events is different from double-programmed vs expected_event, with mutiple enrollment duration",
+  {
+    enrollRates <- define_enroll_rate(
+      duration = c(50, 10),
+      rate = c(10, 5)
     )
-  )
-})
+    failRates <- define_fail_rate(
+      duration = c(10, 20, 10),
+      fail_rate = log(2) / c(5, 10, 5),
+      dropout_rate = c(0.1, 0.2, 0),
+      hr = 1
+    )
+
+    fail_rate$failRate <- fail_rate$fail_rate
+    fail_rate$dropoutRate <- fail_rate$dropout_rate
+    failRates <- fail_rate
+
+    total_duration <- 80
+    testthat::expect_equal(
+      test_Event(enroll_rate, fail_rate, total_duration),
+      expected_event(
+        enroll_rate,
+        fail_rate,
+        total_duration,
+        simple
+      )
+    )
+  }
+)

--- a/tests/testthat/test-independent-expected_event.R
+++ b/tests/testthat/test-independent-expected_event.R
@@ -42,7 +42,7 @@ test_that("data frame returned from expected_event not as expected", {
   testthat::expect_equal(xx, expected)
 })
 
-# double programming tests
+# Double programming tests
 nEvent <- function(followup) {
   failduration <- failRates$duration
   failtime <- cumsum(failduration)

--- a/tests/testthat/test-independent-wlr_weight.R
+++ b/tests/testthat/test-independent-wlr_weight.R
@@ -20,9 +20,11 @@ test_that("test wlr_weight_n", {
   arm0 <- arm$arm0
   arm1 <- arm$arm1
 
+  prob0 <- gsDesign2:::prob_risk(arm0, analysis_time, total_time)
+  prob1 <- gsDesign2:::prob_risk(arm1, analysis_time, total_time)
+
   expect_equal(
     gsDesign2::wlr_weight_n(x = analysis_time, arm0 = arm0, arm1 = arm1, power = 2),
-    (2 * (0.5 * gsDesign2:::prob_risk(arm0, analysis_time, total_time) +
-      0.5 * gsDesign2:::prob_risk(arm1, analysis_time, total_time)))^2
+    (2 * (0.5 * prob0 + 0.5 * prob1))^2
   )
 })

--- a/tests/testthat/test-independent_test_wlr_weight.R
+++ b/tests/testthat/test-independent_test_wlr_weight.R
@@ -20,12 +20,14 @@ test_that("Validate the function based on simple calculation", {
 
   # Calculate theoretical results
   # Tarone-Ware weight is the (N at risk)^factor
-  wlrn <- (npsurvSS::psurv(1:36, arm0, lower.tail = FALSE) *
-    npsurvSS::ploss(1:36, arm0, lower.tail = FALSE) *
-    npsurvSS::paccr(pmin(arm0$accr_time, 36 - 1:36), arm0) +
-    npsurvSS::psurv(1:36, arm1, lower.tail = FALSE) *
-      npsurvSS::ploss(1:36, arm1, lower.tail = FALSE) *
-      npsurvSS::paccr(pmin(arm1$accr_time, 36 - 1:36), arm1) * 2)^0.666
+  wlrn <- (
+    npsurvSS::psurv(1:36, arm0, lower.tail = FALSE) *
+      npsurvSS::ploss(1:36, arm0, lower.tail = FALSE) *
+      npsurvSS::paccr(pmin(arm0$accr_time, 36 - 1:36), arm0) +
+      npsurvSS::psurv(1:36, arm1, lower.tail = FALSE) *
+        npsurvSS::ploss(1:36, arm1, lower.tail = FALSE) *
+        npsurvSS::paccr(pmin(arm1$accr_time, 36 - 1:36), arm1) * 2
+  )^0.666
 
   # Calculate FH weights
   survprob <- 1 - npsurvSS::psurv(1:36, arm0) / 3 - npsurvSS::psurv(1:36, arm1) * 2 / 3

--- a/tests/testthat/test-independent_test_wlr_weight.R
+++ b/tests/testthat/test-independent_test_wlr_weight.R
@@ -18,9 +18,8 @@ test_that("Validate the function based on simple calculation", {
   arm0 <- gs_arm[["arm0"]]
   arm1 <- gs_arm[["arm1"]]
 
-  # calculate theoretical results
+  # Calculate theoretical results
   # Tarone-Ware weight is the (N at risk)^factor
-
   wlrn <- (npsurvSS::psurv(1:36, arm0, lower.tail = FALSE) *
     npsurvSS::ploss(1:36, arm0, lower.tail = FALSE) *
     npsurvSS::paccr(pmin(arm0$accr_time, 36 - 1:36), arm0) +
@@ -28,9 +27,7 @@ test_that("Validate the function based on simple calculation", {
       npsurvSS::ploss(1:36, arm1, lower.tail = FALSE) *
       npsurvSS::paccr(pmin(arm1$accr_time, 36 - 1:36), arm1) * 2)^0.666
 
-
-
-  # calculate FH weights
+  # Calculate FH weights
   survprob <- 1 - npsurvSS::psurv(1:36, arm0) / 3 - npsurvSS::psurv(1:36, arm1) * 2 / 3
   fhwei <- survprob^0.666 * (1 - survprob)^0.888
 
@@ -40,8 +37,6 @@ test_that("Validate the function based on simple calculation", {
   FH00wt <- gsDesign2::wlr_weight_1(x = 1:36, arm0, arm1)
   # wlr_weight_n()
   pckwlrn <- gsDesign2::wlr_weight_n(x = 1:36, arm0, arm1, power = 0.666)
-
-
 
   expect_equal(object = as.numeric(pckwlrn), expected = wlrn, tolerance = 0.0001)
   expect_equal(object = as.numeric(fhwei), expected = pckfhwei, tolerance = 0.0001)

--- a/vignettes/articles/story-design-with-spending.Rmd
+++ b/vignettes/articles/story-design-with-spending.Rmd
@@ -149,8 +149,13 @@ target_power <- 0.9
 If we were using a fixed design, we would approximate the sample size as follows:
 
 ```{r}
-minx <- ((qnorm(.025) / sqrt(zz$info0[n_analysis]) +
-  qnorm(1 - target_power) / sqrt(zz$info[n_analysis])) / zz$theta[n_analysis])^2
+minx <- (
+  (
+    qnorm(.025) / sqrt(zz$info0[n_analysis]) +
+      qnorm(1 - target_power) / sqrt(zz$info[n_analysis])
+  ) /
+    zz$theta[n_analysis]
+)^2
 minx
 ```
 

--- a/vignettes/articles/story-risk-difference.Rmd
+++ b/vignettes/articles/story-risk-difference.Rmd
@@ -1161,8 +1161,10 @@ x <- x %>%
           weight_invar_H0^2 * p_pool * (1 - p_pool) / n_e
       ),
     info0_invar_H1 = 1 /
-      sum(weight_invar_H1^2 * p_pool * (1 - p_pool) /
-        n_c + weight_invar_H1^2 * p_pool * (1 - p_pool) / n_e),
+      sum(
+        weight_invar_H1^2 * p_pool * (1 - p_pool) /
+          n_c + weight_invar_H1^2 * p_pool * (1 - p_pool) / n_e
+      ),
     info0_ss = 1 /
       sum(
         weight_ss^2 * p_pool * (1 - p_pool) / n_c +


### PR DESCRIPTION
This PR improves the documentation of the fixed design functions:

- Split title and description fields so the title is not too long when displayed on the reference page on the pkgdown site.
- Add blank lines between roxygen2 fields.
- Add blank lines between logical blocks and use sentence case for comments in code examples.

Also updates the indentation details of some files to pass the code linting workflow using the (updated) lintr 3.1.0.