### PR TITLE
Replace expect() with expect_equal()

### DIFF
--- a/tests/testthat/test-developer-expected_event.R
+++ b/tests/testthat/test-developer-expected_event.R
@@ -25,6 +25,6 @@ test_that("expected event vs gsDesign", {
     enroll_rate, fail_rate, total_duration,
     simple = TRUE
   )
-  expect(x1, x2)
-  expect(x2, x3)
+  expect_equal(x1, x2)
+  expect_equal(x2, x3)
 })

--- a/tests/testthat/test-independent-fixed_design.R
+++ b/tests/testthat/test-independent-fixed_design.R
@@ -31,7 +31,7 @@ test_that("AHR", {
     study_duration = study_duration, ratio = ratio
   )
 
-  expect(y$analysis$power, 0.9)
+  expect_equal(y$analysis$power, 0.9)
 })
 
 test_that("FH", {
@@ -49,7 +49,7 @@ test_that("FH", {
     rho = 0.5, gamma = 0.5
   )
 
-  expect(y$analysis$power, 0.9)
+  expect_equal(y$analysis$power, 0.9)
 })
 
 test_that("MB", {
@@ -67,7 +67,7 @@ test_that("MB", {
     tau = 8
   )
 
-  expect(y$analysis$power, 0.9)
+  expect_equal(y$analysis$power, 0.9)
 })
 
 test_that("LF", {
@@ -83,7 +83,7 @@ test_that("LF", {
     study_duration = study_duration, ratio = ratio
   )
 
-  expect(y$analysis$power, 0.9)
+  expect_equal(y$analysis$power, 0.9)
 })
 
 test_that("MaxCombo", {
@@ -105,7 +105,7 @@ test_that("MaxCombo", {
     tau = c(-1, 4, 6)
   )
 
-  expect(y$analysis$power, 0.9)
+  expect_equal(y$analysis$power, 0.9)
 })
 
 test_that("RMST", {
@@ -123,7 +123,7 @@ test_that("RMST", {
     tau = 18
   )
 
-  expect(y$analysis$power, 0.9)
+  expect_equal(y$analysis$power, 0.9)
 })
 
 test_that("RD", {
@@ -137,5 +137,5 @@ test_that("RD", {
     p_c = .15, p_e = .1, rd0 = 0, ratio = ratio
   )
 
-  expect(y$analysis$power, 0.9)
+  expect_equal(y$analysis$power, 0.9)
 })


### PR DESCRIPTION
I noticed that some tests used `expect()` when I believe they should be `expect_equal()`. The function signature of `expect()` requires the first argument to be the test, and the second is the error message to print if the test returns `FALSE`.


```R
library("testthat")
args(expect)
## function (ok, failure_message, info = NULL, srcref = NULL, trace = NULL, 
##     trace_env = caller_env()) 
## NULL

expect(1, 2)
expect(1 == 2, "they aren't equal")
## Error: they aren't equal
```

When I run the tests locally, 2 of the tests fail consistently. What is the acceptable tolerance?

```R
── Failed tests ─────────────────────────────────────────────────────────────────────────
Failure (test-independent-fixed_design.R:108:3): MaxCombo
y$analysis$power not equal to 0.9.
1/1 mismatches
[1] 0.9 - 0.9 == -2.32e-07

Failure (test-independent-fixed_design.R:140:3): RD
y$analysis$power not equal to 0.9.
1/1 mismatches
[1] 0.902 - 0.9 == 0.00163

[ FAIL 2 | WARN 2 | SKIP 0 | PASS 470 ]
```