### PR TITLE
Update tests to run via `devtools::test()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.0
+Version: 1.1.0.1
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/R/fixed_design_rd.R
+++ b/R/fixed_design_rd.R
@@ -99,7 +99,8 @@ fixed_design_rd <- function(
       alpha = alpha, beta = 1 - power, ratio = ratio,
       upper = gs_b, upar = qnorm(1 - alpha),
       lower = gs_b, lpar = -Inf,
-      rd0 = rd0, weight = "unstratified"
+      rd0 = rd0, weight = "unstratified",
+      h1_spending = FALSE
     )
   }
   # get the output of MaxCombo

--- a/tests/testthat/test-independent-gs_power_ahr.R
+++ b/tests/testthat/test-independent-gs_power_ahr.R
@@ -1,5 +1,7 @@
 # Test 1: compare with gsDesign under proportional hazard ####
 
+library(gsDesign)
+
 x <- gsSurv(
   k = 2,
   test.type = 1,


### PR DESCRIPTION
The tests pass when executed via `R CMD check`, but I noticed problems when running via `devtools::test()`

First, the test file `test-independent-gs_power_ahr.R` calls functions from {gsDesign} but doesn't load it. `devtools::test()` doesn't run `tests/testthat.R`, so all required libraries need to be loaded in the test file.

```R
devtools::test(filter = "ahr")
ℹ Testing gsDesign2
✔ | F W  S  OK | Context
✔ |          2 | developer-ahr [2.0s]
✔ |         76 | developer-gs_design_ahr [17.9s]
✔ |         56 | developer-gs_power_ahr [23.1s]
✔ |          4 | independent-gs_design_ahr [1.4s]
✔ |          7 | independent-gs_info_ahr [5.1s]
✖ | 1        0 | independent-gs_power_ahr
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Error (test-independent-gs_power_ahr.R:3:1): (code run outside of `test_that()`)
Error in `gsSurv(k = 2, test.type = 1, alpha = 0.025, beta = 0.2, astar = 0, 
    timing = 0.7, sfu = sfLDOF, sfupar = c(0), sfl = sfLDOF, 
    sflpar = c(0), lambdaC = log(2)/9, hr = 0.65, hr0 = 1, eta = 0.001, 
    gamma = c(6, 12, 18, 24), R = c(2, 2, 2, 6), S = NULL, T = NULL, 
    minfup = NULL, ratio = 1)`: could not find function "gsSurv"
──────────────────────────────────────────────────

══ Results ═══════════════════════════════════════
Duration: 50.2 s

── Failed tests ──────────────────────────────────
Error (test-independent-gs_power_ahr.R:3:1): (code run outside of `test_that()`)
Error in `gsSurv(k = 2, test.type = 1, alpha = 0.025, beta = 0.2, astar = 0, 
    timing = 0.7, sfu = sfLDOF, sfupar = c(0), sfl = sfLDOF, 
    sflpar = c(0), lambdaC = log(2)/9, hr = 0.65, hr0 = 1, eta = 0.001, 
    gamma = c(6, 12, 18, 24), R = c(2, 2, 2, 6), S = NULL, T = NULL, 
    minfup = NULL, ratio = 1)`: could not find function "gsSurv"

[ FAIL 1 | WARN 0 | SKIP 0 | PASS 145 ]
```

Second, I noticed the following warnings:

```R
devtools::test(filter = "fixed_design")
ℹ Testing gsDesign2
✔ | F W  S  OK | Context
✔ |   2      7 | independent-fixed_design [4.0s]
──────────────────────────────────────────────────
Warning (test-independent-fixed_design.R:130:3): RD
Unknown or uninitialised column: `theta`.
Backtrace:
    ▆
 1. └─gsDesign2::fixed_design_rd(...) at test-independent-fixed_design.R:130:3
 2.   └─gsDesign2::gs_design_rd(...) at gsDesign2/R/fixed_design_rd.R:96:5
 3.     ├─x$theta at gsDesign2/R/gs_design_rd.R:207:5
 4.     └─tibble:::`$.tbl_df`(x, theta) at gsDesign2/R/gs_design_rd.R:207:5

Warning (test-independent-fixed_design.R:130:3): RD
Unknown or uninitialised column: `info`.
Backtrace:
    ▆
 1. └─gsDesign2::fixed_design_rd(...) at test-independent-fixed_design.R:130:3
 2.   └─gsDesign2::gs_design_rd(...) at gsDesign2/R/fixed_design_rd.R:96:5
 3.     ├─x$info at gsDesign2/R/gs_design_rd.R:208:5
 4.     └─tibble:::`$.tbl_df`(x, info) at gsDesign2/R/gs_design_rd.R:208:5
──────────────────────────────────────────────────

══ Results ═══════════════════════════════════════
Duration: 4.5 s

[ FAIL 0 | WARN 2 | SKIP 0 | PASS 7 ]
```

These are caused by `fixed_design_rd()` calling `gs_design_rd()` with the default value of `h1_spending = TRUE`. I removed the warnings by setting `h1_spending = FALSE`. Though I don't know what the consequences were that `gs_design_rd()` was getting these empty values for `theta` and `info`. I also don't know why `theta` and `info` are not being returned by the earlier call to `gs_info_rd()`.

https://github.com/Merck/gsDesign2/blob/50067c424ab7dca4579ae895edc5de2bdcd9546e/R/gs_design_rd.R#L206-L212

 