### PR TITLE
Increase convergence tolerance for root finding

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.0.1
+Version: 1.1.0.2
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/R/expected_time.R
+++ b/R/expected_time.R
@@ -119,7 +119,7 @@ expected_time <- function(
   #       uniroot AHR()         #
   #    over total_duration      #
   # ----------------------------#
-  res <- try(uniroot(event_diff, interval))
+  res <- try(uniroot(event_diff, interval, tol = 1e-3))
 
   if (inherits(res, "try-error")) {
     stop("expected_time(): solution not found!")

--- a/tests/testthat/old_function/eEvents_.R
+++ b/tests/testthat/old_function/eEvents_.R
@@ -91,7 +91,8 @@ tEvents_ <- function(enrollRates = tibble::tibble(
       function(x) {
         AHR(enrollRates, failRates, x, ratio)$Events - targetEvents
       },
-      interval
+      interval,
+      tol = 1e-3
     )
   )
   if (inherits(res, "try-error")) {

--- a/tests/testthat/old_function/gs_design_ahr_.R
+++ b/tests/testthat/old_function/gs_design_ahr_.R
@@ -156,7 +156,7 @@ gs_design_ahr_ <- function(enrollRates = tibble::tibble(
                            test_upper = TRUE,
                            test_lower = TRUE,
                            r = 18,
-                           tol = 1e-6) {
+                           tol = 1e-3) {
   ################################################################################
   # Check input values
   msg <- "analysisTimes must be a positive number or positive increasing sequence"

--- a/tests/testthat/old_function/gs_design_npe_.R
+++ b/tests/testthat/old_function/gs_design_npe_.R
@@ -198,7 +198,7 @@ gs_design_npe_ <- function(theta = .1, theta1 = NULL, info = 1, info0 = NULL, in
                            alpha = 0.025, beta = .1, binding = FALSE,
                            upper = gs_b, lower = gs_b, upar = qnorm(.975), lpar = -Inf,
                            test_upper = TRUE, test_lower = TRUE,
-                           r = 18, tol = 1e-6) {
+                           r = 18, tol = 1e-3) {
   #######################################################################################
   # WRITE INPUT CHECK TESTS AND RETURN APPROPRIATE ERROR MESSAGES
   # info should be a scalar or vector of positive increasing values


### PR DESCRIPTION
I implemented the idea of increasing the convergence tolerance. This PR is a draft because currently I don't think this is worth pursuing. The median speed improvement on my machine is consistently about 20 milliseconds compared to the current code. And unfortunately it breaks many of the unit tests, even after I also adjusted the tolerance in the internal functions used in the test comparisons. Thus this idea would require more effort for at best a minimal improvement.

```R
library("microbenchmark")

remotes::install_github("Merck/gsDesign2@6d4371a", INSTALL_opts = "--with-keep.source")
## Skipping install of 'gsDesign2' from a github remote, the SHA1 (6d4371ae) has not changed since last install.
##   Use `force = TRUE` to force installation
library("gsDesign2")
packageVersion("gsDesign2")
## [1] ‘1.1.0.1’

microbenchmark(
  gs_power_ahr = gs_power_ahr(
    analysis_time = c(12, 24, 36),
    event = c(30, 40, 50),
    binding = TRUE,
    upper = gs_spending_bound,
    upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
    lower = gs_spending_bound,
    lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
  ),
  times = 100
)
## Unit: milliseconds
##          expr      min       lq     mean   median       uq      max neval
##  gs_power_ahr 376.1468 403.4486 450.8562 434.6752 489.9425 688.7457   100

detach("package:gsDesign2")
devtools::load_all()
## ℹ Loading gsDesign2
packageVersion("gsDesign2")
## [1] ‘1.1.0.2’

microbenchmark(
  gs_power_ahr = gs_power_ahr(
    analysis_time = c(12, 24, 36),
    event = c(30, 40, 50),
    binding = TRUE,
    upper = gs_spending_bound,
    upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
    lower = gs_spending_bound,
    lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
  ),
  times = 100
)
## Unit: milliseconds
##          expr      min       lq     mean   median       uq      max neval
##  gs_power_ahr 354.4254 383.3973 430.2495 422.6296 459.8087 647.3404   100
```
