### PR TITLE
Reduce interval for root finding

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.0.1
+Version: 1.1.0.2
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/R/expected_time.R
+++ b/R/expected_time.R
@@ -95,6 +95,7 @@ expected_time <- function(
     target_event = 150,
     ratio = 1,
     interval = c(.01, 100)) {
+  print(interval)
   # ----------------------------#
   #    check inputs             #
   # ----------------------------#

--- a/R/gs_power_ahr.R
+++ b/R/gs_power_ahr.R
@@ -52,7 +52,8 @@
 #'   Normally, `r` will not be changed by the user.
 #' @param tol Tolerance parameter for boundary convergence (on Z-scale).
 #' @param interval An interval that is presumed to include the time at which
-#'   expected event count is equal to targeted event.
+#'   expected event count is equal to targeted event. If `analysis_time` is
+#'   defined, the upper limit of the interval is set to its maximum.
 #'
 #' @return A tibble with columns `Analysis`, `Bound`, `Z`, `Probability`,
 #'   `theta`, `Time`, `AHR`, `Events`.
@@ -171,7 +172,7 @@ gs_power_ahr <- function(
     info_scale = c("h0_h1_info", "h0_info", "h1_info"),
     r = 18,
     tol = 1e-6,
-    interval = c(.01, 100)) {
+    interval = c(.01, if(is.null(analysis_time)) 100 else max(analysis_time))) {
   # Get the number of analysis
   n_analysis <- max(length(event), length(analysis_time), na.rm = TRUE)
 

--- a/man/gs_power_ahr.Rd
+++ b/man/gs_power_ahr.Rd
@@ -23,7 +23,7 @@ gs_power_ahr(
   info_scale = c("h0_h1_info", "h0_info", "h1_info"),
   r = 18,
   tol = 1e-06,
-  interval = c(0.01, 100)
+  interval = c(0.01, if (is.null(analysis_time)) 100 else max(analysis_time))
 )
 }
 \arguments{
@@ -75,7 +75,8 @@ Normally, \code{r} will not be changed by the user.}
 \item{tol}{Tolerance parameter for boundary convergence (on Z-scale).}
 
 \item{interval}{An interval that is presumed to include the time at which
-expected event count is equal to targeted event.}
+expected event count is equal to targeted event. If \code{analysis_time} is
+defined, the upper limit of the interval is set to its maximum.}
 }
 \value{
 A tibble with columns \code{Analysis}, \code{Bound}, \code{Z}, \code{Probability},


### PR DESCRIPTION
Similar to PR #298, this PR serves as documentation of an approach we discussed. I reduced the maximum interval for the root finding by limiting it to the maximum of `analysis_time`. In the case of my benchmarking code, this reduced the max to 36. However:

* There was no detectable speed increase despite the substantial reduction in the interval
* 9 tests now fail due to minuscule differences. We could fix these failures either by relaxing the tolerance on `expect_equal()` or also updating `gs_power_ahr_()` to use the reduced interval

```R
Failure (test-developer-gs_power_ahr.R:127:3): calendar + event based cut
x1$analysis$info0 not equal to x2$info0[x2$Bound == "Lower"].
1/3 mismatches
[1] 7.5 - 7.5 == -2.37e-07

[ FAIL 9 | WARN 2 | SKIP 0 | PASS 478 ]
```

* The code to implement this isn't great. Because both `interval` and `analysis_time` are arguments to `gs_power_ahr()` and `analysis_time` can be `NULL`, the code to implement this has to be done in the argument processing. Alternatively we could change the API to set `interval  = NULL` and move this code inside the function, but again that would require more documentation