### PR TITLE
Add reference sections "Piecewise exponential" and "Expected ..."

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -99,15 +99,25 @@ reference:
   contents:
     - gs_b
     - gs_spending_bound
+- title: "Expected ..."
+  desc: >
+    Functions for computing trial events.
+  contents:
+    - expected_event
+    - expected_time
+    - expected_accrual
+- title: "Piecewise exponential"
+  desc: >
+    Functions for computing piecewise exponential distributions.
+  contents:
+    - ppwe
+    - s2pwe
 - title: "Low-level helpers"
   desc: >
     Functions to calculate sample size or number of events under non-constant treatment effect over time.
   contents:
     - gs_power_npe
     - gs_design_npe
-    - expected_accrual
-    - ppwe
-    - s2pwe
     - gs_create_arm
     - pw_info
 


### PR DESCRIPTION
Closes #258 

* Please feel free to suggest more detailed descriptions for these sections
* I removed the functions from low-level helpers when I moved them to their dedicated section. If you'd prefer to also leave them there, I can add them back. Duplication isn't a problem here since we want users to be able to find the functions in the section they expect