### PR TITLE
Remove {rlang} to simplify NAMESPACE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.0.2
+Version: 1.1.0.3
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),
@@ -44,7 +44,6 @@ Imports:
     mvtnorm,
     npsurvSS,
     r2rtf,
-    rlang,
     tibble,
     tidyr,
     utils,

--- a/R/globals.R
+++ b/R/globals.R
@@ -112,12 +112,3 @@ utils::globalVariables(
     )
   )
 )
-
-
-# Workaround to remove `R CMD check` NOTE "All declared Imports should be used."
-# https://r-pkgs.org/dependencies-in-practice.html#how-to-not-use-a-package-in-imports
-ignore_unused_imports <- function() {
-  rlang::`:=`
-}
-# Can't use `@importFrom rlang ":="` because it classes with data.table
-# https://github.com/r-lib/rlang/issues/1453

--- a/R/utility_tidy_tbl.R
+++ b/R/utility_tidy_tbl.R
@@ -19,7 +19,7 @@
 #' One-to-many table merge for presentation
 #'
 #' A table is desired based on a one-to-many mapping.
-#' The data frame in `table_a` maps into `table_b` with the by variable `by_a`
+#' The data frame in `table_a` maps into `table_b` with the by variable `byvar`
 #' Examples show how to use with the gt package for printing a compact combined table.
 #'
 #' @param table_a A data frame with one record for each value of `byvar`.
@@ -78,9 +78,11 @@ table_ab <- function(table_a, table_b, byvar, decimals = 1, aname = names(table_
   # Bind this together with the byvar column
   astring <- cbind(table_a %>% select(all_of(byvar)), astring)
   # Now merge with table_b
-  ab <- left_join(astring, table_b, by = byvar) %>%
-    select(-one_of(!!byvar)) %>%
-    dplyr::rename(!!aname := !!"_alab")
+  ab <- left_join(astring, table_b, by = byvar)
+  # Remove column used for grouping
+  ab[[byvar]] <- NULL
+  # Use the new column name from the argument `aname`
+  colnames(ab)[grep("_alab", colnames(ab))] <- aname
   return(ab)
 }
 


### PR DESCRIPTION
I introduced {data.table} in PR #295 to increase the computational efficiency. Both {data.table} and {rlang} define the operator `:=`, which complicates the package NAMESPACE. Motivated by @nanxstats comment in https://github.com/Merck/gsDesign2/pull/295#pullrequestreview-1785047546, I was able to simplify the NAMESPACE by removing the few uses of {rlang}

https://github.com/Merck/gsDesign2/blob/40a4c8b1ee64adf0693edd3f361ba5e928de0db0/R/utility_tidy_tbl.R#L81-L83

I didn't need to add any new tests because the output table returned by this function is already well-tested:

https://github.com/Merck/gsDesign2/blob/40a4c8b1ee64adf0693edd3f361ba5e928de0db0/tests/testthat/test-independent-utility_tbl.R#L17-L34

Also note that this function is not exported, and its documentation file is suppressed with `@noRd`