### PR TITLE
Upgrade to roxygen2 7.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,4 +60,4 @@ VignetteBuilder:
 LinkingTo:
     Rcpp
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0

--- a/R/pw_info.R
+++ b/R/pw_info.R
@@ -72,7 +72,7 @@
 #' }
 #' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
-#' @importFrom data.table ":=" as.data.table copy first last rbindlist setDF
+#' @importFrom data.table := as.data.table copy first last rbindlist setDF
 #'                        setorderv
 #'
 #' @export

--- a/R/pwe.R
+++ b/R/pwe.R
@@ -150,7 +150,7 @@ ppwe <- function(x, duration, rate, lower_tail = FALSE) {
 #'  }
 #' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
-#' @importFrom dplyr select "%>%"
+#' @importFrom dplyr select %>%
 #' @importFrom tibble tibble
 #'
 #' @export


### PR DESCRIPTION
Closes #313 

It turns out that if I remove the quotes around `:=` and `%>%`, then the `NAMESPACE` is correctly generated by both roxygen2 7.2.3 and 7.3.0