### PR TITLE
Pass args via `...` to `mvtnorm::pmvnorm()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.0.4
+Version: 1.1.0.5
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/R/utility_combo.R
+++ b/R/utility_combo.R
@@ -360,7 +360,8 @@ gs_prob_combo <- function(upper_bound,
       upper,
       group = analysis[k_ind],
       mean = theta[k_ind],
-      corr = corr[k_ind, k_ind]
+      corr = corr[k_ind, k_ind],
+      ...
     )
 
     # Futility Bound
@@ -376,7 +377,8 @@ gs_prob_combo <- function(upper_bound,
       upper,
       group = analysis[k_ind],
       mean  = theta[k_ind],
-      corr  = corr[k_ind, k_ind]
+      corr  = corr[k_ind, k_ind],
+      ...
     )
   }
 


### PR DESCRIPTION
To aid our discussion this afternoon. If we want to enable passing parameters to `mvtnorm::pmvnorm()`, this PR fixes that behavior. If we decide to keep this functionality, it would be nice to add some tests of realistic use cases so that this can be caught in the future.

xref: https://github.com/Merck/gsDesign2/issues/235#issuecomment-1896298750

Note that the call to `pmvnorm_combo()`  in `gs_bound()` does pass the `...`:

https://github.com/Merck/gsDesign2/blob/f4a9e8dc03e6383067912262d447c50e7d060d1a/R/utility_combo.R#L481-L486

What this PR does is add the `...` to the 2 calls in `gs_prob_combo()`