### PR TITLE
Test that args are passed via `...` to `mvtnorm::pmvnorm()`

### DIFF
--- a/tests/testthat/test-independent-gs_design_combo.R
+++ b/tests/testthat/test-independent-gs_design_combo.R
@@ -125,3 +125,11 @@ testthat::test_that("calculate probability under null", {
     tolerance = 0.005
   )
 })
+
+testthat::test_that("arguments are passed via ... to mvtnorm::pmvnorm()", {
+  x1 <- gs_design_combo(seed = 1)
+  x2 <- gs_design_combo(seed = 1)
+  x3 <- gs_design_combo(seed = 2)
+  expect_identical(x1, x2)
+  expect_false(identical(x1, x3))
+})

--- a/tests/testthat/test-independent-gs_power_combo.R
+++ b/tests/testthat/test-independent-gs_power_combo.R
@@ -85,3 +85,11 @@ for (i in 1:max(fh_test$analysis)) {
     expect_equal(event, unique(gs_power_combo_test2$analysis$event)[i], tolerance = 0.01)
   })
 }
+
+testthat::test_that("arguments are passed via ... to mvtnorm::pmvnorm()", {
+  x1 <- gs_power_combo(seed = 1)
+  x2 <- gs_power_combo(seed = 1)
+  x3 <- gs_power_combo(seed = 2)
+  expect_identical(x1, x2)
+  expect_false(identical(x1, x3))
+})


### PR DESCRIPTION
I decided to use the argument `seed`. I confirmed that if I interrupt the chain of `...` by deleting them from one of the intermediate function calls, then these tests fail.

xref: Followup to #315, motivation in https://github.com/Merck/gsDesign2/issues/235#issuecomment-1897782719