### PR TITLE
Remove warnings for manually created enrollment and failure rates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.0.6
+Version: 1.1.0.7
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/R/check_arg.R
+++ b/R/check_arg.R
@@ -107,23 +107,38 @@ check_args <- function(arg, type, length = NULL, dim = NULL) {
 #'
 #' check_enroll_rate(enroll_rate)
 check_enroll_rate <- function(enroll_rate) {
-  if (!("enroll_rate" %in% class(enroll_rate))) {
-    msg <- c(
-      "Please use `define_enroll_rate()` to specify the `enroll_rate` argument.",
-      "We will enforce this requirement from the next version."
-    )
-    msg <- paste(msg, collapse = "\n")
-    warning(msg)
+  # Suppress any potential warnings about missing columns. The checks below will
+  # verify the required columns
+  suppressWarnings({
+    duration <- enroll_rate$duration
+    rate <- enroll_rate$rate
+    stratum <- enroll_rate$stratum
+  })
 
-    if (!("stratum" %in% names(enroll_rate))) {
-      enroll_rate$stratum <- rep("All", nrow(enroll_rate))
-    }
+  msg <- " Try the helper function define_enroll_rate() to prepare valid input."
 
-    enroll_rate <- define_enroll_rate(
-      enroll_rate$duration,
-      enroll_rate$rate,
-      enroll_rate$stratum
-    )
+  if (is.null(duration)) {
+    stop("The variable `duration` can't be NULL.", msg)
+  }
+
+  if (is.null(rate)) {
+    stop("The variable `rate` can't be NULL.", msg)
+  }
+
+  check_args(duration, type = c("numeric", "integer"))
+  check_args(rate, type = c("numeric", "integer"))
+  check_args(stratum, type = c("character"))
+
+  if (any(duration < 0)) {
+    stop("The enrollment duration `duration` can't be negative.", msg)
+  }
+
+  if (any(rate < 0)) {
+    stop("The enrollment rate `rate` can't be negative.", msg)
+  }
+
+  if (!("stratum" %in% names(enroll_rate))) {
+    enroll_rate$stratum <- rep("All", nrow(enroll_rate))
   }
 
   enroll_rate
@@ -160,29 +175,58 @@ check_enroll_rate <- function(enroll_rate) {
 #'
 #' check_fail_rate(fail_rate)
 check_fail_rate <- function(fail_rate) {
-  if (!("fail_rate" %in% class(fail_rate))) {
-    msg <- c(
-      "Please use `define_fail_rate()` to specify the `fail_rate` argument.",
-      "We will enforce the requirement from the next version."
-    )
-    msg <- paste(msg, collapse = "\n")
-    warning(msg)
+  # Suppress any potential warnings about missing columns. The checks below will
+  # verify the required columns
+  suppressWarnings({
+    duration <- fail_rate$duration
+    fail_rate_col <- fail_rate$fail_rate
+    dropout_rate <- fail_rate$dropout_rate
+    hr <- fail_rate$hr
+    stratum <- fail_rate$stratum
+  })
 
-    if (!("hr" %in% names(fail_rate))) {
-      fail_rate$hr <- rep(1, nrow(fail_rate))
-    }
+  msg <- " Try the helper function define_fail_rate() to prepare valid input."
 
-    if (!("stratum" %in% names(fail_rate))) {
-      fail_rate$stratum <- rep("All", nrow(fail_rate))
-    }
+  if (is.null(duration)) {
+    stop("The variable `duration` can't be NULL.", msg)
+  }
 
-    fail_rate <- define_fail_rate(
-      fail_rate$duration,
-      fail_rate$fail_rate,
-      fail_rate$dropout_rate,
-      fail_rate$hr,
-      fail_rate$stratum
-    )
+  if (is.null(fail_rate_col)) {
+    stop("The variable `fail_rate` can't be NULL.", msg)
+  }
+
+  if (is.null(dropout_rate)) {
+    stop("The variable `dropout_rate` can't be NULL.", msg)
+  }
+
+  check_args(duration, type = c("numeric", "integer"))
+  check_args(fail_rate_col, type = c("numeric", "integer"))
+  check_args(dropout_rate, type = c("numeric", "integer"))
+  check_args(hr, type = c("numeric", "integer"))
+  check_args(stratum, type = c("character"))
+
+  if (any(duration < 0)) {
+    stop("The enrollment duration `duration` can't be negative.", msg)
+  }
+
+  if (any(fail_rate_col < 0)) {
+    stop("The failure rate `fail_rate` can't be negative.", msg)
+  }
+
+  if (any(dropout_rate < 0)) {
+    stop("The dropout rate `dropout_rate` can't be negative.", msg)
+  }
+
+  if (any(hr < 0)) {
+    stop("The hazard ratio `hr` can't be negative.", msg)
+  }
+
+  if (!("hr" %in% names(fail_rate))) {
+    fail_rate$hr <- rep(1, nrow(fail_rate))
+  }
+
+  if (!("stratum" %in% names(fail_rate))) {
+    fail_rate$stratum <- rep("All", nrow(fail_rate))
   }
 
   fail_rate

--- a/R/define.R
+++ b/R/define.R
@@ -54,31 +54,13 @@ define_enroll_rate <- function(
     duration,
     rate,
     stratum = "All") {
-  if (is.null(duration)) {
-    stop("define_enroll_rate: variable `duration` can't be NULL.")
-  }
-
-  if (is.null(rate)) {
-    stop("define_enroll_rate: variable `rate` can't be NULL.")
-  }
-
-  check_args(duration, type = c("numeric", "integer"))
-  check_args(rate, type = c("numeric", "integer"))
-  check_args(stratum, type = c("character"))
-
-  if (any(duration < 0)) {
-    stop("define_enroll_rate: enrollment duration `duration` can't be negative.")
-  }
-
-  if (any(rate < 0)) {
-    stop("define_enroll_rate: enrollment rate `rate` can't be negative.")
-  }
-
   df <- tibble::tibble(
     stratum = stratum,
     duration = duration,
     rate = rate
   )
+
+  check_enroll_rate(df)
 
   class(df) <- c("enroll_rate", class(df))
 
@@ -135,40 +117,6 @@ define_fail_rate <- function(
     dropout_rate,
     hr = 1,
     stratum = "All") {
-  if (is.null(duration)) {
-    stop("define_enroll_rate: variable `duration` can't be NULL.")
-  }
-
-  if (is.null(fail_rate)) {
-    stop("define_enroll_rate: variable `fail_rate` can't be NULL.")
-  }
-
-  if (is.null(dropout_rate)) {
-    stop("define_enroll_rate: variable `dropout_rate` can't be NULL.")
-  }
-
-  check_args(duration, type = c("numeric", "integer"))
-  check_args(fail_rate, type = c("numeric", "integer"))
-  check_args(dropout_rate, type = c("numeric", "integer"))
-  check_args(hr, type = c("numeric", "integer"))
-  check_args(stratum, type = c("character"))
-
-  if (any(duration < 0)) {
-    stop("define_fail_rate: enrollment duration `duration` can't be negative.")
-  }
-
-  if (any(fail_rate < 0)) {
-    stop("define_fail_rate: failure rate `fail_rate` can't be negative.")
-  }
-
-  if (any(dropout_rate < 0)) {
-    stop("define_fail_rate: failure rate `fail_rate` can't be negative.")
-  }
-
-  if (any(hr < 0)) {
-    stop("define_fail_rate: hazard ratio `hr` can't be negative.")
-  }
-
   df <- tibble::tibble(
     stratum = stratum,
     duration = duration,
@@ -176,6 +124,8 @@ define_fail_rate <- function(
     dropout_rate = dropout_rate,
     hr = hr
   )
+
+  check_fail_rate(df)
 
   class(df) <- c("fail_rate", class(df))
 

--- a/tests/testthat/test-independent-check_arg.R
+++ b/tests/testthat/test-independent-check_arg.R
@@ -1,49 +1,49 @@
 test_that("check enrollments", {
-  expect_warning(expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4)))))
-  expect_warning(expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20), rate = c("a", "b")))))
-  expect_warning(expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20), rate = c(2, -4)))))
+  expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4))))
+  expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20), rate = c("a", "b"))))
+  expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20), rate = c(2, -4))))
 
-  expect_warning(expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20)))))
-  expect_warning(expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4), duration = c("a", "b")))))
-  expect_warning(expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4), duration = c(10, -20)))))
+  expect_error(check_enroll_rate(tibble::tibble(duration = c(10, 20))))
+  expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4), duration = c("a", "b"))))
+  expect_error(check_enroll_rate(tibble::tibble(rate = c(2, 4), duration = c(10, -20))))
 })
 
 test_that("check fail_rate", {
   # lack duration
-  expect_warning(expect_error(
+  expect_error(
     check_fail_rate(tibble::tibble(fail_rate = c(0.2, 0.4), dropout_rate = 0.01))
-  ))
+  )
 
   # lack fail_rate
-  expect_warning(expect_error(
+  expect_error(
     check_fail_rate(tibble::tibble(duration = c(2, 4), dropout_rate = 0.01))
-  ))
+  )
 
   # lack dropout_rate
-  expect_warning(expect_error(
+  expect_error(
     check_fail_rate(tibble::tibble(fail_rate = c(0.2, 0.4), duration = c(10, 20)))
-  ))
+  )
 
   # check of column `duration`
-  expect_warning(expect_error(
+  expect_error(
     check_fail_rate(tibble::tibble(fail_rate = c(2, 4), duration = c("a", "b"), dropout_rate = 0.01))
-  ))
+  )
 
-  expect_warning(expect_error(
+  expect_error(
     check_fail_rate(tibble::tibble(fail_rate = c(2, 4), duration = c(10, -20), dropout_rate = 0.01))
-  ))
+  )
 
   # check of column `fail_rate`
-  expect_warning(expect_error(
+  expect_error(
     check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c("a", "b"), dropout_rate = 0.01))
-  ))
+  )
 
-  expect_warning(expect_error(
+  expect_error(
     check_fail_rate(tibble::tibble(duration = c(10, 20), fail_rate = c(2, -4), dropout_rate = 0.01))
-  ))
+  )
 
   # check of column `hr`
-  expect_warning(expect_error(
+  expect_error(
     check_fail_rate(
       tibble::tibble(
         duration = c(10, 20),
@@ -51,9 +51,9 @@ test_that("check fail_rate", {
         dropout_rate = 0.01, hr = "a"
       )
     )
-  ))
+  )
 
-  expect_warning(expect_error(
+  expect_error(
     check_fail_rate(
       tibble::tibble(
         duration = c(10, 20),
@@ -61,10 +61,10 @@ test_that("check fail_rate", {
         dropout_rate = 0.01, hr = -1
       )
     )
-  ))
+  )
 
   # check of column `dropoutRate`
-  expect_warning(expect_error(
+  expect_error(
     check_fail_rate(
       tibble::tibble(
         duration = c(10, 20),
@@ -72,9 +72,9 @@ test_that("check fail_rate", {
         dropout_rate = "a", hr = 0.6
       )
     )
-  ))
+  )
 
-  expect_warning(expect_error(
+  expect_error(
     check_fail_rate(
       tibble::tibble(
         duration = c(10, 20),
@@ -82,7 +82,7 @@ test_that("check fail_rate", {
         dropout_rate = -1, hr = 0.6
       )
     )
-  ))
+  )
 })
 
 test_that("check enrollments and fail_rate together", {
@@ -158,4 +158,28 @@ test_that("check check_info_frac", {
   expect_error(check_info_frac(c("a", "b")))
   expect_error(check_info_frac(c(2 / 3, 1 / 3, 1)))
   expect_error(check_info_frac(c(2 / 3, 3 / 4)))
+})
+
+test_that("check_enroll_rate does not require a specific class", {
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 10),
+    rate = c(3, 6, 9)
+  )
+  # remove class "enroll_rate"
+  class_orig <- class(enroll_rate)
+  class(enroll_rate) <- class_orig[class_orig != "enroll_rate"]
+  expect_silent(check_enroll_rate(enroll_rate))
+})
+
+test_that("check_fail_rate does not require a specific class", {
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    hr = c(0.9, 0.6),
+    dropout_rate = 0.001
+  )
+  # remove class "fail_rate"
+  class_orig <- class(fail_rate)
+  class(fail_rate) <- class_orig[class_orig != "fail_rate"]
+  expect_silent(check_fail_rate(fail_rate))
 })


### PR DESCRIPTION
Closes #316 

I refactored the `define_*_rate()` and `check_*_rate()` functions so that the end user will no longer receive a warning message if they self-constructed `enroll_rate` and `fail_rate`. However, if they provide an invalid input, the error message recommends the appropriate `define_*_rate()` function

```R
library("gsDesign2")

enroll_rate <- define_enroll_rate(
  duration = c(2, 2, 10),
  rate = c(3, 6, 9)
)

# new behavior: the column stratum was added by define_enroll_rate()
enroll_rate
## # A tibble: 3 × 3
## stratum duration  rate
## <chr>      <dbl> <dbl>
##   1 All            2     3
## 2 All            2     6
## 3 All           10     9

class(enroll_rate)
## [1] "enroll_rate" "tbl_df"      "tbl"         "data.frame" 
gs_design_ahr(enroll_rate = enroll_rate)

# remove the class
class(enroll_rate) <- class(enroll_rate)[-1]
class(enroll_rate)
## [1] "tbl_df"     "tbl"        "data.frame"

# new behavior: no warning for missing class
gs_design_ahr(enroll_rate = enroll_rate)

# New behavior: Recommend define_enroll_rate() in error message when invalid
# input is detected
enroll_rate_invalid <- enroll_rate[, -3]
gs_design_ahr(enroll_rate = enroll_rate_invalid)
## Error in check_enroll_rate(enroll_rate) : 
##   The variable `rate` can't be NULL. Try the helper function define_enroll_rate() to prepare valid input.

```


