### PR TITLE
Add {stats} to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Imports:
     mvtnorm,
     npsurvSS,
     r2rtf,
+    stats,
     tibble,
     tidyr,
     utils,


### PR DESCRIPTION
I noticed that {stats} is in `NAMESPACE` but not `DESCRIPTION`

https://github.com/Merck/gsDesign2/blob/187edf339dcb6c953aa9dd3998560310803c1cf1/NAMESPACE#L80-L83