### PR TITLE
Restore operator quotations and update to roxygen2 7.3.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,4 +61,4 @@ VignetteBuilder:
 LinkingTo:
     Rcpp
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1

--- a/R/pw_info.R
+++ b/R/pw_info.R
@@ -72,7 +72,7 @@
 #' }
 #' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
-#' @importFrom data.table := as.data.table copy first last rbindlist setDF
+#' @importFrom data.table ":=" as.data.table copy first last rbindlist setDF
 #'                        setorderv
 #'
 #' @export

--- a/R/pwe.R
+++ b/R/pwe.R
@@ -150,7 +150,7 @@ ppwe <- function(x, duration, rate, lower_tail = FALSE) {
 #'  }
 #' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
-#' @importFrom dplyr select %>%
+#' @importFrom dplyr select "%>%"
 #' @importFrom tibble tibble
 #'
 #' @export


### PR DESCRIPTION
This PR reverts the changes in https://github.com/Merck/gsDesign2/pull/314 by adding the quotes back as the parser bug in roxygen2 7.3.0 has been fixed in roxygen2 7.3.1 (on CRAN 2024-01-22), and reran roxygen2 to update the `RoxygenNote` field in `DESCIRPTION` to use 7.3.1.

Changing this back ensures the convention to import special operators like `:=` or `%>%` is consistent with both

1. The generated `NAMESPACE` file in this package.
2. All other packages that have been quoting them all along.

so I think this is worth it.