### PR TITLE
Qualify namespaces in tests to avoid `library()` calls

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,6 +1,4 @@
 library(testthat)
-library(gsDesign)
 library(gsDesign2)
-library(dplyr)
 
 test_check("gsDesign2")

--- a/tests/testthat/old_function/AHR_.R
+++ b/tests/testthat/old_function/AHR_.R
@@ -189,37 +189,37 @@ AHR_ <- function(enrollRates = tibble::tibble(
     events <- NULL
     for (s in strata) {
       # subset to stratum
-      enroll <- enrollRates %>% filter(Stratum == s)
-      fail <- failRates %>% filter(Stratum == s)
+      enroll <- enrollRates %>% dplyr::filter(Stratum == s)
+      fail <- failRates %>% dplyr::filter(Stratum == s)
       # Control events
-      enrollc <- enroll %>% mutate(rate = rate * Qc)
+      enrollc <- enroll %>% dplyr::mutate(rate = rate * Qc)
       control <- eEvents_df_(enrollRates = enrollc, failRates = fail, totalDuration = td, simple = FALSE)
       # Experimental events
-      enrolle <- enroll %>% mutate(rate = rate * Qe)
-      fre <- fail %>% mutate(failRate = failRate * hr)
+      enrolle <- enroll %>% dplyr::mutate(rate = rate * Qe)
+      fre <- fail %>% dplyr::mutate(failRate = failRate * hr)
       experimental <- eEvents_df_(enrollRates = enrolle, failRates = fre, totalDuration = td, simple = FALSE)
       # Combine control and experimental; by period recompute HR, events, information
       events <-
         rbind(
-          control %>% mutate(Treatment = "Control"),
-          experimental %>% mutate(Treatment = "Experimental")
+          control %>% dplyr::mutate(Treatment = "Control"),
+          experimental %>% dplyr::mutate(Treatment = "Experimental")
         ) %>%
-        arrange(t, Treatment) %>%
-        ungroup() %>%
-        group_by(t) %>%
-        summarize(
+        dplyr::arrange(t, Treatment) %>%
+        dplyr::ungroup() %>%
+        dplyr::group_by(t) %>%
+        dplyr::summarize(
           Stratum = s, info = (sum(1 / Events))^(-1),
-          Events = sum(Events), HR = last(failRate) / first(failRate)
+          Events = sum(Events), HR = dplyr::last(failRate) / dplyr::first(failRate)
         ) %>%
         rbind(events)
     }
     rval <- rbind(
       rval,
       events %>%
-        mutate(Time = td, lnhr = log(HR), info0 = Events * Qc * Qe) %>%
-        ungroup() %>%
-        group_by(Time, Stratum, HR) %>%
-        summarize(
+        dplyr::mutate(Time = td, lnhr = log(HR), info0 = Events * Qc * Qe) %>%
+        dplyr::ungroup() %>%
+        dplyr::group_by(Time, Stratum, HR) %>%
+        dplyr::summarize(
           t = min(t),
           Events = sum(Events),
           info0 = sum(info0),
@@ -231,14 +231,14 @@ AHR_ <- function(enrollRates = tibble::tibble(
   if (!simple) {
     return(
       rval %>%
-        select(c("Time", "Stratum", "t", "HR", "Events", "info", "info0")) %>%
-        group_by(Time, Stratum) %>%
-        arrange(t, .by_group = TRUE)
+        dplyr::select(c("Time", "Stratum", "t", "HR", "Events", "info", "info0")) %>%
+        dplyr::group_by(Time, Stratum) %>%
+        dplyr::arrange(t, .by_group = TRUE)
     )
   }
   return(rval %>%
-    group_by(Time) %>%
-    summarize(
+    dplyr::group_by(Time) %>%
+    dplyr::summarize(
       AHR = exp(sum(log(HR) * Events) / sum(Events)),
       Events = sum(Events),
       info = sum(info),

--- a/tests/testthat/old_function/eAccrual_.R
+++ b/tests/testthat/old_function/eAccrual_.R
@@ -59,7 +59,7 @@ eAccrual_ <- function(x = 0:24,
   # check input enrollment rate assumptions
   if(!is.numeric(x)){stop("gsDesign2: x in `eAccrual()` must be a strictly increasing non-negative numeric vector")}
   if(!min(x) >= 0){stop("gsDesign2: x in `eAccrual()` must be a strictly increasing non-negative numeric vector")}
-  if(!min(lead(x,default=max(x)+1) - x) > 0){stop("gsDesign2: x in `eAccrual()` must be a strictly increasing non-negative numeric vector")}
+  if(!min(dplyr::lead(x,default=max(x)+1) - x) > 0){stop("gsDesign2: x in `eAccrual()` must be a strictly increasing non-negative numeric vector")}
   
   # check enrollment rate assumptions
   if(!is.data.frame(enrollRates)){stop("gsDesign2: enrollRates in `eAccrual()` must be a data frame")}
@@ -79,7 +79,7 @@ eAccrual_ <- function(x = 0:24,
   xvals <- sort(unique(c(x,cumsum(enrollRates$duration))))
   # make a tibble
   xx <- tibble::tibble(x=xvals,
-                       duration= xvals - lag(xvals,default = 0),
+                       duration= xvals - dplyr::lag(xvals,default = 0),
                        rate=ratefn(xvals), # enrollment rates at points (right continuous)
                        eAccrual=cumsum(rate*duration) # expected accrual
   )

--- a/tests/testthat/old_function/gs_design_ahr_.R
+++ b/tests/testthat/old_function/gs_design_ahr_.R
@@ -145,10 +145,10 @@ gs_design_ahr_ <- function(enrollRates = tibble::tibble(
                            binding = FALSE,
                            upper = gs_b,
                            # Default is Lan-DeMets approximation of
-                           upar = gsDesign(
+                           upar = gsDesign::gsDesign(
                              k = 3, test.type = 1,
                              n.I = c(.25, .75, 1),
-                             sfu = sfLDOF, sfupar = NULL
+                             sfu = gsDesign::sfLDOF, sfupar = NULL
                            )$upper$bound,
                            lower = gs_b,
                            lpar = c(qnorm(.1), -Inf, -Inf), # Futility only at IA1
@@ -191,7 +191,7 @@ gs_design_ahr_ <- function(enrollRates = tibble::tibble(
             tEvents_(enrollRates, failRates,
               targetEvents = IF[K - i] * finalEvents, ratio = ratio,
               interval = c(.01, nextTime)
-            ) %>% mutate(theta = -log(AHR), Analysis = K - i),
+            ) %>% dplyr::mutate(theta = -log(AHR), Analysis = K - i),
             y
           )
       } else if (IF[K - i] > IFalt[K - i]) {
@@ -235,16 +235,16 @@ gs_design_ahr_ <- function(enrollRates = tibble::tibble(
     tol = tol
   ) %>%
     # Add Time, Events, AHR, N from gs_info_ahr call above
-    full_join(y %>% select(-c(info, info0, theta)), by = "Analysis") %>%
-    select(c("Analysis", "Bound", "Time", "N", "Events", "Z", "Probability", "AHR", "theta", "info", "info0")) %>%
-    arrange(desc(Bound), Analysis)
+    dplyr::full_join(y %>% dplyr::select(-c(info, info0, theta)), by = "Analysis") %>%
+    dplyr::select(c("Analysis", "Bound", "Time", "N", "Events", "Z", "Probability", "AHR", "theta", "info", "info0")) %>%
+    dplyr::arrange(dplyr::desc(Bound), Analysis)
   bounds$Events <- bounds$Events * bounds$info[K] / y$info[K]
   bounds$N <- bounds$N * bounds$info[K] / y$info[K]
 
   # Document design enrollment, failure rates, and bounds
   return(list(
     enrollRates = enrollRates %>%
-      mutate(rate = rate * bounds$info[K] / y$info[K]),
+      dplyr::mutate(rate = rate * bounds$info[K] / y$info[K]),
     failRates = failRates,
     bounds = bounds
   ))

--- a/tests/testthat/old_function/gs_design_npe_.R
+++ b/tests/testthat/old_function/gs_design_npe_.R
@@ -129,7 +129,7 @@ NULL
 #'   theta = rep(0, 3), info = design$info0[1:3],
 #'   upar = design$Z[1:3], lpar = rep(-Inf, 3)
 #' ) %>%
-#'   filter(Bound == "Upper")
+#'   dplyr::filter(Bound == "Upper")
 #'
 #' # Spending bound examples
 #'
@@ -186,7 +186,7 @@ NULL
 #'
 #' # Re-use these bounds under alternate hypothesis
 #' # Always use binding = TRUE for power calculations
-#' upar <- (xx %>% filter(Bound == "Upper"))$Z
+#' upar <- (xx %>% dplyr::filter(Bound == "Upper"))$Z
 #' gsDesign2:::gs_design_npe_(
 #'   theta = c(.1, .2, .3), info = (1:3) * 40,
 #'   binding = TRUE,

--- a/tests/testthat/old_function/gs_power_ahr_.R
+++ b/tests/testthat/old_function/gs_power_ahr_.R
@@ -62,7 +62,7 @@ NULL
 #' library(gsDesign2)
 #' library(dplyr)
 #'
-#' gs_power_ahr() %>% filter(abs(Z) < Inf)
+#' gs_power_ahr() %>% dplyr::filter(abs(Z) < Inf)
 #'
 #' # 2-sided symmetric O'Brien-Fleming spending bound
 #' # NOT CURRENTLY WORKING
@@ -93,10 +93,10 @@ gs_power_ahr_ <- function(enrollRates = tibble::tibble(
                           binding = FALSE,
                           upper = gs_b,
                           # Default is Lan-DeMets approximation of
-                          upar = gsDesign(
+                          upar = gsDesign::gsDesign(
                             k = length(events), test.type = 1,
                             n.I = events, maxn.IPlan = max(events),
-                            sfu = sfLDOF, sfupar = NULL
+                            sfu = gsDesign::sfLDOF, sfupar = NULL
                           )$upper$bound,
                           lower = gs_b,
                           lpar = c(qnorm(.1), rep(-Inf, length(events) - 1)), # Futility only at IA1
@@ -117,7 +117,7 @@ gs_power_ahr_ <- function(enrollRates = tibble::tibble(
     test_upper = test_upper, test_lower = test_lower,
     r = r, tol = tol
   ) %>%
-    right_join(x %>% select(-c(info, info0, theta)), by = "Analysis") %>%
-    select(c(Analysis, Bound, Time, Events, Z, Probability, AHR, theta, info, info0)) %>%
-    arrange(desc(Bound), Analysis))
+    dplyr::right_join(x %>% dplyr::select(-c(info, info0, theta)), by = "Analysis") %>%
+    dplyr::select(c(Analysis, Bound, Time, Events, Z, Probability, AHR, theta, info, info0)) %>%
+    dplyr::arrange(dplyr::desc(Bound), Analysis))
 }

--- a/tests/testthat/old_function/gs_power_npe_.R
+++ b/tests/testthat/old_function/gs_power_npe_.R
@@ -89,7 +89,7 @@ NULL
 #' library(dplyr)
 #'
 #' # Default (single analysis; Type I error controlled)
-#' gsDesign2:::gs_power_npe_(theta = 0) %>% filter(Bound == "Upper")
+#' gsDesign2:::gs_power_npe_(theta = 0) %>% dplyr::filter(Bound == "Upper")
 #'
 #' # Fixed bound
 #' gsDesign2:::gs_power_npe_(
@@ -113,7 +113,7 @@ NULL
 #'     sfu = gsDesign::sfLDOF
 #'   )$upper$bound,
 #'   lpar = rep(-Inf, 3)
-#' ) %>% filter(Bound == "Upper")
+#' ) %>% dplyr::filter(Bound == "Upper")
 #'
 #' # Fixed bound with futility only at analysis 1;
 #' # efficacy only at analyses 2, 3
@@ -192,7 +192,7 @@ NULL
 #'
 #' # Re-use these bounds under alternate hypothesis
 #' # Always use binding = TRUE for power calculations
-#' upar <- (xx %>% filter(Bound == "Upper"))$Z
+#' upar <- (xx %>% dplyr::filter(Bound == "Upper"))$Z
 #' gsDesign2:::gs_power_npe_(
 #'   theta = c(.1, .2, .3),
 #'   info = (1:3) * 40,

--- a/tests/testthat/test-developer-ahr.R
+++ b/tests/testthat/test-developer-ahr.R
@@ -1,8 +1,6 @@
 source_files <- list.files("./old_function/", "*.R$")
 sapply(paste0("./old_function/", source_files), source)
 
-library(dplyr)
-
 test_that("unstratified population", {
   enroll_rate <- define_enroll_rate(
     duration = c(2, 10, 4, 4, 8),
@@ -21,11 +19,11 @@ test_that("unstratified population", {
     total_duration = c(15, 30)
   )
   x2 <- AHR_( # old version
-    enrollRates = enroll_rate %>% rename(Stratum = stratum),
-    failRates = fail_rate %>% rename(Stratum = stratum, failRate = fail_rate, dropoutRate = dropout_rate),
+    enrollRates = enroll_rate %>% dplyr::rename(Stratum = stratum),
+    failRates = fail_rate %>% dplyr::rename(Stratum = stratum, failRate = fail_rate, dropoutRate = dropout_rate),
     totalDuration = c(15, 30)
   ) %>%
-    rename(time = Time, ahr = AHR, event = Events)
+    dplyr::rename(time = Time, ahr = AHR, event = Events)
   expect_equal(as.data.frame(x1), as.data.frame(x2))
 })
 
@@ -48,10 +46,10 @@ test_that("stratified population", {
     total_duration = c(15, 30)
   )
   x2 <- AHR_( # old version
-    enrollRates = enroll_rate %>% rename(Stratum = stratum),
-    failRates = fail_rate %>% rename(Stratum = stratum, failRate = fail_rate, dropoutRate = dropout_rate),
+    enrollRates = enroll_rate %>% dplyr::rename(Stratum = stratum),
+    failRates = fail_rate %>% dplyr::rename(Stratum = stratum, failRate = fail_rate, dropoutRate = dropout_rate),
     totalDuration = c(15, 30)
   ) %>%
-    rename(time = Time, ahr = AHR, event = Events)
+    dplyr::rename(time = Time, ahr = AHR, event = Events)
   expect_equal(as.data.frame(x1), as.data.frame(x2))
 })

--- a/tests/testthat/test-developer-expected_event.R
+++ b/tests/testthat/test-developer-expected_event.R
@@ -1,5 +1,3 @@
-library(dplyr)
-
 source_files <- list.files("./old_function/", "*.R$")
 sapply(paste0("./old_function/", source_files), source)
 
@@ -16,8 +14,8 @@ test_that("expected event vs gsDesign", {
     T = total_duration
   )$d
   x2 <- eEvents_df_( # gsDesign2 old version
-    enrollRates = enroll_rate %>% rename(Stratum = stratum),
-    failRates = fail_rate %>% rename(Stratum = stratum, failRate = fail_rate, dropoutRate = dropout_rate),
+    enrollRates = enroll_rate %>% dplyr::rename(Stratum = stratum),
+    failRates = fail_rate %>% dplyr::rename(Stratum = stratum, failRate = fail_rate, dropoutRate = dropout_rate),
     total_duration,
     simple = TRUE
   )

--- a/tests/testthat/test-developer-expected_time.R
+++ b/tests/testthat/test-developer-expected_time.R
@@ -1,8 +1,6 @@
 source_files <- list.files("./old_function/", "*.R$")
 sapply(paste0("./old_function/", source_files), source)
 
-library(dplyr)
-
 test_that("time to targeted events", {
   enroll_rate <- define_enroll_rate(stratum = "All", duration = c(2, 2, 10), rate = c(3, 6, 9) * 5)
   fail_rate <- define_fail_rate(
@@ -11,8 +9,8 @@ test_that("time to targeted events", {
   )
   ratio <- 1
   x <- AHR_(
-    enrollRates = enroll_rate %>% rename(Stratum = stratum),
-    failRates = fail_rate %>% rename(Stratum = stratum, failRate = fail_rate, dropoutRate = dropout_rate),
+    enrollRates = enroll_rate %>% dplyr::rename(Stratum = stratum),
+    failRates = fail_rate %>% dplyr::rename(Stratum = stratum, failRate = fail_rate, dropoutRate = dropout_rate),
     ratio = ratio,
     totalDuration = 20
   )
@@ -27,7 +25,7 @@ test_that("time to targeted events", {
 
 test_that("default", {
   x1 <- expected_time()
-  x2 <- tEvents_() %>% rename(time = Time, ahr = AHR, event = Events)
+  x2 <- tEvents_() %>% dplyr::rename(time = Time, ahr = AHR, event = Events)
   expect_equal(x1, as.data.frame(x2))
 })
 
@@ -46,11 +44,11 @@ test_that("time to targeted events by new/old version", {
     target_event = 200
   )
   x2 <- tEvents_(
-    enrollRates = enroll_rate %>% rename(Stratum = stratum),
-    failRates = fail_rate %>% rename(Stratum = stratum, failRate = fail_rate, dropoutRate = dropout_rate),
+    enrollRates = enroll_rate %>% dplyr::rename(Stratum = stratum),
+    failRates = fail_rate %>% dplyr::rename(Stratum = stratum, failRate = fail_rate, dropoutRate = dropout_rate),
     ratio = ratio,
     targetEvents = 200
   ) %>%
-    rename(time = Time, ahr = AHR, event = Events)
+    dplyr::rename(time = Time, ahr = AHR, event = Events)
   expect_equal(x1, as.data.frame(x2))
 })

--- a/tests/testthat/test-developer-gridpts.R
+++ b/tests/testthat/test-developer-gridpts.R
@@ -1,8 +1,6 @@
 source_files <- list.files("./old_function/", "*.R$")
 sapply(paste0("./old_function/", source_files), source)
 
-library(dplyr)
-
 test_that("Default (N(0,1)) - approximate variance of standard normal (i.e., 1)", {
   x1 <- gridpts_(mu = 0, a = -20, b = 20, r = 18) # gsDesign2 old version
   x2 <- gsDesign2:::gridpts(mu = 0, a = -20, b = 20, r = 18) # gsDesign2 latest version

--- a/tests/testthat/test-developer-gs_design_ahr.R
+++ b/tests/testthat/test-developer-gs_design_ahr.R
@@ -1,8 +1,6 @@
 source_files <- list.files("./old_function/", "*.R$")
 sapply(paste0("./old_function/", source_files), source)
 
-library(dplyr)
-
 test_that("Call with defaults", {
   x1 <- gs_design_ahr()
   x2 <- gs_design_ahr_()

--- a/tests/testthat/test-developer-gs_design_npe.R
+++ b/tests/testthat/test-developer-gs_design_npe.R
@@ -1,8 +1,6 @@
 source_files <- list.files("./old_function/", "*.R$")
 sapply(paste0("./old_function/", source_files), source)
 
-library(dplyr)
-
 test_that("verify by gs_power_npe", {
   beta <- 0.1
   # new version
@@ -16,8 +14,8 @@ test_that("verify by gs_power_npe", {
   # The power is 0.9. If we re-use these bounds under alternate hypothesis, then we can get a power close to 0.9.
   y <- gs_power_npe(
     theta = c(.1, .2, .3), info = (1:3) * 40,
-    upper = gs_b, upar = (x %>% filter(bound == "upper"))$z,
-    lower = gs_b, lpar = -(x %>% filter(bound == "upper"))$z,
+    upper = gs_b, upar = (x %>% dplyr::filter(bound == "upper"))$z,
+    lower = gs_b, lpar = -(x %>% dplyr::filter(bound == "upper"))$z,
     binding = TRUE # Always use binding = TRUE for power calculations
   )
   expect_equal(y$probability[y$analysis == 3 & y$bound == "upper"], 1 - beta, tolerance = 1e-2)
@@ -32,8 +30,8 @@ test_that("verify by gs_power_npe", {
   # The power is 0.9. If we re-use these bounds under alternate hypothesis, then we can get a power close to 0.9.
   y <- gs_power_npe_(
     theta = c(.1, .2, .3), info = (1:3) * 40,
-    upper = gs_b, upar = (x %>% filter(Bound == "Upper"))$Z,
-    lower = gs_b, lpar = -(x %>% filter(Bound == "Upper"))$Z,
+    upper = gs_b, upar = (x %>% dplyr::filter(Bound == "Upper"))$Z,
+    lower = gs_b, lpar = -(x %>% dplyr::filter(Bound == "Upper"))$Z,
     binding = TRUE # Always use binding = TRUE for power calculations
   )
   expect_equal(y$Probability[y$Analysis == 3 & y$Bound == "Upper"], 1 - beta, tolerance = 1e-2)
@@ -49,14 +47,14 @@ test_that("examples in spec - Lachin book p71", {
   # Result should round up to next even number = 652
   # Divide information needed under H1 by information per patient added
   x1_a <- gs_design_npe(theta = pe - pc, info = info, info0 = info0, info_scale = "h0_info") %>%
-    select(-c(info_frac, probability0, info1))
+    dplyr::select(-c(info_frac, probability0, info1))
   x1_b <- gs_design_npe(theta = pe - pc, info = info, info0 = info0, info_scale = "h1_info") %>%
-    select(-c(info_frac, probability0, info1))
+    dplyr::select(-c(info_frac, probability0, info1))
   x1_c <- gs_design_npe(theta = pe - pc, info = info, info0 = info0, info_scale = "h0_h1_info") %>%
-    select(-c(info_frac, probability0, info1))
+    dplyr::select(-c(info_frac, probability0, info1))
   x2 <- gs_design_npe_(theta = pe - pc, info = info, info0 = info0) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound))
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound))
   expect_equal(x1_c, x2)
 })
 
@@ -67,34 +65,34 @@ test_that("fixed design with 3 equal info", {
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    select(-c(info_frac, probability0, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::select(-c(info_frac, probability0, info1)) %>%
+    dplyr::arrange(analysis, bound)
   x1_b <- gs_design_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 80, info_scale = "h1_info",
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    select(-c(info_frac, probability0, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::select(-c(info_frac, probability0, info1)) %>%
+    dplyr::arrange(analysis, bound)
   x1_c <- gs_design_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 80, info_scale = "h0_h1_info",
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    select(-c(info_frac, probability0, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::select(-c(info_frac, probability0, info1)) %>%
+    dplyr::arrange(analysis, bound)
   x2 <- gs_design_npe_(
     theta = c(.1, .2, .3),
     info = (1:3) * 80,
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound)) %>%
-    select(-c(theta1, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound)) %>%
+    dplyr::select(-c(theta1, info1)) %>%
+    dplyr::arrange(analysis, bound)
   expect_equal(x1_c, x2)
 })
 
@@ -105,34 +103,34 @@ test_that("fixed design with 3 unequal info", {
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    select(-c(info_frac, probability0, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::select(-c(info_frac, probability0, info1)) %>%
+    dplyr::arrange(analysis, bound)
   x1_b <- gs_design_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 80, info0 = (1:3) * 90 + 10, info1 = (1:3) * 70 - 5, info_scale = "h1_info",
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    select(-c(info_frac, probability0, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::select(-c(info_frac, probability0, info1)) %>%
+    dplyr::arrange(analysis, bound)
   x1_c <- gs_design_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 80, info0 = (1:3) * 90 + 10, info1 = (1:3) * 70 - 5, info_scale = "h0_h1_info",
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    select(-c(info_frac, probability0, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::select(-c(info_frac, probability0, info1)) %>%
+    dplyr::arrange(analysis, bound)
   x2 <- gs_design_npe_(
     theta = c(.1, .2, .3),
     info = (1:3) * 80, info0 = (1:3) * 90 + 10, info1 = (1:3) * 70 - 5,
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound)) %>%
-    select(-c(theta1, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound)) %>%
+    dplyr::select(-c(theta1, info1)) %>%
+    dplyr::arrange(analysis, bound)
   expect_equal(x1_c, x2)
 })
 
@@ -144,8 +142,8 @@ test_that("futility at IA1; efficacy only at IA2 +FA", {
     lower = gs_b, lpar = c(-1, -Inf, -Inf),
     test_upper = c(FALSE, TRUE, TRUE)
   ) %>%
-    select(-c(info_frac, probability0, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::select(-c(info_frac, probability0, info1)) %>%
+    dplyr::arrange(analysis, bound)
   x1_b <- gs_design_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 40, info0 = (1:3) * 40, info_scale = "h1_info",
@@ -153,8 +151,8 @@ test_that("futility at IA1; efficacy only at IA2 +FA", {
     lower = gs_b, lpar = c(-1, -Inf, -Inf),
     test_upper = c(FALSE, TRUE, TRUE)
   ) %>%
-    select(-c(info_frac, probability0, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::select(-c(info_frac, probability0, info1)) %>%
+    dplyr::arrange(analysis, bound)
   x1_c <- gs_design_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 40, info0 = (1:3) * 40, info_scale = "h0_h1_info",
@@ -162,8 +160,8 @@ test_that("futility at IA1; efficacy only at IA2 +FA", {
     lower = gs_b, lpar = c(-1, -Inf, -Inf),
     test_upper = c(FALSE, TRUE, TRUE)
   ) %>%
-    select(-c(info_frac, probability0, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::select(-c(info_frac, probability0, info1)) %>%
+    dplyr::arrange(analysis, bound)
   x2 <- gs_design_npe_(
     theta = c(.1, .2, .3),
     info = (1:3) * 40, info0 = (1:3) * 40,
@@ -171,10 +169,10 @@ test_that("futility at IA1; efficacy only at IA2 +FA", {
     lower = gs_b, lpar = c(-1, -Inf, -Inf),
     test_upper = c(FALSE, TRUE, TRUE)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound)) %>%
-    select(-c(theta1, info1)) %>%
-    arrange(analysis, bound)
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound)) %>%
+    dplyr::select(-c(theta1, info1)) %>%
+    dplyr::arrange(analysis, bound)
   expect_equal(x1_c, x2)
 })
 
@@ -187,8 +185,8 @@ test_that("spending bounds", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfHSD, total_spend = 0.1, param = -1, timing = NULL)
   ) %>%
-    select(analysis, bound, z, probability, theta, info, info0, info1) %>%
-    arrange(analysis, bound)
+    dplyr::select(analysis, bound, z, probability, theta, info, info0, info1) %>%
+    dplyr::arrange(analysis, bound)
   x1_b <- gs_design_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 40, info0 = (1:3) * 50, info_scale = "h1_info",
@@ -197,8 +195,8 @@ test_that("spending bounds", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfHSD, total_spend = 0.1, param = -1, timing = NULL)
   ) %>%
-    select(analysis, bound, z, probability, theta, info, info0, info1) %>%
-    arrange(analysis, bound)
+    dplyr::select(analysis, bound, z, probability, theta, info, info0, info1) %>%
+    dplyr::arrange(analysis, bound)
   x1_c <- gs_design_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 40, info0 = (1:3) * 50, info_scale = "h0_h1_info",
@@ -207,8 +205,8 @@ test_that("spending bounds", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfHSD, total_spend = 0.1, param = -1, timing = NULL)
   ) %>%
-    select(analysis, bound, z, probability, theta, info, info0, info1) %>%
-    arrange(analysis, bound)
+    dplyr::select(analysis, bound, z, probability, theta, info, info0, info1) %>%
+    dplyr::arrange(analysis, bound)
   x2 <- gs_design_npe_(
     theta = c(.1, .2, .3),
     info = (1:3) * 40, info0 = (1:3) * 50,
@@ -217,10 +215,10 @@ test_that("spending bounds", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfHSD, total_spend = 0.1, param = -1, timing = NULL)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound)) %>%
-    select(analysis, bound, z, probability, theta, info, info0, info1) %>%
-    arrange(analysis, bound)
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound)) %>%
+    dplyr::select(analysis, bound, z, probability, theta, info, info0, info1) %>%
+    dplyr::arrange(analysis, bound)
   expect_equal(x1_c, x2)
 })
 
@@ -234,8 +232,8 @@ test_that("2-sided symmetric spend", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
   ) %>%
-    select(analysis, bound, z, probability, theta, info, info0, info1) %>%
-    arrange(analysis, bound)
+    dplyr::select(analysis, bound, z, probability, theta, info, info0, info1) %>%
+    dplyr::arrange(analysis, bound)
   x1_b <- gs_design_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 40, info_scale = "h1_info",
@@ -245,8 +243,8 @@ test_that("2-sided symmetric spend", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
   ) %>%
-    select(analysis, bound, z, probability, theta, info, info0, info1) %>%
-    arrange(analysis, bound)
+    dplyr::select(analysis, bound, z, probability, theta, info, info0, info1) %>%
+    dplyr::arrange(analysis, bound)
   x1_c <- gs_design_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 40, info_scale = "h0_h1_info",
@@ -256,8 +254,8 @@ test_that("2-sided symmetric spend", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
   ) %>%
-    select(analysis, bound, z, probability, theta, info, info0, info1) %>%
-    arrange(analysis, bound)
+    dplyr::select(analysis, bound, z, probability, theta, info, info0, info1) %>%
+    dplyr::arrange(analysis, bound)
   x2 <- gs_design_npe_(
     theta = c(.1, .2, .3),
     info = (1:3) * 40,
@@ -267,9 +265,9 @@ test_that("2-sided symmetric spend", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound)) %>%
-    select(analysis, bound, z, probability, theta, info, info0, info1) %>%
-    arrange(analysis, bound)
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound)) %>%
+    dplyr::select(analysis, bound, z, probability, theta, info, info0, info1) %>%
+    dplyr::arrange(analysis, bound)
   expect_equal(x1_c, x2)
 })

--- a/tests/testthat/test-developer-gs_design_rd.R
+++ b/tests/testthat/test-developer-gs_design_rd.R
@@ -15,8 +15,8 @@ test_that("fixed design", {
   )
 
   x2 <- gs_design_rd(
-    p_c = tibble(stratum = "All", rate = p1),
-    p_e = tibble(stratum = "All", rate = p2),
+    p_c = tibble::tibble(stratum = "All", rate = p1),
+    p_e = tibble::tibble(stratum = "All", rate = p2),
     alpha = alpha, beta = beta,
     rd0 = rd0, ratio = 1, info_frac = 1,
     upper = gs_b,

--- a/tests/testthat/test-developer-gs_power_ahr.R
+++ b/tests/testthat/test-developer-gs_power_ahr.R
@@ -1,8 +1,6 @@
 source_files <- list.files("./old_function/", "*.R$")
 sapply(paste0("./old_function/", source_files), source)
 
-library(dplyr)
-
 test_that("default parameter", {
   x1 <- gs_power_ahr()
   x2 <- gs_power_ahr_()

--- a/tests/testthat/test-developer-gs_power_npe.R
+++ b/tests/testthat/test-developer-gs_power_npe.R
@@ -1,16 +1,14 @@
 source_files <- list.files("./old_function/", "*.R$")
 sapply(paste0("./old_function/", source_files), source)
 
-library(dplyr)
-
 test_that("The default of `gs_power_npe` is a single analysis with type I error controlled.", {
   x1 <- gs_power_npe(theta = 0) %>%
-    filter(bound == "upper") %>%
-    select(-info_frac)
+    dplyr::filter(bound == "upper") %>%
+    dplyr::select(-info_frac)
   x2 <- gs_power_npe_(theta = 0) %>%
-    filter(Bound == "Upper") %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound))
+    dplyr::filter(Bound == "Upper") %>%
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound))
   expect_equal(x1, x2)
 })
 
@@ -23,7 +21,7 @@ test_that("fixed bound", {
     lower = gs_b,
     lpar = c(-1, 0, 0)
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   x2 <- gs_power_npe_(
     theta = c(.1, .2, .3),
     info = (1:3) * 40,
@@ -32,8 +30,8 @@ test_that("fixed bound", {
     lower = gs_b,
     lpar = c(-1, 0, 0)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound))
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound))
   expect_equal(x1, x2)
 })
 
@@ -44,15 +42,15 @@ test_that("Same fixed efficacy bounds, no futility bound (i.e., non-binding boun
     upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lpar = rep(-Inf, 3)
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   x2 <- gs_power_npe_(
     theta = rep(0, 3),
     info = (1:3) * 40,
     upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lpar = rep(-Inf, 3)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound))
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound))
   expect_equal(x1, x2)
 })
 
@@ -65,7 +63,7 @@ test_that("Fixed bound with futility only at analysis 1; efficacy only at analys
     lower = gs_b,
     lpar = c(qnorm(.1), -Inf, -Inf)
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   x2 <- gs_power_npe_(
     theta = c(.1, .2, .3),
     info = (1:3) * 40,
@@ -74,8 +72,8 @@ test_that("Fixed bound with futility only at analysis 1; efficacy only at analys
     lower = gs_b,
     lpar = c(qnorm(.1), -Inf, -Inf)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound))
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound))
   expect_equal(x1, x2)
 })
 
@@ -88,7 +86,7 @@ test_that("Spending function bounds - Lower spending based on non-zero effect", 
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfHSD, total_spend = 0.1, param = -1, timing = NULL)
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   x2 <- gs_power_npe_(
     theta = c(.1, .2, .3),
     info = (1:3) * 40,
@@ -97,8 +95,8 @@ test_that("Spending function bounds - Lower spending based on non-zero effect", 
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfHSD, total_spend = 0.1, param = -1, timing = NULL)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound))
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound))
   expect_equal(x1, x2)
 })
 
@@ -111,7 +109,7 @@ test_that("Same bounds, but power under different theta", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfHSD, total_spend = 0.1, param = -1, timing = NULL)
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   x2 <- gs_power_npe_(
     theta = c(.15, .25, .35),
     info = (1:3) * 40,
@@ -120,8 +118,8 @@ test_that("Same bounds, but power under different theta", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfHSD, total_spend = 0.1, param = -1, timing = NULL)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound))
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound))
   expect_equal(x1, x2)
 })
 
@@ -135,7 +133,7 @@ test_that("Two-sided symmetric spend, O'Brien-Fleming spending", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   x2 <- gs_power_npe_(
     theta = rep(0, 3),
     info = (1:3) * 40,
@@ -145,8 +143,8 @@ test_that("Two-sided symmetric spend, O'Brien-Fleming spending", {
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound))
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound))
   expect_equal(x1, x2)
 })
 
@@ -160,24 +158,24 @@ test_that("Re-use these bounds under alternate hypothesis - Always use binding =
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   x1 <- gs_power_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 40,
     binding = TRUE,
-    upar = (x %>% filter(bound == "upper"))$z,
-    lpar = -(x %>% filter(bound == "upper"))$z
+    upar = (x %>% dplyr::filter(bound == "upper"))$z,
+    lpar = -(x %>% dplyr::filter(bound == "upper"))$z
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   x2 <- gs_power_npe_(
     theta = c(.1, .2, .3),
     info = (1:3) * 40,
     binding = TRUE,
-    upar = (x %>% filter(bound == "upper"))$z,
-    lpar = -(x %>% filter(bound == "upper"))$z
+    upar = (x %>% dplyr::filter(bound == "upper"))$z,
+    lpar = -(x %>% dplyr::filter(bound == "upper"))$z
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound))
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound))
   expect_equal(x1, x2)
 })
 
@@ -189,29 +187,29 @@ test_that("info != info0 != info1 - If one inputs info in upar", {
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   x1_b <- gs_power_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 80, info0 = (1:3) * 90 + 10, info1 = (1:3) * 70 - 5, info_scale = "h1_info",
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   x1_c <- gs_power_npe(
     theta = c(.1, .2, .3),
     info = (1:3) * 80, info0 = (1:3) * 90 + 10, info1 = (1:3) * 70 - 5, info_scale = "h0_h1_info",
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   x2 <- gs_power_npe_(
     theta = c(.1, .2, .3),
     info = (1:3) * 80, info0 = (1:3) * 90 + 10, info1 = (1:3) * 70 - 5,
     upper = gs_b, upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b, lpar = c(-1, 0, 0)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound))
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound))
   expect_equal(x1_c, x2)
 })
 
@@ -222,27 +220,27 @@ test_that("Developer Tests 1-sided test", {
     info = (1:3) * 400,
     binding = FALSE, r = r,
     upper = gs_b, # gs_spending_bound,
-    upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF)$upper$bound,
+    upar = gsDesign::gsDesign(k = 3, test.type = 1, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b,
     lpar = rep(-Inf, 3)
   ) %>%
-    select(-info_frac)
+    dplyr::select(-info_frac)
   y <- gs_power_npe_(
     theta = 0,
     info = (1:3) * 400,
     binding = FALSE, r = r,
     upper = gs_b, # gs_spending_bound,
-    upar = gsDesign(k = 3, test.type = 1, sfu = sfLDOF)$upper$bound,
+    upar = gsDesign::gsDesign(k = 3, test.type = 1, sfu = gsDesign::sfLDOF)$upper$bound,
     lower = gs_b,
     lpar = rep(-Inf, 3)
   ) %>%
-    rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
-    mutate(bound = tolower(bound))
+    dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) %>%
+    dplyr::mutate(bound = tolower(bound))
   z <- gsDesign::gsProbability(
     k = 3,
     theta = 0,
     n.I = (1:3) * 400,
-    b = gsDesign(k = 3, test.type = 1, sfu = sfLDOF)$upper$bound, a = rep(-20, 3), r = r
+    b = gsDesign::gsDesign(k = 3, test.type = 1, sfu = gsDesign::sfLDOF)$upper$bound, a = rep(-20, 3), r = r
   )
   expect_equal(x, y)
   expect_equal(x$z[x$bound == "upper"], z$upper$bound)
@@ -262,8 +260,8 @@ test_that("Independent Tests - Expect equal with mvtnorm for efficacy and futili
     lower = gs_spending_bound,
     lpar = list(sf = gsDesign::sfLDOF, param = NULL, total_spend = 0.02)
   )
-  test1 <- test %>% filter(bound == "upper")
-  test2 <- test %>% filter(bound == "lower")
+  test1 <- test %>% dplyr::filter(bound == "upper")
+  test2 <- test %>% dplyr::filter(bound == "lower")
   alpha_t <- 0.025
   b_ia <- gsDesign::sfLDOF(alpha = alpha_t, t = r)
   alpha_ia <- b_ia$spend
@@ -322,7 +320,7 @@ test_that("Expect equal with gsDesign::gsProbability outcome for efficacy bounds
     lower = gs_b,
     lpar = rep(-Inf, 3)
   ) %>%
-    filter(bound == "upper")
+    dplyr::filter(bound == "upper")
   y <- gs_power_npe(
     theta = .1,
     info = info, binding = FALSE,
@@ -331,12 +329,12 @@ test_that("Expect equal with gsDesign::gsProbability outcome for efficacy bounds
     lower = gs_b,
     lpar = rep(-Inf, 3)
   ) %>%
-    filter(bound == "upper")
+    dplyr::filter(bound == "upper")
   z <- gsDesign::gsProbability(
     k = 3, theta = .1,
     n.I = info,
     a = rep(-20, 3),
-    b = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, n.I = info)$upper$bound
+    b = gsDesign::gsDesign(k = 3, test.type = 1, sfu = gsDesign::sfLDOF, n.I = info)$upper$bound
   )
   expect_equal(x, y)
   expect_equal(x$z[x$bound == "upper"], z$upper$bound, tolerance = 1e-5)

--- a/tests/testthat/test-independent-expected_event.R
+++ b/tests/testthat/test-independent-expected_event.R
@@ -1,5 +1,3 @@
-library(dplyr)
-
 test_that("expected events is different from gsDesign::eEvents and expected_event", {
   enroll_rate <- define_enroll_rate(duration = c(2, 1, 2), rate = c(5, 10, 20))
   fail_rate <- define_fail_rate(duration = c(1, 1, 1), fail_rate = c(.05, .02, .01), hr = 1, dropout_rate = .01)
@@ -49,8 +47,8 @@ nEvent <- function(followup) {
   failRate <- failRates$failRate
   dropoutRate <- failRates$dropoutRate
   lamda <- failRate + dropoutRate
-  lamda1 <- c(lamda, last(lamda))
-  failRate1 <- c(failRate, last(failRate))
+  lamda1 <- c(lamda, dplyr::last(lamda))
+  failRate1 <- c(failRate, dplyr::last(failRate))
 
   failtimeend <- c(0, failtime[failtime < followup], followup)
   failtimeend1 <- c(failtime[failtime < followup], followup)

--- a/tests/testthat/test-independent-fixed_design.R
+++ b/tests/testthat/test-independent-fixed_design.R
@@ -27,7 +27,7 @@ test_that("AHR", {
 
   y <- fixed_design_ahr(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
     study_duration = study_duration, ratio = ratio
   )
 
@@ -44,7 +44,7 @@ test_that("FH", {
 
   y <- fixed_design_fh(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
     study_duration = study_duration, ratio = ratio,
     rho = 0.5, gamma = 0.5
   )
@@ -63,7 +63,7 @@ test_that("MB", {
 
   y <- fixed_design_mb(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
     study_duration = study_duration, ratio = ratio,
     tau = 8
   )
@@ -81,7 +81,7 @@ test_that("LF", {
 
   y <- fixed_design_lf(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
     study_duration = study_duration, ratio = ratio
   )
 
@@ -100,7 +100,7 @@ test_that("MaxCombo", {
 
   y <- fixed_design_maxcombo(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
     study_duration = study_duration, ratio = ratio,
     rho = c(0, 0.5, 0.5),
     gamma = c(0, 0, 0.5),
@@ -120,7 +120,7 @@ test_that("RMST", {
 
   y <- fixed_design_rmst(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
     study_duration = study_duration, ratio = ratio,
     tau = 18
   )

--- a/tests/testthat/test-independent-gs_design_ahr.R
+++ b/tests/testthat/test-independent-gs_design_ahr.R
@@ -21,27 +21,27 @@ testthat::test_that("compare results with AHR in the situation of single analysi
   )
 
   testthat::expect_equal(
-    out$analysis %>% select(time, ahr) %>% as.data.frame(),
+    out$analysis %>% dplyr::select(time, ahr) %>% as.data.frame(),
     ahr(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
       total_duration = total_duration
     ) %>%
-      select(time, ahr) %>%
+      dplyr::select(time, ahr) %>%
       as.data.frame()
   )
 
   # update enroll_rate for AHR to make Events/info/info0 also match in outputs
-  enroll_rate1 <- enroll_rate %>% mutate(rate = rate * c(out$analysis$n / (duration %*% rate)))
+  enroll_rate1 <- enroll_rate %>% dplyr::mutate(rate = rate * c(out$analysis$n / (duration %*% rate)))
 
   testthat::expect_equal(
-    out$analysis %>% select(time, ahr, event, info, info0) %>% as.data.frame(),
+    out$analysis %>% dplyr::select(time, ahr, event, info, info0) %>% as.data.frame(),
     ahr(
       enroll_rate = enroll_rate1,
       fail_rate = fail_rate,
       total_duration = total_duration
     ) %>%
-      select(time, ahr, event, info, info0) %>%
+      dplyr::select(time, ahr, event, info, info0) %>%
       as.data.frame()
   )
 })
@@ -70,7 +70,7 @@ testthat::test_that(
 
     testthat::expect_equal(
       out$analysis %>%
-        select(time, ahr) %>%
+        dplyr::select(time, ahr) %>%
         dplyr::distinct(.keep_all = TRUE) %>%
         as.data.frame(),
       ahr(
@@ -78,16 +78,16 @@ testthat::test_that(
         fail_rate = fail_rate,
         total_duration = total_duration
       ) %>%
-        select(time, ahr) %>%
+        dplyr::select(time, ahr) %>%
         as.data.frame()
     )
 
     # update enroll_rate for AHR to make Events/info/info0 also match in outputs
-    enroll_rate1 <- enroll_rate %>% mutate(rate = rate * c(max(out$analysis$n) / (duration %*% rate)))
+    enroll_rate1 <- enroll_rate %>% dplyr::mutate(rate = rate * c(max(out$analysis$n) / (duration %*% rate)))
 
     testthat::expect_equal(
       out$analysis %>%
-        select(time, ahr, event, info, info0) %>%
+        dplyr::select(time, ahr, event, info, info0) %>%
         dplyr::distinct(.keep_all = TRUE) %>%
         as.data.frame(),
       ahr(
@@ -95,7 +95,7 @@ testthat::test_that(
         fail_rate = fail_rate,
         total_duration = total_duration
       ) %>%
-        select(time, ahr, event, info, info0) %>%
+        dplyr::select(time, ahr, event, info, info0) %>%
         as.data.frame()
     )
   }

--- a/tests/testthat/test-independent-gs_design_combo.R
+++ b/tests/testthat/test-independent-gs_design_combo.R
@@ -46,9 +46,9 @@ x <- gsDesign::gsSurv(
   beta = 0.2,
   astar = 0,
   timing = c(1),
-  sfu = sfLDOF,
+  sfu = gsDesign::sfLDOF,
   sfupar = c(0),
-  sfl = sfLDOF,
+  sfl = gsDesign::sfLDOF,
   sflpar = c(0),
   lambdaC = c(0.1),
   hr = 0.6,
@@ -113,7 +113,7 @@ for (i in 1:max(fh_test$analysis)) {
 testthat::test_that("calculate probability under alternative", {
   expect_equal(
     1 - beta,
-    max((gs_design_combo_test2$bounds %>% filter(bound == "upper"))$probability),
+    max((gs_design_combo_test2$bounds %>% dplyr::filter(bound == "upper"))$probability),
     tolerance = 0.0001
   )
 })
@@ -121,7 +121,7 @@ testthat::test_that("calculate probability under alternative", {
 testthat::test_that("calculate probability under null", {
   expect_equal(
     alpha,
-    max((gs_design_combo_test2$bounds %>% filter(bound == "upper"))$probability0),
+    max((gs_design_combo_test2$bounds %>% dplyr::filter(bound == "upper"))$probability0),
     tolerance = 0.005
   )
 })

--- a/tests/testthat/test-independent-gs_design_npe.R
+++ b/tests/testthat/test-independent-gs_design_npe.R
@@ -1,6 +1,5 @@
 # Parameters used repeatedly
-library(gsDesign)
-library(gsDesign2)
+
 K <- 3
 timing <- c(.45, .8, 1)
 sfu <- gsDesign::sfPower
@@ -11,9 +10,8 @@ delta <- .2
 alpha <- .02
 beta <- .15
 
-
 test_that("One-sided design fails to reproduce gsDesign package bounds", {
-  gsd <- gsDesign(
+  gsd <- gsDesign::gsDesign(
     test.type = 1, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
     delta = delta, alpha = alpha, beta = beta
   )
@@ -23,7 +21,7 @@ test_that("One-sided design fails to reproduce gsDesign package bounds", {
     upar = list(sf = sfu, total_spend = alpha, param = sfupar),
     lower = gs_b,
     lpar = rep(-Inf, K)
-  ) %>% filter(bound == "upper")
+  ) %>% dplyr::filter(bound == "upper")
 
   # compare boundaries
   expect_equal(gsd$upper$bound, gsdv$z, tolerance = 7e-6)
@@ -31,7 +29,7 @@ test_that("One-sided design fails to reproduce gsDesign package bounds", {
 
   # compare statistical information
   # While tolerance should not be problematic, it seems large
-  expect_equal(gsd$n.I, (gsdv %>% filter(bound == "upper"))$info, tolerance = .04)
+  expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability
   expect_equal(gsdv$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
@@ -39,7 +37,7 @@ test_that("One-sided design fails to reproduce gsDesign package bounds", {
 
 
 test_that("Two-sided symmetric design fails to reproduce gsDesign test.type=2 bounds", {
-  gsd <- gsDesign(
+  gsd <- gsDesign::gsDesign(
     test.type = 2, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
     delta = delta, alpha = alpha, beta = beta, tol = 1e-6
   )
@@ -54,19 +52,19 @@ test_that("Two-sided symmetric design fails to reproduce gsDesign test.type=2 bo
     tol = 1e-6
   )
   # compare boundaries
-  expect_equal(gsd$upper$bound, (gsdv %>% filter(bound == "upper"))$z, tolerance = 7e-6)
-  expect_equal(gsd$lower$bound, (gsdv %>% filter(bound == "lower"))$z, tolerance = 7e-6)
+  expect_equal(gsd$upper$bound, (gsdv %>% dplyr::filter(bound == "upper"))$z, tolerance = 7e-6)
+  expect_equal(gsd$lower$bound, (gsdv %>% dplyr::filter(bound == "lower"))$z, tolerance = 7e-6)
 
   # compare statistical information
   # While tolerance should not be problematic, it seems large
-  expect_equal(gsd$n.I, (gsdv %>% filter(bound == "upper"))$info, tolerance = .04)
+  expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability
-  expect_equal((gsdv %>% filter(bound == "upper"))$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
+  expect_equal((gsdv %>% dplyr::filter(bound == "upper"))$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
 })
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=3 bounds", {
-  gsd <- gsDesign(
+  gsd <- gsDesign::gsDesign(
     test.type = 3, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
     delta = delta, alpha = alpha, beta = beta
   )
@@ -80,20 +78,20 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=3 b
     lpar = list(sf = sfl, total_spend = beta, param = sflpar)
   )
   # compare boundaries
-  expect_equal(gsd$upper$bound, (gsdv %>% filter(bound == "upper"))$z, tolerance = 7e-6)
-  expect_equal(gsd$lower$bound, (gsdv %>% filter(bound == "lower"))$z, tolerance = 9e-6)
+  expect_equal(gsd$upper$bound, (gsdv %>% dplyr::filter(bound == "upper"))$z, tolerance = 7e-6)
+  expect_equal(gsd$lower$bound, (gsdv %>% dplyr::filter(bound == "lower"))$z, tolerance = 9e-6)
 
   # compare statistical information
   # While tolerance should not be problematic, it seems large
-  expect_equal(gsd$n.I, (gsdv %>% filter(bound == "upper"))$info, tolerance = .04)
+  expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability under null hypothesis (theta = 0)
-  expect_equal((gsdv %>% filter(bound == "upper"))$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
-  expect_equal((gsdv %>% filter(bound == "lower"))$probability, sfl(alpha = beta, t = timing, param = sflpar)$spend)
+  expect_equal((gsdv %>% dplyr::filter(bound == "upper"))$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
+  expect_equal((gsdv %>% dplyr::filter(bound == "lower"))$probability, sfl(alpha = beta, t = timing, param = sflpar)$spend)
 })
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 bounds", {
-  gsd <- gsDesign(
+  gsd <- gsDesign::gsDesign(
     test.type = 4, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
     delta = delta, alpha = alpha, beta = beta
   )
@@ -108,19 +106,19 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 b
   )
 
   # compare boundaries
-  expect_equal(gsd$upper$bound, (gsdv %>% filter(bound == "upper"))$z, tolerance = 7e-6)
-  expect_equal(gsd$lower$bound, (gsdv %>% filter(bound == "lower"))$z, tolerance = 9e-6)
+  expect_equal(gsd$upper$bound, (gsdv %>% dplyr::filter(bound == "upper"))$z, tolerance = 7e-6)
+  expect_equal(gsd$lower$bound, (gsdv %>% dplyr::filter(bound == "lower"))$z, tolerance = 9e-6)
 
   # compare statistical information
   # While tolerance should not be problematic, it seems large
-  expect_equal(gsd$n.I, (gsdv %>% filter(bound == "upper"))$info, tolerance = .04)
+  expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability under null hypothesis (theta = 0)
   expect_equal(
     gsdv$probability0,
     gsDesign::gsBoundSummary(gsd) %>%
       subset(Value == "P(Cross) if delta=0") %>%
-      select(Efficacy, Futility) %>%
+      dplyr::select(Efficacy, Futility) %>%
       t() %>%
       as.numeric(),
     tolerance = .0001
@@ -130,7 +128,7 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 b
     gsdv$probability,
     gsDesign::gsBoundSummary(gsd) %>%
       subset(Value == "P(Cross) if delta=1") %>%
-      select(Efficacy, Futility) %>%
+      dplyr::select(Efficacy, Futility) %>%
       t() %>%
       as.numeric(),
     tolerance = .0001
@@ -140,7 +138,7 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 b
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 bounds", {
   astar <- 0.2
-  gsd <- gsDesign(
+  gsd <- gsDesign::gsDesign(
     test.type = 5, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
     delta = delta, alpha = alpha, beta = beta, astar = astar
   )
@@ -155,18 +153,18 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 b
   )
 
   # compare boundaries
-  expect_equal(gsd$upper$bound, (gsdv %>% filter(bound == "upper"))$z, tolerance = 7e-6)
-  expect_equal(gsd$lower$bound, (gsdv %>% filter(bound == "lower"))$z, tolerance = 9e-6)
+  expect_equal(gsd$upper$bound, (gsdv %>% dplyr::filter(bound == "upper"))$z, tolerance = 7e-6)
+  expect_equal(gsd$lower$bound, (gsdv %>% dplyr::filter(bound == "lower"))$z, tolerance = 9e-6)
 
   # compare statistical information
   # While tolerance should not be problematic, it seems large
-  expect_equal(gsd$n.I, (gsdv %>% filter(bound == "upper"))$info, tolerance = .04)
+  expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability under null hypothesis (theta = 0)
-  expect_equal((gsdv %>% filter(bound == "upper"))$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
+  expect_equal((gsdv %>% dplyr::filter(bound == "upper"))$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
   expect_equal(
     (gs_power_npe(
-      theta = 0, info = (gsdv %>% filter(bound == "upper"))$info,
+      theta = 0, info = (gsdv %>% dplyr::filter(bound == "upper"))$info,
       theta1 = 0, # Spending for lower bound under H0
       binding = TRUE, # Use this for test.type=3 and 5
       upper = gs_spending_bound,
@@ -174,7 +172,7 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 b
       lower = gs_spending_bound,
       lpar = list(sf = sfl, total_spend = astar, param = sflpar)
     ) %>%
-      filter(bound == "lower")
+      dplyr::filter(bound == "lower")
     )$probability,
     sfl(alpha = astar, t = timing, param = sflpar)$spend
   )
@@ -182,7 +180,7 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 b
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=6 bounds", {
   astar <- 0.2
-  gsd <- gsDesign(
+  gsd <- gsDesign::gsDesign(
     test.type = 6, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
     delta = delta, alpha = alpha, beta = beta, astar = astar
   )
@@ -197,22 +195,22 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=6 b
   )
 
   # compare boundaries
-  expect_equal(gsd$upper$bound, (gsdv %>% filter(bound == "upper"))$z, tolerance = 7e-6)
-  expect_equal(gsd$lower$bound, (gsdv %>% filter(bound == "lower"))$z, tolerance = 9e-6)
+  expect_equal(gsd$upper$bound, (gsdv %>% dplyr::filter(bound == "upper"))$z, tolerance = 7e-6)
+  expect_equal(gsd$lower$bound, (gsdv %>% dplyr::filter(bound == "lower"))$z, tolerance = 9e-6)
 
   # compare statistical information
   # While tolerance should not be problematic, it seems large
-  expect_equal(gsd$n.I, (gsdv %>% filter(bound == "upper"))$info, tolerance = .04)
+  expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability under null hypothesis (theta = 0)
   expect_equal(
-    (gsdv %>% filter(bound == "upper"))$probability0,
+    (gsdv %>% dplyr::filter(bound == "upper"))$probability0,
     sfu(alpha = alpha, t = timing, param = sfupar)$spend,
     tolerance = 1e-5
   )
   expect_equal(
     (gs_power_npe(
-      theta = 0, info = (gsdv %>% filter(bound == "upper"))$info,
+      theta = 0, info = (gsdv %>% dplyr::filter(bound == "upper"))$info,
       theta1 = 0, # Spending for lower bound under H0
       binding = TRUE, # Use this for test.type=3 and 5
       upper = gs_spending_bound,
@@ -220,7 +218,7 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=6 b
       lower = gs_spending_bound,
       lpar = list(sf = sfl, total_spend = astar, param = sflpar)
     ) %>%
-      filter(bound == "lower")
+      dplyr::filter(bound == "lower")
     )$probability,
     sfl(alpha = astar, t = timing, param = sflpar)$spend
   )

--- a/tests/testthat/test-independent-gs_design_npe.R
+++ b/tests/testthat/test-independent-gs_design_npe.R
@@ -60,7 +60,10 @@ test_that("Two-sided symmetric design fails to reproduce gsDesign test.type=2 bo
   expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability
-  expect_equal((gsdv %>% dplyr::filter(bound == "upper"))$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
+  expect_equal(
+    (gsdv %>% dplyr::filter(bound == "upper"))$probability0,
+    sfu(alpha = alpha, t = timing, param = sfupar)$spend
+  )
 })
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=3 bounds", {
@@ -86,8 +89,14 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=3 b
   expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability under null hypothesis (theta = 0)
-  expect_equal((gsdv %>% dplyr::filter(bound == "upper"))$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
-  expect_equal((gsdv %>% dplyr::filter(bound == "lower"))$probability, sfl(alpha = beta, t = timing, param = sflpar)$spend)
+  expect_equal(
+    (gsdv %>% dplyr::filter(bound == "upper"))$probability0,
+    sfu(alpha = alpha, t = timing, param = sfupar)$spend
+  )
+  expect_equal(
+    (gsdv %>% dplyr::filter(bound == "lower"))$probability,
+    sfl(alpha = beta, t = timing, param = sflpar)$spend
+  )
 })
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 bounds", {
@@ -161,7 +170,10 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 b
   expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
   # compare crossing boundaries probability under null hypothesis (theta = 0)
-  expect_equal((gsdv %>% dplyr::filter(bound == "upper"))$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
+  expect_equal(
+    (gsdv %>% dplyr::filter(bound == "upper"))$probability0,
+    sfu(alpha = alpha, t = timing, param = sfupar)$spend
+  )
   expect_equal(
     (gs_power_npe(
       theta = 0, info = (gsdv %>% dplyr::filter(bound == "upper"))$info,

--- a/tests/testthat/test-independent-gs_info_ahr.R
+++ b/tests/testthat/test-independent-gs_info_ahr.R
@@ -19,7 +19,7 @@ testthat::test_that("results match if only put in targeted analysis times", {
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
       analysis_time = total_duration
-    ) %>% select(time, ahr, event, info, info0),
+    ) %>% dplyr::select(time, ahr, event, info, info0),
     ahr(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
@@ -37,7 +37,7 @@ testthat::test_that("results match if only put in targeted events", {
   total_duration <- out1$time
 
   testthat::expect_equal(
-    out1 %>% select(time, ahr, event, info, info0),
+    out1 %>% dplyr::select(time, ahr, event, info, info0),
     ahr(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
@@ -66,7 +66,7 @@ testthat::test_that("results match if put in both analysis time and targeted eve
   total_duration <- out1$time
 
   testthat::expect_equal(
-    out1 %>% select(time, ahr, event, info, info0),
+    out1 %>% dplyr::select(time, ahr, event, info, info0),
     ahr(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,

--- a/tests/testthat/test-independent-gs_power_ahr.R
+++ b/tests/testthat/test-independent-gs_power_ahr.R
@@ -1,17 +1,15 @@
-library(gsDesign)
-
 # Test 1: compare with gsDesign under proportional hazard ####
 
-x <- gsSurv(
+x <- gsDesign::gsSurv(
   k = 2,
   test.type = 1,
   alpha = 0.025,
   beta = 0.2,
   astar = 0,
   timing = 0.7,
-  sfu = sfLDOF,
+  sfu = gsDesign::sfLDOF,
   sfupar = c(0),
-  sfl = sfLDOF,
+  sfl = gsDesign::sfLDOF,
   sflpar = c(0),
   lambdaC = log(2) / 9,
   hr = 0.65,
@@ -26,7 +24,7 @@ x <- gsSurv(
 )
 
 # update x with gsDesign() to get integer event counts
-x <- gsDesign(
+x <- gsDesign::gsDesign(
   k = x$k,
   test.type = 1,
   alpha = x$alpha,
@@ -39,7 +37,7 @@ x <- gsDesign(
   delta1 = x$delta1,
   delta0 = x$delta0
 )
-y <- gsBoundSummary(x,
+y <- gsDesign::gsBoundSummary(x,
   ratio = 1,
   digits = 4,
   ddigits = 2,

--- a/tests/testthat/test-independent-gs_power_npe.R
+++ b/tests/testthat/test-independent-gs_power_npe.R
@@ -13,8 +13,8 @@ test_that("expect equal with mvtnorm for efficacy and futility bounds", {
     lpar = list(sf = gsDesign::sfLDOF, param = NULL, total_spend = 0.02)
   )
 
-  test1 <- test %>% filter(bound == "upper")
-  test2 <- test %>% filter(bound == "lower")
+  test1 <- test %>% dplyr::filter(bound == "upper")
+  test2 <- test %>% dplyr::filter(bound == "lower")
 
   alpha.t <- 0.025
   b.ia <- gsDesign::sfLDOF(alpha = alpha.t, t = r)
@@ -69,14 +69,14 @@ test_that("expect equal with gsDesign::gsProbability outcome for efficacy bounds
       upar = list(sf = gsDesign::sfLDOF, param = NULL, total_spend = 0.025),
       lower = gs_b,
       lpar = rep(-Inf, 3)
-    ) %>% filter(bound == "upper")
+    ) %>% dplyr::filter(bound == "upper")
 
   x3 <- gsDesign::gsProbability(
     k = 3,
     theta = .1,
     n.I = info,
     a = rep(-20, 3),
-    b = gsDesign(k = 3, test.type = 1, sfu = sfLDOF, n.I = info)$upper$bound
+    b = gsDesign::gsDesign(k = 3, test.type = 1, sfu = gsDesign::sfLDOF, n.I = info)$upper$bound
   )
 
 


### PR DESCRIPTION
Following the recommendation in [R Packages](https://r-pkgs.org/testing-basics.html#test-organisation) (also tidyverse and tidymodels conventions), this PR removes the extra `library()` calls from `tests/testthat.R` and individual tests, and qualify the namespaces explicitly.

The involved namespaces and functions include (might not be exhaustive):

```
- gsDesign: gsDesign gsSurv gsBoundSummary sfLDOF
- tibble: tibble
- dplyr: filter mutate transmute full_join group_by summarize ungroup
  first last lag lead select arrange desc right_join rename
```