### PR TITLE
Update vignette for spending bounds under nph

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -11,6 +11,9 @@ exclusions:
     list(
       "inst/",
       "tests/testthat/old_function/",
+      "vignettes/articles/usage-gs-spending-bound.Rmd" = list(
+        object_name_linter = Inf
+      ),
       "data-raw/simu_test_gs_design_combo.R" = list(
         object_name_linter = Inf,
         commented_code_linter = Inf

--- a/vignettes/articles/story-design-with-spending.Rmd
+++ b/vignettes/articles/story-design-with-spending.Rmd
@@ -9,11 +9,10 @@ output:
     number_sections: true
     highlight: "textmate"
     css: "custom.css"
-# bibliography: "example.bib"
 vignette: >
   %\VignetteIndexEntry{Trial design with spending under NPH}
-  %\VignetteEncoding{UTF-8}
   %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 ---
 
 ```{r, include=FALSE}
@@ -24,11 +23,8 @@ knitr::opts_chunk$set(
 ```
 
 ```{r, message=FALSE, warning=FALSE}
-library(dplyr)
-library(tibble)
 library(gsDesign)
 library(gsDesign2)
-library(gt)
 ```
 
 # Overview
@@ -36,7 +32,7 @@ library(gt)
 This vignette covers how to implement designs for trials with spending assuming non-proportional hazards.
 We are primarily concerned with practical issues of implementation rather than design strategies, but we will not ignore design strategy.
 
-# Scenario for Consideration
+# Scenario for consideration
 
 Here we set up enrollment, failure and dropout rates along with assumptions for enrollment duration and times of analyses.
 We assume there are 4 analysis (3 interim analyses + 1 final analysis) conducted 18, 24, 30, and 36 months after trial enrollment is opened.
@@ -57,8 +53,8 @@ enroll_rate <- define_enroll_rate(
 )
 
 enroll_rate |>
-  gt() |>
-  tab_header(title = "Planned Relative Enrollment Rates")
+  gt::gt() |>
+  gt::tab_header(title = "Planned Relative Enrollment Rates")
 ```
 
 We assume a hazard ratio (HR) of 0.9 for the first 3 months 0.6 thereafter.
@@ -73,51 +69,60 @@ fail_rate <- define_fail_rate(
 )
 
 fail_rate |>
-  gt() |>
-  tab_header(title = "Table of Failure Rate Assumptions") 
+  gt::gt() |>
+  gt::tab_header(title = "Table of Failure Rate Assumptions")
 ```
 
-# Fixed Design with no Interim Analysis
+# Fixed design with no interim analysis
 
 We can derive power for the above enrollment rates and failure rates as follows:
 
 ```{r}
-fixed_design_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, power = NULL, ratio = 1, study_duration = 36, event = NULL) |> 
-  summary()
+fixed_design_ahr(
+  enroll_rate = enroll_rate,
+  fail_rate = fail_rate,
+  power = NULL,
+  ratio = 1,
+  study_duration = 36,
+  event = NULL
+) |> summary()
 ```
-
-
 
 We now compute sample size and then translate from a continuous sample size to an integer sample size.
 
 ```{r}
-fixed_design <- fixed_design_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, power = .9, ratio = 1, study_duration = 36, event = NULL) |> 
-  to_integer()
+fixed_design <- fixed_design_ahr(
+  enroll_rate = enroll_rate,
+  fail_rate = fail_rate,
+  power = .9,
+  ratio = 1,
+  study_duration = 36,
+  event = NULL
+) |> to_integer()
+
 fixed_design$analysis
 ```
 
-
-## Group Sequential Design
+## Group sequential design
 
 We now consider a group sequential design with bounds derived using spending functions.
 We target the interim analysis for 24 months and the final analysis for 36 months.
 Spending for both efficacy and futility is based on the proportion of events expected at each analysis divided by the total expected events at the final analysis.
 
-
-
 ```{r}
-gs <- 
-  gs_design_ahr(
-    enroll_rate = enroll_rate,
-    fail_rate = fail_rate,
-    info_frac = NULL,
-    analysis_time = c(24, 36),
-    upper = gs_spending_bound,
-    lower = gs_spending_bound,
-    upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
-    lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1, param = NULL, timing = NULL), 
-    h1_spending = TRUE
-  ) |> to_integer()
-summary(gs) |> gt()
-```
+gs <- gs_design_ahr(
+  enroll_rate = enroll_rate,
+  fail_rate = fail_rate,
+  info_frac = NULL,
+  analysis_time = c(24, 36),
+  upper = gs_spending_bound,
+  lower = gs_spending_bound,
+  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
+  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1, param = NULL, timing = NULL),
+  h1_spending = TRUE
+) |> to_integer()
 
+gs |>
+  summary() |>
+  gt::gt()
+```

--- a/vignettes/articles/story-design-with-spending.Rmd
+++ b/vignettes/articles/story-design-with-spending.Rmd
@@ -124,3 +124,17 @@ gs <-
 summary(gs) %>% gt()
 ```
 
+The following is temporary.
+
+```{r}
+gs_npe <- 
+  gs_design_npe(
+    theta = .1,
+    info = 1:2,
+    upper = gs_spending_bound,
+    lower = gs_spending_bound,
+    upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
+    lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1, param = NULL, timing = NULL)#, theta = 0)
+  ) 
+gs_npe %>% gt()
+```

--- a/vignettes/articles/story-design-with-spending.Rmd
+++ b/vignettes/articles/story-design-with-spending.Rmd
@@ -39,18 +39,16 @@ We are primarily concerned with practical issues of implementation rather than d
 # Scenario for Consideration
 
 Here we set up enrollment, failure and dropout rates along with assumptions for enrollment duration and times of analyses.
-
-In this example, we assume there are 4 analysis (3 interim analysis + 1 final analysis), and they are conducted after 18, 24, 30, 36 months after the trail starts.
+We assume there are 4 analysis (3 interim analyses + 1 final analysis) conducted 18, 24, 30, and 36 months after trial enrollment is opened.
 
 ```{r}
 n_analysis <- 4
 analysis_time <- c(18, 24, 30, 36)
 ```
 
-And we further assume there is not stratum and the enrollment last for 12 months.
-For the first 2 months, second 2 months, third 2 months and the reminder month, the enrollment rate is $8:12:16:24$.
-Please note that $8:12:16:24$ is not the real enrollment rate.
-Instead, it only specifies the enrollment rate ratio between different duration.
+We assume there is a single stratum and enrollment targeted to last for 12 months.
+For the first 2 months, second 2 months, third 2 months and the remaining months, the relative enrollment rates are $8:12:16:24$.
+These rates will be updated by a constant multiple at the time of design as we will note below.
 
 ```{r}
 enroll_rate <- define_enroll_rate(
@@ -58,13 +56,13 @@ enroll_rate <- define_enroll_rate(
   rate = c(8, 12, 16, 24)
 )
 
-enroll_rate %>%
-  gt() %>%
-  tab_header(title = "Table of Enrollment")
+enroll_rate |>
+  gt() |>
+  tab_header(title = "Planned Relative Enrollment Rates")
 ```
 
-Moreover, we assume the hazard ratio (HR) of the first 3 month is 0.9 and thereafter is 0.6.
-We also assume the the survival time follow a piecewise exponential distribution with a median of 8 month for the first 3 months and 14 month thereafter.
+We assume a hazard ratio (HR) of 0.9 for the first 3 months 0.6 thereafter.
+We also assume the the control time-to-event follows a piecewise exponential distribution with a median of 8 month for the first 3 months and 14 months thereafter.
 
 ```{r}
 fail_rate <- define_fail_rate(
@@ -74,9 +72,9 @@ fail_rate <- define_fail_rate(
   dropout_rate = .001
 )
 
-fail_rate %>%
-  gt() %>%
-  tab_header(title = "Table of Failure Rate")
+fail_rate |>
+  gt() |>
+  tab_header(title = "Table of Failure Rate Assumptions") 
 ```
 
 # Fixed Design with no Interim Analysis
@@ -84,7 +82,8 @@ fail_rate %>%
 We can derive power for the above enrollment rates and failure rates as follows:
 
 ```{r}
-fixed_design_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, power = NULL, ratio = 1, study_duration = 36, event = NULL) %>% summary()
+fixed_design_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, power = NULL, ratio = 1, study_duration = 36, event = NULL) |> 
+  summary()
 ```
 
 
@@ -92,11 +91,9 @@ fixed_design_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, power = NULL,
 We now compute sample size and then translate from a continuous sample size to an integer sample size.
 
 ```{r}
-fixed_design <- fixed_design_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, power = .9, ratio = 1, study_duration = 36, event = NULL) 
-integer_fixed_design <- fixed_design %>% to_integer()
-# NOTE: the next line should not be needed, but to_integer() changed names
-names(integer_fixed_design$analysis) <- names(fixed_design$analysis)
-summary(integer_fixed_design)
+fixed_design <- fixed_design_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, power = .9, ratio = 1, study_duration = 36, event = NULL) |> 
+  to_integer()
+fixed_design$analysis
 ```
 
 
@@ -120,21 +117,7 @@ gs <-
     upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
     lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1, param = NULL, timing = NULL), 
     h1_spending = TRUE
-  ) %>% to_integer()
-summary(gs) %>% gt()
+  ) |> to_integer()
+summary(gs) |> gt()
 ```
 
-The following is temporary.
-
-```{r}
-gs_npe <- 
-  gs_design_npe(
-    theta = .1,
-    info = 1:2,
-    upper = gs_spending_bound,
-    lower = gs_spending_bound,
-    upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
-    lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1, param = NULL, timing = NULL)#, theta = 0)
-  ) 
-gs_npe %>% gt()
-```

--- a/vignettes/articles/story-design-with-spending.Rmd
+++ b/vignettes/articles/story-design-with-spending.Rmd
@@ -79,149 +79,48 @@ fail_rate %>%
   tab_header(title = "Table of Failure Rate")
 ```
 
-# Deriving Power for a Given Sample Size
+# Fixed Design with no Interim Analysis
 
-In this section, we discuss how to drive the power, given a known sample size.
-
-First, we calculate the number of events and statistical information (both under H0 and H1) at targeted analysis times.
+We can derive power for the above enrollment rates and failure rates as follows:
 
 ```{r}
-xx <- ahr(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  total_duration = analysis_time
-)
-
-xx %>% gt()
+fixed_design_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, power = NULL, ratio = 1, study_duration = 36, event = NULL) %>% summary()
 ```
 
-Then, we can use `gs_info_ahr()` to calculate (1) the treatment effect (`theta`), (2) AHR, (3) the statistical information (both under H0 and H1) under the targeted number of events.
+
+
+We now compute sample size and then translate from a continuous sample size to an integer sample size.
 
 ```{r}
-yy <- gs_info_ahr(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  event = ceiling(xx$event)
-) %>%
-  mutate(timing = info0 / max(info0))
-
-yy %>%
-  gt() %>%
-  fmt_number(columns = 2:8, decimals = 4)
+fixed_design <- fixed_design_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, power = .9, ratio = 1, study_duration = 36, event = NULL) 
+integer_fixed_design <- fixed_design %>% to_integer()
+# NOTE: the next line should not be needed, but to_integer() changed names
+names(integer_fixed_design$analysis) <- names(fixed_design$analysis)
+summary(integer_fixed_design)
 ```
 
-Finally, we can calculate the power of `yy` by using `gs_power_npe()`.
-
-```{r}
-zz <- gs_power_npe(
-  # set the treatment effet
-  theta = yy$theta,
-  # set the statistical information under H0 and H1
-  info = yy$info,
-  info0 = yy$info0,
-  # set the upper bound
-  upper = gs_b,
-  upar = gsDesign(k = n_analysis, test.type = 2, sfu = sfLDOF, alpha = .025, timing = yy$timing)$upper$bound,
-  # set the lower bound
-  lower = gs_b,
-  lpar = gsDesign(k = n_analysis, test.type = 2, sfu = sfLDOF, alpha = .025, timing = yy$timing)$lower$bound
-)
-
-zz %>%
-  filter(bound == "upper") %>%
-  select(analysis, bound, z, probability, info_frac) %>%
-  gt() %>%
-  fmt_number(columns = 3:5, decimals = 4)
-```
-From the above table, we find the power is 0.6267.
-
-# Deriving Sample Size for a Given Power
-
-In this section, we discuss how to calculate the sample size for a given power (we take the given power as 0.9 in this section).
-And we discuss the calculation into 2 scenarios: (1) fixed design and (2) group sequential design.
-
-```{r}
-target_power <- 0.9
-```
-
-## Fixed Design
-
-If we were using a fixed design, we would approximate the sample size as follows:
-
-```{r}
-minx <- (
-  (
-    qnorm(.025) / sqrt(zz$info0[n_analysis]) +
-      qnorm(1 - target_power) / sqrt(zz$info[n_analysis])
-  ) /
-    zz$theta[n_analysis]
-)^2
-minx
-```
-
-If we inflate the enrollment rates by `minx` and use a fixed design, we will see this achieves the targeted power.
-
-```{r}
-gs_power_npe(
-  theta = yy$theta[n_analysis],
-  info = yy$info[n_analysis] * minx,
-  info0 = yy$info0[n_analysis] * minx,
-  upar = qnorm(.975),
-  lpar = -Inf
-) %>%
-  filter(bound == "upper") %>%
-  select(probability)
-```
 
 ## Group Sequential Design
 
-The power for a group sequential design with the same final sample size is a bit lower:
+We now consider a group sequential design with bounds derived using spending functions.
+We target the interim analysis for 24 months and the final analysis for 36 months.
+Spending for both efficacy and futility is based on the proportion of events expected at each analysis divided by the total expected events at the final analysis.
+
+
 
 ```{r}
-gs_power_npe(
-  theta = yy$theta,
-  info = yy$info * minx,
-  info0 = yy$info0 * minx,
-  upper = gs_spending_bound,
-  lower = gs_spending_bound,
-  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
-  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
-) %>%
-  filter(bound == "upper", analysis == n_analysis) %>%
-  select(probability) %>%
-  gt()
+gs <- 
+  gs_design_ahr(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    info_frac = NULL,
+    analysis_time = c(24, 36),
+    upper = gs_spending_bound,
+    lower = gs_spending_bound,
+    upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
+    lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1, param = NULL, timing = NULL), 
+    h1_spending = TRUE
+  ) %>% to_integer()
+summary(gs) %>% gt()
 ```
 
-If we inflate this a bit we will be overpowered.
-
-```{r}
-gs_power_npe(
-  theta = yy$theta,
-  info = yy$info * minx * 1.2,
-  info0 = yy$info0 * minx * 1.2,
-  upper = gs_spending_bound,
-  lower = gs_spending_bound,
-  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
-  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
-) %>%
-  filter(bound == "upper", analysis == n_analysis) %>%
-  select(probability) %>%
-  gt()
-```
-
-Now we use `gs_design_npe()` to inflate the information proportionately to power the trial.
-
-```{r}
-gs_design_npe(
-  theta = yy$theta,
-  info = yy$info,
-  info0 = yy$info0,
-  upper = gs_spending_bound,
-  lower = gs_spending_bound,
-  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
-  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
-) %>%
-  filter(bound == "upper", analysis == n_analysis) %>%
-  select(probability) %>%
-  gt()
-```

--- a/vignettes/articles/usage-gs-spending-bound.Rmd
+++ b/vignettes/articles/usage-gs-spending-bound.Rmd
@@ -1,6 +1,6 @@
 ---
-title: "gs_spending_bound: compute spending boundary in group sequential design"
-author: "Yujie Zhao"
+title: "Computing spending boundaries in group sequential design"
+author: "Keaven Anderson and Yujie Zhao "
 output:
   rmarkdown::html_document:
     toc: true
@@ -9,10 +9,10 @@ output:
     number_sections: true
     highlight: "textmate"
     css: "custom.css"
-# bibliography: "example.bib"
+bibliography: "gsDesign2.bib"
 vignette: >
   %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteIndexEntry{gs_spending_bound: compute spending boundary in group sequential design}
+  %\VignetteIndexEntry{Computing spending boundaries in group sequential design}
 ---
 
 ```{r, message=FALSE, warning=FALSE}
@@ -21,57 +21,435 @@ library(dplyr)
 library(gsDesign2)
 ```
 
-# Introduction of `gs_spending_bound()`
+# Introduction
 
-`gs_spending_bound()` can be used to derive spending boundary in group sequential design. It is usually used in the `upper = ...` and `lower = ...` arguments in
+We compare derivation of different spending bounds using the *gsDesign2* and *gsDesign* packages.
+In *gsDesign* there are 6 types of bounds. We demonstrate here how to replicate these using *gsDesign2*.
+In *gsDesign2* the `gs_spending_bound()` function can be used to derive spending boundaries for all group sequential design derivations and power calculations. 
+We demonstrate with the `gs_design_ahr()` function here, using designs under proportional hazards assumptions to compare with `gsDesign::gsSurv()`. 
+Since the sample size methods differ between the `gsDesign2::gs_design_ahr()` and `gsDesign::gsSurv()` functions, we use continuous sample sizes so that spending bounds (Z-values, nominal p-values, spending) should be identical except where noted. 
+Indeed, we are able to reproduce bounds to a high degree of accuracy.
+Due to the different sample size methods, sample size and other boundary approximations vary slightly.
 
-- `gs_power_npe()`
-- `gs_design_npe()`
-- `gs_power_ahr()`
-- `gs_design_ahr()`
-- `gs_power_wlr()`
-- `gs_design_wlr()`
-- `gs_power_combo()`
-- `gs_design_combo()`
+We also present a seventh example where to implement a futility bound based on observed hazard ratio as well as a Haybittle-Peto-like efficacy bound. In particular, the futility bound would be difficult to implement using the *gsDesign* package while it is straightforward using *gsDesign2*.
 
-# Usage of `gs_spending_bound()`
+For all of our examples, we will use the following design assumptions:
 
-## Example 1
-
-```{r}
-info <- (1:3) * 10
-info_frac <- info / max(info)
-k <- length(info_frac)
-
-# 1st analysis
-a1 <- gs_spending_bound(
-  k = 1, efficacy = FALSE, theta = 0,
-  par = list(sf = gsDesign::sfLDOF, total_spend = 0.025, timing = info_frac, param = NULL),
-  hgm1 = NULL
-)
-
-b1 <- gs_spending_bound(
-  k = 1, efficacy = TRUE, theta = 0,
-  par = list(sf = gsDesign::sfLDOF, total_spend = 0.025, timing = info_frac, param = NULL),
-  hgm1 = NULL
-)
-cat("The (lower, upper) boundary at the 1st analysis is (", a1, ", ", b1, ").\n")
-
-# 2nd analysis
-a2 <- gs_spending_bound(
-  k = 2, efficacy = FALSE, theta = 0,
-  par = list(sf = gsDesign::sfLDOF, total_spend = 0.025, timing = info_frac, param = NULL),
-  hgm1 = gsDesign2:::h1(r = 18, theta = 0, info = info[1], a = a1, b = b1)
-)
-
-b2 <- gs_spending_bound(
-  k = 2, efficacy = TRUE, theta = 0,
-  par = list(sf = gsDesign::sfLDOF, total_spend = 0.025, timing = info_frac, param = NULL),
-  hgm1 = gsDesign2:::h1(r = 18, theta = 0, info = info[1], a = a1, b = b1)
-)
-cat("The upper boundary at the 2nd analysis is (", a2, ", ", b2, ").\n")
+```{r, message=FALSE}
+library(gt)
+library(gsDesign2)
+library(gsDesign)
+trial_duration <- 36         # Planned trial duration
+info_frac <- c(.35, .7, 1)   # Information fraction at analyses
+# 16 month planned enrollment with constant rate
+enroll_rate <- define_enroll_rate(duration = 16, rate = 1)
+# Minimum follow-up for gsSurv() (computed)
+minfup <- trial_duration - enroll_rate$duration
+# Failure rates
+fail_rate <-
+  define_fail_rate(
+    duration = Inf,          # single time period, exponential failure
+                             # 4 months and then remainder
+    fail_rate = log(2) / 12, # Exponential time-to-event with 12 month median
+    hr = .7,                 # Proportional hazards
+    dropout_rate = -log(.99) / 12  # 1% dropout rate per year
+  )
+alpha <- 0.025  # Type I error
+beta <- 0.15    # 85% power = 15% Type II error
+ratio <- 1      # Randomization ratio
 ```
 
-# Inner Logic of `gs_spending_bound()`
 
-TODO
+
+# Examples
+
+Analogous to the *gsDesign* package, we look at 6 variations on combinations of efficacy and futility bounds.
+
+## Example 1: Efficacy bound only
+
+One-sided design has only an efficacy bound.
+An easy way to do this is to use a fixed bound (`lower = gs_b`) with negative infinite bounds (`lpar = rep(-Inf, 3)`); in the table, infinite bounds do not appear.
+The upper bound implements a spending bound (`upper = gs_spending_bound`) and the list of objects provided in `upar`.
+The only parts of the list used here are `sf = gsDesign::sfLDOF` to select a Lan-DeMets spending function that approximates an O'Brien-Fleming bound. The `total_spend = alpha` sets the total spending to the targeted Type I error for the study.
+The upper bound provides the Type I error control for the design as it is not specified elsewhere.
+
+
+```{r}
+upar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL, timing = NULL)
+
+one_sided <- gsDesign2::gs_design_ahr(
+  enroll_rate = enroll_rate, fail_rate = fail_rate,
+  ratio = ratio, beta = beta,
+  # Information fraction at analyses and trial duration
+  info_frac = info_frac, analysis_time = trial_duration,
+  # precision parameters for computations
+  r = 32, tol = 1e-08,
+  # Use NULL information for Type I error, H1 information for Type II error
+  info_scale = "h0_info", # Default
+  # Upper spending bound and corresponding parameter(s)
+  upper = gs_spending_bound, upar = upar,
+  # No lower bound
+  lower = gs_b, lpar = rep(-Inf, 3)
+)
+
+summary(one_sided) |> gsDesign2::as_gt(title = "Efficacy bound only", subtitle = "alpha-spending")
+```
+
+Check with `gsDesign::gsSurv().` As noted above, sample size and event counts vary slightly from the design derived using `gs_design_ahr()`.
+This also results in different crossing probabilities under the alternate hypothesis at interim analyses.
+
+```{r}
+oneSided <-
+   gsSurv(alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup,
+          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+          r = 32, tol = 1e-08, # Precision parameters for computations
+          test.type = 1, # One-sided bound; efficacy only
+          # Upper bound parameters
+          sfu = upar$sf, sfupar = upar$param,
+          )
+oneSided |> gsBoundSummary()
+```
+
+Comparing Z-value bounds directly we see they are the same through approximately 6 digits with precision parameters chosen (`r=32, tol = 1e-08`):
+
+```{r}
+one_sided$bound$z - oneSided$upper$bound
+```
+
+
+
+## Example 2: Symmetric 2-sided design
+
+We now derive a symmetric 2-sided design. 
+This requires use of the argument `h1_spending = FALSE` to use $\alpha$-spending for both the upper and lower bounds.
+While the lower bound is labeled as a futility bound in the table, it would be better termed an efficacy bound for control better than experimental treatment.
+
+```{r}
+upar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL)
+lpar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL)
+
+symmetric <- gs_design_ahr(
+  enroll_rate = enroll_rate, fail_rate = fail_rate,
+  ratio = ratio, beta = beta,
+  # Information fraction at analyses and trial duration
+  info_frac = info_frac, analysis_time = trial_duration,
+  # precision parameters for computations
+  r = 32, tol = 1e-08,
+  # Use NULL information for Type I error, H1 information for Type II error
+  info_scale = "h0_h1_info", # Default
+  # Function and parameter(s) for upper spending bound 
+  upper = gs_spending_bound, upar = upar,
+  lower = gs_spending_bound, lpar = lpar,
+  # Symmetric design use binding bounds
+  binding = TRUE,
+  h1_spending = FALSE # Use null hypothesis spending
+)
+
+summary(symmetric) |> 
+  gsDesign2::as_gt(title = "2-sided Symmetric Design", subtitle = "Single spending function")
+```
+
+We compare with `gsDesign::gsSurv()`.
+
+```{r}
+Symmetric <-
+   gsSurv(test.type = 2, # Two-sided symmetric bound
+          alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup=minfup, r = 32, tol = 1e-08,
+          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+          sfu = upar$sf, sfupar = upar$param
+          ) 
+Symmetric |> gsBoundSummary()
+```
+
+Comparing Z-value bounds directly, we again see approximately 6 digits of accuracy.
+
+```{r}
+filter(symmetric$bound, bound == 'upper')$z - Symmetric$upper$bound
+filter(symmetric$bound, bound == 'lower')$z - Symmetric$lower$bound
+```
+
+## Example 3: Asymmetric 2-sided design with $\beta$-spending and binding futility
+
+Designs with binding futility bounds are generally not considered acceptable for Phase 3 trials as Type I error is not controlled if a futility bound is crossed and the trial continues, a not infrequent occurrence.
+For a Phase 2b study, this may be acceptable and results in a slightly smaller sample size than a comparable design with 
+a non-binding futility  bound that is presented in Example 4.
+
+
+```{r}
+upar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL)
+lpar <- list(sf = gsDesign::sfHSD, total_spend = beta, param = -.5)
+
+asymmetric_binding <- gs_design_ahr(
+  enroll_rate = enroll_rate, fail_rate = fail_rate,
+  ratio = ratio, beta = beta,
+  # Information fraction at analyses and trial duration
+  info_frac = info_frac, analysis_time = trial_duration,
+  # precision parameters for computations
+  r = 32, tol = 1e-08,
+  # Use NULL information for Type I error, H1 information for Type II error
+  info_scale = "h0_info",
+  # Function and parameter(s) for upper spending bound 
+  upper = gs_spending_bound, upar = upar,
+  lower = gs_spending_bound, lpar = lpar,
+  # Asymmetric beta-spending design using binding bounds
+  binding = TRUE,
+  h1_spending = TRUE # Use beta-spending for futility
+)
+
+summary(asymmetric_binding) |>
+  gsDesign2::as_gt(title = "2-sided asymmetric design with binding futility",
+        subtitle = "Both alpha- and beta-spending used")
+```
+
+We compare with `gsDesign::gsSurv()`.
+
+```{r}
+asymmetricBinding <-
+   gsSurv(test.type = 3, # Two-sided asymmetric bound, binding futility
+          alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup,  r = 32, tol = 1e-07,
+          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+          sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
+          ) 
+asymmetricBinding |> gsBoundSummary()
+```
+
+Comparing Z-value bounds directly, we again see approximately 6 digits of accuracy in spite of needing to relaxing accuracy to `tol = 1e-07` in the call to `gsSurv()` in order to get convergence.
+
+```{r}
+filter(asymmetric_binding$bound, bound == 'upper')$z - asymmetricBinding$upper$bound
+filter(asymmetric_binding$bound, bound == 'lower')$z - asymmetricBinding$lower$bound
+```
+
+
+## Example 4: Aymmetric 2-sided design with $\beta$-spending and non-binding futility bound
+
+In the *gsDesign* package, asymmetric designs with non-binding $\beta$-spending used for futility are the default design.
+The objectives of this type of design include:
+
+- Meaningful futility bounds to stop a trial early if no treatment benefit is emerging for the experimental treatment vs. control.
+- Type I error is controlled even if the trial continues after a futility bound is crossed.
+
+
+```{r}
+upar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL)
+lpar <- list(sf = gsDesign::sfHSD, total_spend = beta, param = -.5)
+
+asymmetric_nonbinding <- gs_design_ahr(
+  enroll_rate = enroll_rate, fail_rate = fail_rate,
+  ratio = ratio, beta = beta,
+  # Information fraction at analyses and trial duration
+  info_frac = info_frac, analysis_time = trial_duration,
+  # precision parameters for computations
+  r = 32, tol = 1e-08,
+  # Use NULL information for Type I error, H1 information for Type II error
+  info_scale = "h0_info",
+  # Function and parameter(s) for upper spending bound 
+  upper = gs_spending_bound, upar = upar,
+  lower = gs_spending_bound, lpar = lpar,
+  # Asymmetric beta-spending design use binding bounds
+  binding = FALSE,
+  h1_spending = TRUE # Use beta-spending for futility
+)
+
+summary(asymmetric_nonbinding) |>
+  gsDesign2::as_gt(title = "2-sided asymmetric design with non-binding futility",
+        subtitle = "Both alpha- and beta-spending used")
+```
+
+
+We compare with `gsDesign::gsSurv()`.
+
+```{r}
+asymmetricNonBinding <-
+   gsSurv(test.type = 4, # Two-sided asymmetric bound, non-binding futility
+          alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup, r = 32, tol = 1e-08,
+          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+          sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
+          ) 
+asymmetricNonBinding |> gsBoundSummary()
+```
+
+Comparing Z-value bounds directly, we again see approximately 6 digits of accuracy.
+
+```{r}
+filter(asymmetric_nonbinding$bound, bound == 'upper')$z - asymmetricNonBinding$upper$bound
+filter(asymmetric_nonbinding$bound, bound == 'lower')$z - asymmetricNonBinding$lower$bound
+```
+
+
+## Example 5: Aymmetric 2-sided design with null hypothesis spending and binding futility bound
+
+```{r}
+alpha_star <- .5
+upar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL)
+lpar <- list(sf = gsDesign::sfHSD, total_spend = alpha_star, param = 1)
+
+asymmetric_safety_binding <- gs_design_ahr(
+  enroll_rate = enroll_rate, fail_rate = fail_rate,
+  ratio = ratio, beta = beta,
+  # Information fraction at analyses and trial duration
+  info_frac = info_frac, analysis_time = trial_duration,
+  # precision parameters for computations
+  r = 32, tol = 1e-08,
+  # Use NULL information for Type I error, H1 information for Type II error
+  info_scale = "h0_info",
+  # Function and parameter(s) for upper spending bound 
+  upper = gs_spending_bound, upar = upar,
+  lower = gs_spending_bound, lpar = lpar,
+  # Asymmetric design use binding bounds
+  binding = TRUE,
+  h1_spending = FALSE # Use null-spending for futility
+)
+
+summary(asymmetric_safety_binding) |>
+  gsDesign2::as_gt(title = "2-sided asymmetric safety design with binding futility",
+        subtitle = "Alpha-spending used for both bounds, asymmetrically")
+```
+
+
+```{r}
+asymmetricSafetyBinding <-
+   gsSurv(test.type = 5, # Two-sided asymmetric bound, binding futility, H0 futility spending
+          astar = alpha_star, # Total Type I error spend for futility
+          alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup,
+          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+          sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
+          ) 
+asymmetricSafetyBinding |> gsBoundSummary()
+```
+
+Comparing Z-value bounds directly, we again see approximately 6 digits of accuracy.
+For `gsSurv()` this did not require the alternate arguments for `r` and `tol`.
+
+```{r}
+filter(asymmetric_safety_binding$bound, bound == 'upper')$z - asymmetricSafetyBinding$upper$bound
+filter(asymmetric_safety_binding$bound, bound == 'lower')$z - asymmetricSafetyBinding$lower$bound
+```
+
+## Example 6: Aymmetric 2-sided design with null hypothesis spending and non-binding futility bound
+
+
+
+```{r}
+upar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL)
+lpar <- list(sf = gsDesign::sfHSD, total_spend = alpha_star, param = 1)
+
+asymmetric_safety_nonbinding <- gs_design_ahr(
+  enroll_rate = enroll_rate, fail_rate = fail_rate,
+  ratio = ratio, beta = beta,
+  # Information fraction at analyses and trial duration
+  info_frac = info_frac, analysis_time = trial_duration,
+  # precision parameters for computations
+  r = 32, tol = 1e-08,
+  # Use NULL information for Type I error, H1 information for Type II error
+  info_scale = "h0_info",
+  # Function and parameter(s) for upper spending bound 
+  upper = gs_spending_bound, upar = upar,
+  lower = gs_spending_bound, lpar = lpar,
+  # Asymmetric design use non-binding bounds
+  binding = FALSE,
+  h1_spending = FALSE, # Use null-spending for futility
+  test_lower = c(TRUE, TRUE, FALSE),
+  test_upper = c(FALSE, TRUE, TRUE)
+)
+
+summary(asymmetric_safety_nonbinding) |>
+  gsDesign2::as_gt(title = "2-sided asymmetric safety design with non-binding futility",
+                   subtitle = "Alpha-spending used for both bounds, asymmetrically")
+```
+
+```{r}
+asymmetricSafetyNonBinding <-
+   gsSurv(test.type = 6, # Two-sided asymmetric bound, binding futility, H0 futility spending
+          astar = alpha_star, # Total Type I error spend for futility
+          alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup, r = 32, tol = 1e-08,
+          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+          sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
+          ) 
+asymmetricSafetyBinding |> gsBoundSummary()
+```
+
+Comparing Z-value bounds directly, we again see approximately 6 digits of accuracy.
+
+```{r}
+filter(asymmetric_safety_nonbinding$bound, bound == 'upper')$z - asymmetricSafetyNonBinding$upper$bound
+filter(asymmetric_safety_nonbinding$bound, bound == 'lower')$z - asymmetricSafetyNonBinding$lower$bound
+```
+
+## Example 7: Alternate bound types
+
+We consider two types of alternative boundary computation approaches. 
+
+- Computing futility bounds based on a hazard ratio.
+- Computing efficacy bounds with a Haybittle-Peto or a related Fleming-Harrington-O'Brien approach.
+
+We begin with a futility bound. We will consider a non-binding futility bound as it does not impact Type I error.
+Assume the clinical trial team wishes to stop the trial at the first two interim analyses if a targeted interim hazard ratio is not achieved.
+This approach can require a bit of iteration (trial and error) to incorporate the final design endpoint count; we skip over this iteration here.
+We assume we wish to consider stopping for futility if a hazard ratio greater than 1 and 0.9 are observed at interim analyses 1 and 2 with 106 and 212 events observed, respectively. The final analysis is planned for 306 events.
+
+```{r}
+# Targeted events at interim and final analysis
+# This is based on above designs and then adjusted, as necessary
+targeted_events <- c(106, 212, 305)
+```
+
+We wish to translate the hazard ratios specified to corresponding Z-values; this can be done as follows.
+
+```{r}
+interim_futility_z <- -gsDesign::hrn2z(hr = c(1, .9), n = c(106, 212))
+interim_futility_z
+```
+We will add a final futility bound of `-Inf`, indicating no final futility analysis; this gives us a vector of Z-value bounds for all analyses. 
+For this type of bound, Type II error will be computed rather based on bounds rather than the spending approach were bounds are computed based on specified spending.
+
+```{r}
+lower <- gs_b; # Allows specifying fixed Z-values for futility
+# Translated HR bounds to Z-value scale
+lpar <- c(interim_futility_z, -Inf)
+```
+
+For the efficacy bound, we first consider a Haybittle-Peto fixed bound for interim analyses.
+
+```{r}
+upper = gs_b; upar = qnorm(c(.001, .001, .0023), lower.tail = FALSE)
+```
+
+
+
+and then use a spending approach suggested by @fleming1984designs where a fixed spend is considered for each analysis. 
+
+
+
+
+```{r}
+upper <- gs_b; upar <- qnorm(c(.001, .001, .0244), lower.tail = FALSE)
+upper <- gs_spending_bound
+upar <- list(sf = gsDesign::sfLinear, 
+             total_spend = alpha, 
+             param = c(c(106, 212) / 305, c(.001, .00165)/.025), 
+             timing = NULL)
+
+asymmetric_fixed_bounds <- gs_design_ahr(
+  enroll_rate = enroll_rate, fail_rate = fail_rate,
+  ratio = ratio, beta = beta,
+  # Information fraction at analyses and trial duration
+  info_frac = info_frac, analysis_time = trial_duration,
+  # precision parameters for computations
+  r = 32, tol = 1e-08,
+  # Use NULL information for Type I error, H1 information for Type II error
+  info_scale = "h0_info",
+  # Function and parameter(s) for upper spending bound 
+  upper = upper, upar = upar,
+  lower = lower, lpar = lpar,
+  # Non-binding futility bounds
+  binding = FALSE
+) |> to_integer()
+
+summary(asymmetric_fixed_bounds) |>
+  gsDesign2::as_gt(title = "2-sided asymmetric safety design with fixed non-binding futility",
+                   subtitle = "Futility bounds computed to approximate HR")
+```
+
+# References
+

--- a/vignettes/articles/usage-gs-spending-bound.Rmd
+++ b/vignettes/articles/usage-gs-spending-bound.Rmd
@@ -31,7 +31,10 @@ Since the sample size methods differ between the `gsDesign2::gs_design_ahr()` an
 Indeed, we are able to reproduce bounds to a high degree of accuracy.
 Due to the different sample size methods, sample size and other boundary approximations vary slightly.
 
-We also present a seventh example where to implement a futility bound based on observed hazard ratio as well as a Haybittle-Peto-like efficacy bound. In particular, the futility bound would be difficult to implement using the *gsDesign* package while it is straightforward using *gsDesign2*.
+We also present a seventh example to implement a futility bound based on observed hazard ratio as well as a Haybittle-Peto-like efficacy bound. In particular, the futility bound would be difficult to implement using the *gsDesign* package while it is straightforward using *gsDesign2*.
+
+For the last two examples, we implement integer sample size and event counts using the `to_integer()` function for the *gsDesign2* package and the `toInteger()` function for the *gsDesign* package.
+This would generally would be used for all cases other than when we are comparing package computations as in Examples 1-5.
 
 For all of our examples, we will use the following design assumptions:
 
@@ -44,22 +47,23 @@ info_frac <- c(.35, .7, 1)   # Information fraction at analyses
 # 16 month planned enrollment with constant rate
 enroll_rate <- define_enroll_rate(duration = 16, rate = 1)
 # Minimum follow-up for gsSurv() (computed)
-minfup <- trial_duration - enroll_rate$duration
+minfup <- trial_duration - sum(enroll_rate$duration)
 # Failure rates
 fail_rate <-
   define_fail_rate(
     duration = Inf,          # single time period, exponential failure
-                             # 4 months and then remainder
     fail_rate = log(2) / 12, # Exponential time-to-event with 12 month median
     hr = .7,                 # Proportional hazards
     dropout_rate = -log(.99) / 12  # 1% dropout rate per year
   )
-alpha <- 0.025  # Type I error
+alpha <- 0.025  # Type I error (one-sided)
 beta <- 0.15    # 85% power = 15% Type II error
-ratio <- 1      # Randomization ratio
+ratio <- 1      # Randomization ratio (experimental / control)
 ```
 
-
+The choice of Type II error of 0.15 corresponding to 85% power is intentional.
+This allows for more impactful futility bounds at interim analyses.
+Many teams may decide on the more typical 90% power (`beta = .1`), but this can make futility bounds less likely to impact early decisions.
 
 # Examples
 
@@ -68,14 +72,13 @@ Analogous to the *gsDesign* package, we look at 6 variations on combinations of 
 ## Example 1: Efficacy bound only
 
 One-sided design has only an efficacy bound.
-An easy way to do this is to use a fixed bound (`lower = gs_b`) with negative infinite bounds (`lpar = rep(-Inf, 3)`); in the table, infinite bounds do not appear.
-The upper bound implements a spending bound (`upper = gs_spending_bound`) and the list of objects provided in `upar`.
-The only parts of the list used here are `sf = gsDesign::sfLDOF` to select a Lan-DeMets spending function that approximates an O'Brien-Fleming bound. The `total_spend = alpha` sets the total spending to the targeted Type I error for the study.
+An easy way to do this is to use a fixed bound (`lower = gs_b`) with negative infinite bounds (`lpar = rep(-Inf, 3)`); in the summary table produced, infinite bounds do not appear.
+The upper bound implements a spending bound (`upper = gs_spending_bound`) and the list of objects provided in `upar` describe the spending function and any associated parameters.
+The only parts of the `upar` list used here are `sf = gsDesign::sfLDOF` to select a Lan-DeMets spending function that approximates an O'Brien-Fleming bound. The `total_spend = alpha` sets the total spending to the targeted Type I error for the study.
 The upper bound provides the Type I error control for the design as it is not specified elsewhere.
 
-
 ```{r}
-upar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL, timing = NULL)
+upar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL)
 
 one_sided <- gsDesign2::gs_design_ahr(
   enroll_rate = enroll_rate, fail_rate = fail_rate,
@@ -84,8 +87,8 @@ one_sided <- gsDesign2::gs_design_ahr(
   info_frac = info_frac, analysis_time = trial_duration,
   # precision parameters for computations
   r = 32, tol = 1e-08,
-  # Use NULL information for Type I error, H1 information for Type II error
-  info_scale = "h0_info", # Default
+  # Use NULL information for Type I error, H1 information for Type II error (power)
+  info_scale = "h0_h1_info", # Default
   # Upper spending bound and corresponding parameter(s)
   upper = gs_spending_bound, upar = upar,
   # No lower bound
@@ -95,8 +98,8 @@ one_sided <- gsDesign2::gs_design_ahr(
 summary(one_sided) |> gsDesign2::as_gt(title = "Efficacy bound only", subtitle = "alpha-spending")
 ```
 
-Check with `gsDesign::gsSurv().` As noted above, sample size and event counts vary slightly from the design derived using `gs_design_ahr()`.
-This also results in different crossing probabilities under the alternate hypothesis at interim analyses.
+Now we check this with `gsDesign::gsSurv().` As noted above, sample size and event counts vary slightly from the design derived using `gs_design_ahr()`.
+This also results in slightly different crossing probabilities under the alternate hypothesis at interim analyses as well as slightly different approximate hazard ratios required to cross bounds.
 
 ```{r}
 oneSided <-
@@ -135,14 +138,14 @@ symmetric <- gs_design_ahr(
   info_frac = info_frac, analysis_time = trial_duration,
   # precision parameters for computations
   r = 32, tol = 1e-08,
-  # Use NULL information for Type I error, H1 information for Type II error
+  # Use NULL information for Type I error, H1 information for power
   info_scale = "h0_h1_info", # Default
   # Function and parameter(s) for upper spending bound 
   upper = gs_spending_bound, upar = upar,
   lower = gs_spending_bound, lpar = lpar,
-  # Symmetric design use binding bounds
+  # Symmetric designs use binding bounds
   binding = TRUE,
-  h1_spending = FALSE # Use null hypothesis spending
+  h1_spending = FALSE # Use null hypothesis spending for lower bound
 )
 
 summary(symmetric) |> 
@@ -171,9 +174,9 @@ filter(symmetric$bound, bound == 'lower')$z - Symmetric$lower$bound
 ## Example 3: Asymmetric 2-sided design with $\beta$-spending and binding futility
 
 Designs with binding futility bounds are generally not considered acceptable for Phase 3 trials as Type I error is not controlled if a futility bound is crossed and the trial continues, a not infrequent occurrence.
-For a Phase 2b study, this may be acceptable and results in a slightly smaller sample size than a comparable design with 
-a non-binding futility  bound that is presented in Example 4.
-
+A binding futility bound means that Type I error computations assume that a trial stops when a futility bound is crossed.
+If the trial continues after a futility bound has been crossed, Type I error is no longer controlled with the computed efficacy bound.
+For a Phase 2b study, this may be acceptable and results in a slightly smaller sample size and less stringent efficacy bounds after the first analysis than a comparable design with a non-binding futility bound presented in Example 4.
 
 ```{r}
 upar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL)
@@ -186,8 +189,8 @@ asymmetric_binding <- gs_design_ahr(
   info_frac = info_frac, analysis_time = trial_duration,
   # precision parameters for computations
   r = 32, tol = 1e-08,
-  # Use NULL information for Type I error, H1 information for Type II error
-  info_scale = "h0_info",
+  # Use NULL information for Type I error, H1 information for Type II error and power
+  info_scale = "h0_h1_info",
   # Function and parameter(s) for upper spending bound 
   upper = gs_spending_bound, upar = upar,
   lower = gs_spending_bound, lpar = lpar,
@@ -221,7 +224,7 @@ filter(asymmetric_binding$bound, bound == 'lower')$z - asymmetricBinding$lower$b
 ```
 
 
-## Example 4: Aymmetric 2-sided design with $\beta$-spending and non-binding futility bound
+## Example 4: Asymmetric 2-sided design with $\beta$-spending and non-binding futility bound
 
 In the *gsDesign* package, asymmetric designs with non-binding $\beta$-spending used for futility are the default design.
 The objectives of this type of design include:
@@ -241,8 +244,8 @@ asymmetric_nonbinding <- gs_design_ahr(
   info_frac = info_frac, analysis_time = trial_duration,
   # precision parameters for computations
   r = 32, tol = 1e-08,
-  # Use NULL information for Type I error, H1 information for Type II error
-  info_scale = "h0_info",
+  # Use NULL information for Type I error, H1 info for Type II error and power
+  info_scale = "h0_h1_info", # Default
   # Function and parameter(s) for upper spending bound 
   upper = gs_spending_bound, upar = upar,
   lower = gs_spending_bound, lpar = lpar,
@@ -276,8 +279,15 @@ filter(asymmetric_nonbinding$bound, bound == 'upper')$z - asymmetricNonBinding$u
 filter(asymmetric_nonbinding$bound, bound == 'lower')$z - asymmetricNonBinding$lower$bound
 ```
 
+## Example 5: Asymmetric 2-sided design with null hypothesis spending and binding futility bound
 
-## Example 5: Aymmetric 2-sided design with null hypothesis spending and binding futility bound
+Now we use null hypothesis probabilities to set futility bounds.
+The parameter `alpha_star` is used to set the total spending for the futility bound under the null hypothesis.
+For our example, this is set to 0.5 which is a 50% probability of crossing the futility bound at the interim and final analyses combined.
+The futility bound at the final analysis really has no role, so we use the `test_lower` argument to eliminate this evaluation at the final analysis.
+This is arbitrary and largely selected so that the interim futility bounds can be meaningful tests. 
+In this case, more than a minor trend in favor of control at the first or second interim will cross a futility bound.
+This is less stringent than the $\beta$-spending bounds previously described, but still address a potential ethical issue of continuing the trial when more than a minor trend in favor of control is present.
 
 ```{r}
 alpha_star <- .5
@@ -296,6 +306,7 @@ asymmetric_safety_binding <- gs_design_ahr(
   # Function and parameter(s) for upper spending bound 
   upper = gs_spending_bound, upar = upar,
   lower = gs_spending_bound, lpar = lpar,
+  test_lower = c(TRUE, TRUE, FALSE),
   # Asymmetric design use binding bounds
   binding = TRUE,
   h1_spending = FALSE # Use null-spending for futility
@@ -323,12 +334,14 @@ For `gsSurv()` this did not require the alternate arguments for `r` and `tol`.
 
 ```{r}
 filter(asymmetric_safety_binding$bound, bound == 'upper')$z - asymmetricSafetyBinding$upper$bound
-filter(asymmetric_safety_binding$bound, bound == 'lower')$z - asymmetricSafetyBinding$lower$bound
+filter(asymmetric_safety_binding$bound, bound == 'lower')$z - asymmetricSafetyBinding$lower$bound[1:2]
 ```
 
-## Example 6: Aymmetric 2-sided design with null hypothesis spending and non-binding futility bound
+## Example 6: Asymmetric 2-sided design with null hypothesis spending and non-binding futility bound
 
-
+Again, we would recommend a non-binding bound presented here over the binding bound in example 5.
+We again eliminate the final futility bound using the `test_lower` argument.
+Addition, we show how to eliminate the efficacy bound at interim 1 allowing a team to decide that it is too early to stop a trial for efficacy without longer-term data.
 
 ```{r}
 upar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL)
@@ -345,18 +358,21 @@ asymmetric_safety_nonbinding <- gs_design_ahr(
   info_scale = "h0_info",
   # Function and parameter(s) for upper spending bound 
   upper = gs_spending_bound, upar = upar,
+  test_upper = c(FALSE, TRUE, TRUE),
   lower = gs_spending_bound, lpar = lpar,
+  test_lower = c(TRUE, TRUE, FALSE),
   # Asymmetric design use non-binding bounds
   binding = FALSE,
-  h1_spending = FALSE, # Use null-spending for futility
-  test_lower = c(TRUE, TRUE, FALSE),
-  test_upper = c(FALSE, TRUE, TRUE)
-)
+  h1_spending = FALSE # Use null-spending for futility
+) |> to_integer()
 
 summary(asymmetric_safety_nonbinding) |>
   gsDesign2::as_gt(title = "2-sided asymmetric safety design with non-binding futility",
-                   subtitle = "Alpha-spending used for both bounds, asymmetrically")
+                   subtitle = "Alpha-spending used for both bounds, asymmetrically") |>
+  tab_footnote(footnote = "Integer-based sample size and event counts")
 ```
+
+The corresponding `gsDesign::gsSurv()` design is not strictly comparable since the option to eliminate some futility and efficacy analyses is not enabled. 
 
 ```{r}
 asymmetricSafetyNonBinding <-
@@ -369,12 +385,6 @@ asymmetricSafetyNonBinding <-
 asymmetricSafetyBinding |> gsBoundSummary()
 ```
 
-Comparing Z-value bounds directly, we again see approximately 6 digits of accuracy.
-
-```{r}
-filter(asymmetric_safety_nonbinding$bound, bound == 'upper')$z - asymmetricSafetyNonBinding$upper$bound
-filter(asymmetric_safety_nonbinding$bound, bound == 'lower')$z - asymmetricSafetyNonBinding$lower$bound
-```
 
 ## Example 7: Alternate bound types
 
@@ -383,21 +393,21 @@ We consider two types of alternative boundary computation approaches.
 - Computing futility bounds based on a hazard ratio.
 - Computing efficacy bounds with a Haybittle-Peto or a related Fleming-Harrington-O'Brien approach.
 
-We begin with a futility bound. We will consider a non-binding futility bound as it does not impact Type I error.
+We begin with a futility bound. We will consider a non-binding futility bound as it does not impact the efficacy bound.
 Assume the clinical trial team wishes to stop the trial at the first two interim analyses if a targeted interim hazard ratio is not achieved.
 This approach can require a bit of iteration (trial and error) to incorporate the final design endpoint count; we skip over this iteration here.
-We assume we wish to consider stopping for futility if a hazard ratio greater than 1 and 0.9 are observed at interim analyses 1 and 2 with 106 and 212 events observed, respectively. The final analysis is planned for 306 events.
+We assume we wish to consider stopping for futility if a hazard ratio greater than 1 and 0.9 are observed at interim analyses 1 and 2 with 104 and 209 events observed, respectively. The final analysis is planned for 300 events.
 
 ```{r}
 # Targeted events at interim and final analysis
 # This is based on above designs and then adjusted, as necessary
-targeted_events <- c(106, 212, 305)
+targeted_events <- c(104, 209, 300)
 ```
 
 We wish to translate the hazard ratios specified to corresponding Z-values; this can be done as follows.
 
 ```{r}
-interim_futility_z <- -gsDesign::hrn2z(hr = c(1, .9), n = c(106, 212))
+interim_futility_z <- -gsDesign::hrn2z(hr = c(1, .9), n = targeted_events[1:2])
 interim_futility_z
 ```
 We will add a final futility bound of `-Inf`, indicating no final futility analysis; this gives us a vector of Z-value bounds for all analyses. 
@@ -410,24 +420,24 @@ lpar <- c(interim_futility_z, -Inf)
 ```
 
 For the efficacy bound, we first consider a Haybittle-Peto fixed bound for interim analyses.
+Using a Bonferroni approach, we test at nominal levels 0.001, 0.001, and 0.023 at the 3 analyses.
+By not accounting for correlations, this will actually not quite use all of the 0.025 1-sided Type I error allowed.
+We allow the user to substitute this code for what follows to verify this.
 
 ```{r}
 upper = gs_b; upar = qnorm(c(.001, .001, .0023), lower.tail = FALSE)
 ```
 
-
-
-and then use a spending approach suggested by @fleming1984designs where a fixed spend is considered for each analysis. 
-
-
+The alternative approach is to use a fixed spending approach at each analysis as suggested by @fleming1984designs. 
+Again, with some iteration not shown, we use a piecewise linear spending function to select interim bounds that match the desired Haybittle-Peto interim bounds.
+However, using this approach a slightly more liberal final bound is achieved that still controls Type I error.
 
 
 ```{r}
-upper <- gs_b; upar <- qnorm(c(.001, .001, .0244), lower.tail = FALSE)
 upper <- gs_spending_bound
 upar <- list(sf = gsDesign::sfLinear, 
              total_spend = alpha, 
-             param = c(c(106, 212) / 305, c(.001, .00165)/.025), 
+             param = c(targeted_events[1:2] / targeted_events[3], c(.001, .0018)/.025), 
              timing = NULL)
 
 asymmetric_fixed_bounds <- gs_design_ahr(
@@ -448,8 +458,14 @@ asymmetric_fixed_bounds <- gs_design_ahr(
 
 summary(asymmetric_fixed_bounds) |>
   gsDesign2::as_gt(title = "2-sided asymmetric safety design with fixed non-binding futility",
-                   subtitle = "Futility bounds computed to approximate HR")
+                   subtitle = "Futility bounds computed to approximate HR") |>
+  tab_footnote(footnote = "Integer-based sample size and event counts")
 ```
+
+We see that the targeted bounds are achieved with nominal p-values of 0.0001 for each interim efficacy bound and the targeted hazard ratios at interim futility bounds.
+With these methods, trial designers have more control over design characteristics they may desire.
+In particular, we note that the Haybittle-Peto efficacy bounds are less stringent at the first interim and more stringent at the second interim than corresponding O'Brien-Fleming-like bounds we computed with the spending approach.
+This may or may not be desirable.
 
 # References
 

--- a/vignettes/articles/usage-gs-spending-bound.Rmd
+++ b/vignettes/articles/usage-gs-spending-bound.Rmd
@@ -11,54 +11,57 @@ output:
     css: "custom.css"
 bibliography: "gsDesign2.bib"
 vignette: >
-  %\VignetteEngine{knitr::rmarkdown}
   %\VignetteIndexEntry{Computing spending boundaries in group sequential design}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
 ---
 
+```{r, include=FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
 ```{r, message=FALSE, warning=FALSE}
-library(tibble)
-library(dplyr)
 library(gsDesign2)
+library(gsDesign)
 ```
 
 # Introduction
 
-We compare derivation of different spending bounds using the *gsDesign2* and *gsDesign* packages.
-In *gsDesign* there are 6 types of bounds. We demonstrate here how to replicate these using *gsDesign2*.
-In *gsDesign2* the `gs_spending_bound()` function can be used to derive spending boundaries for all group sequential design derivations and power calculations. 
-We demonstrate with the `gs_design_ahr()` function here, using designs under proportional hazards assumptions to compare with `gsDesign::gsSurv()`. 
-Since the sample size methods differ between the `gsDesign2::gs_design_ahr()` and `gsDesign::gsSurv()` functions, we use continuous sample sizes so that spending bounds (Z-values, nominal p-values, spending) should be identical except where noted. 
+We compare derivation of different spending bounds using the gsDesign2 and gsDesign packages.
+In gsDesign, there are 6 types of bounds. We demonstrate here how to replicate these using gsDesign2.
+In gsDesign2, the `gs_spending_bound()` function can be used to derive spending boundaries for all group sequential design derivations and power calculations.
+We demonstrate with the `gs_design_ahr()` function here, using designs under proportional hazards assumptions to compare with `gsDesign::gsSurv()`.
+Since the sample size methods differ between the `gsDesign2::gs_design_ahr()` and `gsDesign::gsSurv()` functions, we use continuous sample sizes so that spending bounds (Z-values, nominal $p$-values, spending) should be identical except where noted.
 Indeed, we are able to reproduce bounds to a high degree of accuracy.
 Due to the different sample size methods, sample size and other boundary approximations vary slightly.
 
-We also present a seventh example to implement a futility bound based on observed hazard ratio as well as a Haybittle-Peto-like efficacy bound. In particular, the futility bound would be difficult to implement using the *gsDesign* package while it is straightforward using *gsDesign2*.
+We also present a seventh example to implement a futility bound based on observed hazard ratio as well as a Haybittle-Peto-like efficacy bound. In particular, the futility bound would be difficult to implement using the gsDesign package while it is straightforward using gsDesign2.
 
-For the last two examples, we implement integer sample size and event counts using the `to_integer()` function for the *gsDesign2* package and the `toInteger()` function for the *gsDesign* package.
-This would generally would be used for all cases other than when we are comparing package computations as in Examples 1-5.
+For the last two examples, we implement integer sample size and event counts using the `to_integer()` function for the gsDesign2 package and the `toInteger()` function for the gsDesign package.
+This would generally would be used for all cases other than when we are comparing package computations as in Examples 1--5.
 
 For all of our examples, we will use the following design assumptions:
 
-```{r, message=FALSE}
-library(gt)
-library(gsDesign2)
-library(gsDesign)
-trial_duration <- 36         # Planned trial duration
-info_frac <- c(.35, .7, 1)   # Information fraction at analyses
+```{r}
+trial_duration <- 36 # Planned trial duration
+info_frac <- c(.35, .7, 1) # Information fraction at analyses
 # 16 month planned enrollment with constant rate
 enroll_rate <- define_enroll_rate(duration = 16, rate = 1)
 # Minimum follow-up for gsSurv() (computed)
 minfup <- trial_duration - sum(enroll_rate$duration)
 # Failure rates
-fail_rate <-
-  define_fail_rate(
-    duration = Inf,          # single time period, exponential failure
-    fail_rate = log(2) / 12, # Exponential time-to-event with 12 month median
-    hr = .7,                 # Proportional hazards
-    dropout_rate = -log(.99) / 12  # 1% dropout rate per year
-  )
-alpha <- 0.025  # Type I error (one-sided)
-beta <- 0.15    # 85% power = 15% Type II error
-ratio <- 1      # Randomization ratio (experimental / control)
+fail_rate <- define_fail_rate(
+  duration = Inf, # Single time period, exponential failure
+  fail_rate = log(2) / 12, # Exponential time-to-event with 12 month median
+  hr = .7, # Proportional hazards
+  dropout_rate = -log(.99) / 12 # 1% dropout rate per year
+)
+alpha <- 0.025 # Type I error (one-sided)
+beta <- 0.15 # 85% power = 15% Type II error
+ratio <- 1 # Randomization ratio (experimental / control)
 ```
 
 The choice of Type II error of 0.15 corresponding to 85% power is intentional.
@@ -67,7 +70,7 @@ Many teams may decide on the more typical 90% power (`beta = .1`), but this can 
 
 # Examples
 
-Analogous to the *gsDesign* package, we look at 6 variations on combinations of efficacy and futility bounds.
+Analogous to the gsDesign package, we look at 6 variations on combinations of efficacy and futility bounds.
 
 ## Example 1: Efficacy bound only
 
@@ -85,7 +88,7 @@ one_sided <- gsDesign2::gs_design_ahr(
   ratio = ratio, beta = beta,
   # Information fraction at analyses and trial duration
   info_frac = info_frac, analysis_time = trial_duration,
-  # precision parameters for computations
+  # Precision parameters for computations
   r = 32, tol = 1e-08,
   # Use NULL information for Type I error, H1 information for Type II error (power)
   info_scale = "h0_h1_info", # Default
@@ -95,35 +98,35 @@ one_sided <- gsDesign2::gs_design_ahr(
   lower = gs_b, lpar = rep(-Inf, 3)
 )
 
-summary(one_sided) |> gsDesign2::as_gt(title = "Efficacy bound only", subtitle = "alpha-spending")
+one_sided |>
+  summary() |>
+  gsDesign2::as_gt(title = "Efficacy bound only", subtitle = "alpha-spending")
 ```
 
 Now we check this with `gsDesign::gsSurv().` As noted above, sample size and event counts vary slightly from the design derived using `gs_design_ahr()`.
 This also results in slightly different crossing probabilities under the alternate hypothesis at interim analyses as well as slightly different approximate hazard ratios required to cross bounds.
 
 ```{r}
-oneSided <-
-   gsSurv(alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup,
-          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
-          r = 32, tol = 1e-08, # Precision parameters for computations
-          test.type = 1, # One-sided bound; efficacy only
-          # Upper bound parameters
-          sfu = upar$sf, sfupar = upar$param,
-          )
+oneSided <- gsSurv(
+  alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup,
+  lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+  r = 32, tol = 1e-08, # Precision parameters for computations
+  test.type = 1, # One-sided bound; efficacy only
+  # Upper bound parameters
+  sfu = upar$sf, sfupar = upar$param,
+)
 oneSided |> gsBoundSummary()
 ```
 
-Comparing Z-value bounds directly we see they are the same through approximately 6 digits with precision parameters chosen (`r=32, tol = 1e-08`):
+Comparing Z-value bounds directly we see they are the same through approximately 6 digits with precision parameters chosen (`r=32`, `tol=1e-08`):
 
 ```{r}
 one_sided$bound$z - oneSided$upper$bound
 ```
 
-
-
 ## Example 2: Symmetric 2-sided design
 
-We now derive a symmetric 2-sided design. 
+We now derive a symmetric 2-sided design.
 This requires use of the argument `h1_spending = FALSE` to use $\alpha$-spending for both the upper and lower bounds.
 While the lower bound is labeled as a futility bound in the table, it would be better termed an efficacy bound for control better than experimental treatment.
 
@@ -136,11 +139,11 @@ symmetric <- gs_design_ahr(
   ratio = ratio, beta = beta,
   # Information fraction at analyses and trial duration
   info_frac = info_frac, analysis_time = trial_duration,
-  # precision parameters for computations
+  # Precision parameters for computations
   r = 32, tol = 1e-08,
   # Use NULL information for Type I error, H1 information for power
   info_scale = "h0_h1_info", # Default
-  # Function and parameter(s) for upper spending bound 
+  # Function and parameter(s) for upper spending bound
   upper = gs_spending_bound, upar = upar,
   lower = gs_spending_bound, lpar = lpar,
   # Symmetric designs use binding bounds
@@ -148,27 +151,32 @@ symmetric <- gs_design_ahr(
   h1_spending = FALSE # Use null hypothesis spending for lower bound
 )
 
-summary(symmetric) |> 
-  gsDesign2::as_gt(title = "2-sided Symmetric Design", subtitle = "Single spending function")
+symmetric |>
+  summary() |>
+  gsDesign2::as_gt(
+    title = "2-sided Symmetric Design",
+    subtitle = "Single spending function"
+  )
 ```
 
 We compare with `gsDesign::gsSurv()`.
 
 ```{r}
 Symmetric <-
-   gsSurv(test.type = 2, # Two-sided symmetric bound
-          alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup=minfup, r = 32, tol = 1e-08,
-          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
-          sfu = upar$sf, sfupar = upar$param
-          ) 
+  gsSurv(
+    test.type = 2, # Two-sided symmetric bound
+    alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup, r = 32, tol = 1e-08,
+    lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+    sfu = upar$sf, sfupar = upar$param
+  )
 Symmetric |> gsBoundSummary()
 ```
 
 Comparing Z-value bounds directly, we again see approximately 6 digits of accuracy.
 
 ```{r}
-filter(symmetric$bound, bound == 'upper')$z - Symmetric$upper$bound
-filter(symmetric$bound, bound == 'lower')$z - Symmetric$lower$bound
+dplyr::filter(symmetric$bound, bound == "upper")$z - Symmetric$upper$bound
+dplyr::filter(symmetric$bound, bound == "lower")$z - Symmetric$lower$bound
 ```
 
 ## Example 3: Asymmetric 2-sided design with $\beta$-spending and binding futility
@@ -187,11 +195,11 @@ asymmetric_binding <- gs_design_ahr(
   ratio = ratio, beta = beta,
   # Information fraction at analyses and trial duration
   info_frac = info_frac, analysis_time = trial_duration,
-  # precision parameters for computations
+  # Precision parameters for computations
   r = 32, tol = 1e-08,
   # Use NULL information for Type I error, H1 information for Type II error and power
   info_scale = "h0_h1_info",
-  # Function and parameter(s) for upper spending bound 
+  # Function and parameter(s) for upper spending bound
   upper = gs_spending_bound, upar = upar,
   lower = gs_spending_bound, lpar = lpar,
   # Asymmetric beta-spending design using binding bounds
@@ -199,39 +207,40 @@ asymmetric_binding <- gs_design_ahr(
   h1_spending = TRUE # Use beta-spending for futility
 )
 
-summary(asymmetric_binding) |>
-  gsDesign2::as_gt(title = "2-sided asymmetric design with binding futility",
-        subtitle = "Both alpha- and beta-spending used")
+asymmetric_binding |>
+  summary() |>
+  gsDesign2::as_gt(
+    title = "2-sided asymmetric design with binding futility",
+    subtitle = "Both alpha- and beta-spending used"
+  )
 ```
 
 We compare with `gsDesign::gsSurv()`.
 
 ```{r}
-asymmetricBinding <-
-   gsSurv(test.type = 3, # Two-sided asymmetric bound, binding futility
-          alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup,  r = 32, tol = 1e-07,
-          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
-          sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
-          ) 
+asymmetricBinding <- gsSurv(
+  test.type = 3, # Two-sided asymmetric bound, binding futility
+  alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup, r = 32, tol = 1e-07,
+  lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+  sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
+)
 asymmetricBinding |> gsBoundSummary()
 ```
 
 Comparing Z-value bounds directly, we again see approximately 6 digits of accuracy in spite of needing to relaxing accuracy to `tol = 1e-07` in the call to `gsSurv()` in order to get convergence.
 
 ```{r}
-filter(asymmetric_binding$bound, bound == 'upper')$z - asymmetricBinding$upper$bound
-filter(asymmetric_binding$bound, bound == 'lower')$z - asymmetricBinding$lower$bound
+dplyr::filter(asymmetric_binding$bound, bound == "upper")$z - asymmetricBinding$upper$bound
+dplyr::filter(asymmetric_binding$bound, bound == "lower")$z - asymmetricBinding$lower$bound
 ```
-
 
 ## Example 4: Asymmetric 2-sided design with $\beta$-spending and non-binding futility bound
 
-In the *gsDesign* package, asymmetric designs with non-binding $\beta$-spending used for futility are the default design.
+In the gsDesign package, asymmetric designs with non-binding $\beta$-spending used for futility are the default design.
 The objectives of this type of design include:
 
 - Meaningful futility bounds to stop a trial early if no treatment benefit is emerging for the experimental treatment vs. control.
 - Type I error is controlled even if the trial continues after a futility bound is crossed.
-
 
 ```{r}
 upar <- list(sf = gsDesign::sfLDOF, total_spend = alpha, param = NULL)
@@ -242,11 +251,11 @@ asymmetric_nonbinding <- gs_design_ahr(
   ratio = ratio, beta = beta,
   # Information fraction at analyses and trial duration
   info_frac = info_frac, analysis_time = trial_duration,
-  # precision parameters for computations
+  # Precision parameters for computations
   r = 32, tol = 1e-08,
   # Use NULL information for Type I error, H1 info for Type II error and power
   info_scale = "h0_h1_info", # Default
-  # Function and parameter(s) for upper spending bound 
+  # Function and parameter(s) for upper spending bound
   upper = gs_spending_bound, upar = upar,
   lower = gs_spending_bound, lpar = lpar,
   # Asymmetric beta-spending design use binding bounds
@@ -254,29 +263,31 @@ asymmetric_nonbinding <- gs_design_ahr(
   h1_spending = TRUE # Use beta-spending for futility
 )
 
-summary(asymmetric_nonbinding) |>
-  gsDesign2::as_gt(title = "2-sided asymmetric design with non-binding futility",
-        subtitle = "Both alpha- and beta-spending used")
+asymmetric_nonbinding |>
+  summary() |>
+  gsDesign2::as_gt(
+    title = "2-sided asymmetric design with non-binding futility",
+    subtitle = "Both alpha- and beta-spending used"
+  )
 ```
-
 
 We compare with `gsDesign::gsSurv()`.
 
 ```{r}
-asymmetricNonBinding <-
-   gsSurv(test.type = 4, # Two-sided asymmetric bound, non-binding futility
-          alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup, r = 32, tol = 1e-08,
-          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
-          sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
-          ) 
+asymmetricNonBinding <- gsSurv(
+  test.type = 4, # Two-sided asymmetric bound, non-binding futility
+  alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup, r = 32, tol = 1e-08,
+  lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+  sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
+)
 asymmetricNonBinding |> gsBoundSummary()
 ```
 
 Comparing Z-value bounds directly, we again see approximately 6 digits of accuracy.
 
 ```{r}
-filter(asymmetric_nonbinding$bound, bound == 'upper')$z - asymmetricNonBinding$upper$bound
-filter(asymmetric_nonbinding$bound, bound == 'lower')$z - asymmetricNonBinding$lower$bound
+dplyr::filter(asymmetric_nonbinding$bound, bound == "upper")$z - asymmetricNonBinding$upper$bound
+dplyr::filter(asymmetric_nonbinding$bound, bound == "lower")$z - asymmetricNonBinding$lower$bound
 ```
 
 ## Example 5: Asymmetric 2-sided design with null hypothesis spending and binding futility bound
@@ -285,7 +296,7 @@ Now we use null hypothesis probabilities to set futility bounds.
 The parameter `alpha_star` is used to set the total spending for the futility bound under the null hypothesis.
 For our example, this is set to 0.5 which is a 50% probability of crossing the futility bound at the interim and final analyses combined.
 The futility bound at the final analysis really has no role, so we use the `test_lower` argument to eliminate this evaluation at the final analysis.
-This is arbitrary and largely selected so that the interim futility bounds can be meaningful tests. 
+This is arbitrary and largely selected so that the interim futility bounds can be meaningful tests.
 In this case, more than a minor trend in favor of control at the first or second interim will cross a futility bound.
 This is less stringent than the $\beta$-spending bounds previously described, but still address a potential ethical issue of continuing the trial when more than a minor trend in favor of control is present.
 
@@ -299,11 +310,11 @@ asymmetric_safety_binding <- gs_design_ahr(
   ratio = ratio, beta = beta,
   # Information fraction at analyses and trial duration
   info_frac = info_frac, analysis_time = trial_duration,
-  # precision parameters for computations
+  # Precision parameters for computations
   r = 32, tol = 1e-08,
   # Use NULL information for Type I error, H1 information for Type II error
   info_scale = "h0_info",
-  # Function and parameter(s) for upper spending bound 
+  # Function and parameter(s) for upper spending bound
   upper = gs_spending_bound, upar = upar,
   lower = gs_spending_bound, lpar = lpar,
   test_lower = c(TRUE, TRUE, FALSE),
@@ -312,20 +323,22 @@ asymmetric_safety_binding <- gs_design_ahr(
   h1_spending = FALSE # Use null-spending for futility
 )
 
-summary(asymmetric_safety_binding) |>
-  gsDesign2::as_gt(title = "2-sided asymmetric safety design with binding futility",
-        subtitle = "Alpha-spending used for both bounds, asymmetrically")
+asymmetric_safety_binding |>
+  summary() |>
+  gsDesign2::as_gt(
+    title = "2-sided asymmetric safety design with binding futility",
+    subtitle = "Alpha-spending used for both bounds, asymmetrically"
+  )
 ```
 
-
 ```{r}
-asymmetricSafetyBinding <-
-   gsSurv(test.type = 5, # Two-sided asymmetric bound, binding futility, H0 futility spending
-          astar = alpha_star, # Total Type I error spend for futility
-          alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup,
-          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
-          sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
-          ) 
+asymmetricSafetyBinding <- gsSurv(
+  test.type = 5, # Two-sided asymmetric bound, binding futility, H0 futility spending
+  astar = alpha_star, # Total Type I error spend for futility
+  alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup,
+  lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+  sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
+)
 asymmetricSafetyBinding |> gsBoundSummary()
 ```
 
@@ -333,8 +346,8 @@ Comparing Z-value bounds directly, we again see approximately 6 digits of accura
 For `gsSurv()` this did not require the alternate arguments for `r` and `tol`.
 
 ```{r}
-filter(asymmetric_safety_binding$bound, bound == 'upper')$z - asymmetricSafetyBinding$upper$bound
-filter(asymmetric_safety_binding$bound, bound == 'lower')$z - asymmetricSafetyBinding$lower$bound[1:2]
+dplyr::filter(asymmetric_safety_binding$bound, bound == "upper")$z - asymmetricSafetyBinding$upper$bound
+dplyr::filter(asymmetric_safety_binding$bound, bound == "lower")$z - asymmetricSafetyBinding$lower$bound[1:2]
 ```
 
 ## Example 6: Asymmetric 2-sided design with null hypothesis spending and non-binding futility bound
@@ -352,11 +365,11 @@ asymmetric_safety_nonbinding <- gs_design_ahr(
   ratio = ratio, beta = beta,
   # Information fraction at analyses and trial duration
   info_frac = info_frac, analysis_time = trial_duration,
-  # precision parameters for computations
+  # Precision parameters for computations
   r = 32, tol = 1e-08,
   # Use NULL information for Type I error, H1 information for Type II error
   info_scale = "h0_info",
-  # Function and parameter(s) for upper spending bound 
+  # Function and parameter(s) for upper spending bound
   upper = gs_spending_bound, upar = upar,
   test_upper = c(FALSE, TRUE, TRUE),
   lower = gs_spending_bound, lpar = lpar,
@@ -366,29 +379,31 @@ asymmetric_safety_nonbinding <- gs_design_ahr(
   h1_spending = FALSE # Use null-spending for futility
 ) |> to_integer()
 
-summary(asymmetric_safety_nonbinding) |>
-  gsDesign2::as_gt(title = "2-sided asymmetric safety design with non-binding futility",
-                   subtitle = "Alpha-spending used for both bounds, asymmetrically") |>
-  tab_footnote(footnote = "Integer-based sample size and event counts")
+asymmetric_safety_nonbinding |>
+  summary() |>
+  gsDesign2::as_gt(
+    title = "2-sided asymmetric safety design with non-binding futility",
+    subtitle = "Alpha-spending used for both bounds, asymmetrically"
+  ) |>
+  gt::tab_footnote(footnote = "Integer-based sample size and event counts")
 ```
 
-The corresponding `gsDesign::gsSurv()` design is not strictly comparable since the option to eliminate some futility and efficacy analyses is not enabled. 
+The corresponding `gsDesign::gsSurv()` design is not strictly comparable since the option to eliminate some futility and efficacy analyses is not enabled.
 
 ```{r}
-asymmetricSafetyNonBinding <-
-   gsSurv(test.type = 6, # Two-sided asymmetric bound, binding futility, H0 futility spending
-          astar = alpha_star, # Total Type I error spend for futility
-          alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup, r = 32, tol = 1e-08,
-          lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
-          sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
-          ) 
+asymmetricSafetyNonBinding <- gsSurv(
+  test.type = 6, # Two-sided asymmetric bound, binding futility, H0 futility spending
+  astar = alpha_star, # Total Type I error spend for futility
+  alpha = alpha, beta = beta, timing = info_frac, T = trial_duration, minfup = minfup, r = 32, tol = 1e-08,
+  lambdaC = fail_rate$fail_rate, eta = fail_rate$dropout_rate, hr = fail_rate$hr,
+  sfu = upar$sf, sfupar = upar$param, sfl = lpar$sf, sflpar = lpar$param
+)
 asymmetricSafetyBinding |> gsBoundSummary()
 ```
 
-
 ## Example 7: Alternate bound types
 
-We consider two types of alternative boundary computation approaches. 
+We consider two types of alternative boundary computation approaches.
 
 - Computing futility bounds based on a hazard ratio.
 - Computing efficacy bounds with a Haybittle-Peto or a related Fleming-Harrington-O'Brien approach.
@@ -410,11 +425,13 @@ We wish to translate the hazard ratios specified to corresponding Z-values; this
 interim_futility_z <- -gsDesign::hrn2z(hr = c(1, .9), n = targeted_events[1:2])
 interim_futility_z
 ```
-We will add a final futility bound of `-Inf`, indicating no final futility analysis; this gives us a vector of Z-value bounds for all analyses. 
+
+We will add a final futility bound of `-Inf`, indicating no final futility analysis; this gives us a vector of Z-value bounds for all analyses.
 For this type of bound, Type II error will be computed rather based on bounds rather than the spending approach were bounds are computed based on specified spending.
 
 ```{r}
-lower <- gs_b; # Allows specifying fixed Z-values for futility
+lower <- gs_b
+# Allows specifying fixed Z-values for futility
 # Translated HR bounds to Z-value scale
 lpar <- c(interim_futility_z, -Inf)
 ```
@@ -425,47 +442,51 @@ By not accounting for correlations, this will actually not quite use all of the 
 We allow the user to substitute this code for what follows to verify this.
 
 ```{r}
-upper = gs_b; upar = qnorm(c(.001, .001, .0023), lower.tail = FALSE)
+upper <- gs_b
+upar <- qnorm(c(.001, .001, .0023), lower.tail = FALSE)
 ```
 
-The alternative approach is to use a fixed spending approach at each analysis as suggested by @fleming1984designs. 
+The alternative approach is to use a fixed spending approach at each analysis as suggested by @fleming1984designs.
 Again, with some iteration not shown, we use a piecewise linear spending function to select interim bounds that match the desired Haybittle-Peto interim bounds.
 However, using this approach a slightly more liberal final bound is achieved that still controls Type I error.
 
-
 ```{r}
 upper <- gs_spending_bound
-upar <- list(sf = gsDesign::sfLinear, 
-             total_spend = alpha, 
-             param = c(targeted_events[1:2] / targeted_events[3], c(.001, .0018)/.025), 
-             timing = NULL)
+upar <- list(
+  sf = gsDesign::sfLinear,
+  total_spend = alpha,
+  param = c(targeted_events[1:2] / targeted_events[3], c(.001, .0018) / .025),
+  timing = NULL
+)
 
 asymmetric_fixed_bounds <- gs_design_ahr(
   enroll_rate = enroll_rate, fail_rate = fail_rate,
   ratio = ratio, beta = beta,
   # Information fraction at analyses and trial duration
   info_frac = info_frac, analysis_time = trial_duration,
-  # precision parameters for computations
+  # Precision parameters for computations
   r = 32, tol = 1e-08,
   # Use NULL information for Type I error, H1 information for Type II error
   info_scale = "h0_info",
-  # Function and parameter(s) for upper spending bound 
+  # Function and parameter(s) for upper spending bound
   upper = upper, upar = upar,
   lower = lower, lpar = lpar,
   # Non-binding futility bounds
   binding = FALSE
 ) |> to_integer()
 
-summary(asymmetric_fixed_bounds) |>
-  gsDesign2::as_gt(title = "2-sided asymmetric safety design with fixed non-binding futility",
-                   subtitle = "Futility bounds computed to approximate HR") |>
-  tab_footnote(footnote = "Integer-based sample size and event counts")
+asymmetric_fixed_bounds |>
+  summary() |>
+  gsDesign2::as_gt(
+    title = "2-sided asymmetric safety design with fixed non-binding futility",
+    subtitle = "Futility bounds computed to approximate HR"
+  ) |>
+  gt::tab_footnote(footnote = "Integer-based sample size and event counts")
 ```
 
-We see that the targeted bounds are achieved with nominal p-values of 0.0001 for each interim efficacy bound and the targeted hazard ratios at interim futility bounds.
+We see that the targeted bounds are achieved with nominal $p$-values of 0.0001 for each interim efficacy bound and the targeted hazard ratios at interim futility bounds.
 With these methods, trial designers have more control over design characteristics they may desire.
 In particular, we note that the Haybittle-Peto efficacy bounds are less stringent at the first interim and more stringent at the second interim than corresponding O'Brien-Fleming-like bounds we computed with the spending approach.
 This may or may not be desirable.
 
 # References
-


### PR DESCRIPTION
This PR:

- Updated the vignette "trial design with spending under NPH".
- Extended the vignette "computing spending boundaries in group sequential design" to compare derivation of different spending bounds using gsDesign2 and gsDesign.