### PR TITLE
Run `as_gt()` examples conditionally

### DIFF
--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -32,9 +32,8 @@ as_gt <- function(x, ...) {
 #'
 #' @export
 #'
-#' @examples
+#' @examplesIf interactive() && !identical(Sys.getenv("IN_PKGDOWN"), "true")
 #' library(dplyr)
-#' library(tibble)
 #'
 #' # Enrollment rate
 #' enroll_rate <- define_enroll_rate(
@@ -214,8 +213,7 @@ as_gt.fixed_design <- function(x, title = NULL, footnote = NULL, ...) {
 #'
 #' @export
 #'
-#' @examples
-#' \donttest{
+#' @examplesIf interactive() && !identical(Sys.getenv("IN_PKGDOWN"), "true")
 #' # the default output
 #' library(dplyr)
 #'
@@ -234,7 +232,6 @@ as_gt.fixed_design <- function(x, title = NULL, footnote = NULL, ...) {
 #' gs_power_wlr() %>%
 #'   summary() %>%
 #'   as_gt()
-#'
 #'
 #' gs_power_combo() %>%
 #'   summary() %>%
@@ -294,18 +291,18 @@ as_gt.fixed_design <- function(x, title = NULL, footnote = NULL, ...) {
 #' gs_power_wlr() %>%
 #'   summary() %>%
 #'   as_gt(display_columns = c("Analysis", "Bound", "Nominal p", "Z", "Probability"))
-#' }
-as_gt.gs_design <- function(x,
-                            title = NULL,
-                            subtitle = NULL,
-                            colname_spanner = "Cumulative boundary crossing probability",
-                            colname_spannersub = c("Alternate hypothesis", "Null hypothesis"),
-                            footnote = NULL,
-                            display_bound = c("Efficacy", "Futility"),
-                            display_columns = NULL,
-                            display_inf_bound = TRUE,
-                            full_alpha = 0.025,
-                            ...) {
+as_gt.gs_design <- function(
+    x,
+    title = NULL,
+    subtitle = NULL,
+    colname_spanner = "Cumulative boundary crossing probability",
+    colname_spannersub = c("Alternate hypothesis", "Null hypothesis"),
+    footnote = NULL,
+    display_bound = c("Efficacy", "Futility"),
+    display_columns = NULL,
+    display_inf_bound = TRUE,
+    full_alpha = 0.025,
+    ...) {
   method <- class(x)[class(x) %in% c("ahr", "wlr", "combo", "rd")]
   x_alpha <- max((x %>% dplyr::filter(Bound == display_bound[1]))[[colname_spannersub[2]]])
   x_non_binding <- "non_binding" %in% class(x)

--- a/man/as_gt.Rd
+++ b/man/as_gt.Rd
@@ -65,8 +65,8 @@ A \code{gt_tbl} object.
 Convert summary table of a fixed or group sequential design object to a gt object
 }
 \examples{
+\dontshow{if (interactive() && !identical(Sys.getenv("IN_PKGDOWN"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(dplyr)
-library(tibble)
 
 # Enrollment rate
 enroll_rate <- define_enroll_rate(
@@ -113,7 +113,8 @@ fixed_design_fh(
 ) \%>\%
   summary() \%>\%
   as_gt()
-\donttest{
+\dontshow{\}) # examplesIf}
+\dontshow{if (interactive() && !identical(Sys.getenv("IN_PKGDOWN"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # the default output
 library(dplyr)
 
@@ -132,7 +133,6 @@ gs_design_wlr() \%>\%
 gs_power_wlr() \%>\%
   summary() \%>\%
   as_gt()
-
 
 gs_power_combo() \%>\%
   summary() \%>\%
@@ -192,5 +192,5 @@ gs_power_wlr() \%>\%
 gs_power_wlr() \%>\%
   summary() \%>\%
   as_gt(display_columns = c("Analysis", "Bound", "Nominal p", "Z", "Probability"))
-}
+\dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
Fixes #334 

I used `@examplesIf` to only run the `as_gt()` examples when it is either in interactive mode OR not rendered by pkgdown.

```r
#' @examplesIf interactive() && !identical(Sys.getenv("IN_PKGDOWN"), "true")
```

This will make the examples section in the pkgdown site not showing the 7,000 lines of raw HTML.

---

I did not choose to capture the tables as images and create an "example output" section to link them (what gtsummary does) because:

- gt outputs is not the main theme of this package so it's less important to show what the output looks like.
- Since we have 11 tables here, the saved PNG files will bloat up the bundled package size by at least 1 Mb.
- One needs to regenerate the images using a script if the examples are updated. As people tend to forget about things outside of the standard workflow, it could become easily out of sync or a maintenance burden.