### PR TITLE
Make tests self-contained

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -21,7 +21,7 @@ exclusions:
       "tests/testthat/helper.R" = list(
         object_name_linter = Inf
       ),
-      "tests/testthat/test-double_programming_ppwe.R" = list(
+      "tests/testthat/helper-ppwe.R" = list(
         object_name_linter = Inf
       ),
       "tests/testthat/test-independent_test_gs_design_wlr.R" = list(
@@ -35,9 +35,11 @@ exclusions:
         object_name_linter = Inf,
         commented_code_linter = Inf
       ),
-      "tests/testthat/test-independent-expected_accrual.R" = list(
-        object_name_linter = Inf,
-        commented_code_linter = Inf
+      "tests/testthat/helper-expected_accrual.R" = list(
+        object_name_linter = Inf
+      ),
+      "tests/testthat/helper-expected_event.R" = list(
+        object_name_linter = Inf
       ),
       "tests/testthat/test-independent-expected_event.R" = list(
         object_name_linter = Inf
@@ -64,6 +66,7 @@ exclusions:
         object_name_linter = Inf
       ),
       "tests/testthat/test-independent-hupdate.R" = list(
-        object_name_linter = Inf
+        object_name_linter = Inf,
+        commented_code_linter = Inf
       )
     )

--- a/tests/testthat/helper-ahr.R
+++ b/tests/testthat/helper-ahr.R
@@ -1,0 +1,25 @@
+# Helper functions used by test-independent-AHR.R
+
+test_ahr <- function() {
+  load("fixtures/simulation_test_data.Rdata")
+
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 10),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    stratum = "All",
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    hr = c(.9, .6),
+    dropout_rate = rep(.001, 2)
+  )
+
+  list(
+    "simulation_ahr1" = simulation_AHR1,
+    "simulation_ahr2" = simulation_AHR2,
+    "simulation_ahr3" = simulation_AHR3,
+    "enroll_rate" = enroll_rate,
+    "fail_rate" = fail_rate
+  )
+}

--- a/tests/testthat/helper-expected_accrual.R
+++ b/tests/testthat/helper-expected_accrual.R
@@ -1,0 +1,26 @@
+# Helper functions used by test-independent-expected_accrual.R
+
+test_eAccrual <- function(x, enroll_rate) {
+  boundary <- cumsum(enroll_rate$duration)
+  rate <- enroll_rate$rate
+  xvals <- unique(c(x, boundary))
+
+  eAc2 <- numeric(length(xvals))
+  for (t in seq_along(xvals)) {
+    val <- xvals[t]
+    if (val <= boundary[1]) {
+      eAc2[t] <- val * rate[1]
+    } else if (val <= boundary[2]) {
+      eAc2[t] <- boundary[1] * rate[1] + (val - boundary[1]) * rate[2]
+    } else if (val <= boundary[3]) {
+      eAc2[t] <- boundary[1] * rate[1] +
+        (boundary[2] - boundary[1]) * rate[2] + (val - boundary[2]) * rate[3]
+    } else {
+      eAc2[t] <- boundary[1] * rate[1] +
+        (boundary[2] - boundary[1]) * rate[2] + (boundary[3] - boundary[2]) * rate[3]
+    }
+  }
+
+  ind <- !is.na(match(xvals, x))
+  return(eAc2[ind])
+}

--- a/tests/testthat/helper-expected_event.R
+++ b/tests/testthat/helper-expected_event.R
@@ -1,0 +1,81 @@
+# Helper functions used by test-independent-expected_event.R
+
+n_event <- function(failRates, followup) {
+  failduration <- failRates$duration
+  failtime <- cumsum(failduration)
+  failRate <- failRates$failRate
+  dropoutRate <- failRates$dropoutRate
+  lamda <- failRate + dropoutRate
+  lamda1 <- c(lamda, dplyr::last(lamda))
+  failRate1 <- c(failRate, dplyr::last(failRate))
+
+  failtimeend <- c(0, failtime[failtime < followup], followup)
+  failtimeend1 <- c(failtime[failtime < followup], followup)
+  lamda2 <- lamda1[c(1:(length(failtimeend) - 1))]
+  failRate2 <- failRate1[c(1:(length(failtimeend) - 1))]
+
+  failduration <- diff(failtimeend)
+  failduration2 <- followup - failtimeend1
+
+  fail <- lamda2 * failduration
+  sumfail <- cumsum(fail)
+  Bi1 <- c(1, exp(-sumfail))
+  diffbi <- diff(Bi1)
+  Bi <- Bi1[c(1:(length(Bi1) - 1))]
+
+  totalevent <- diffbi * (1 / lamda2 - failduration2) + Bi * failduration
+
+  failevent <- totalevent * (failRate2 / lamda2)
+  return(sum(failevent))
+}
+
+test_expected_event <- function(enrollRates, failRates, totalDuration) {
+  enrolltime <- c(0, cumsum(enrollRates$duration))
+  Event <- 0
+  for (i in seq_along(enrollRates$duration)) {
+    enrollmentstart <- 0
+    enrollmentend <- enrollRates$duration[i]
+    enrollrate <- enrollRates$rate[i]
+    followup <- totalDuration - enrolltime[i]
+    nEventnum <- 0
+
+    if (followup > 0 && followup <= enrollmentend) {
+      nEventnum <- n_event(failRates, followup) * enrollrate
+    } else if (followup > 0 && followup > enrollmentend) {
+      nEventnum <- (n_event(failRates, followup) - n_event(failRates, followup - enrollmentend)) * enrollrate
+    } else {
+      nEventnum <- 0
+    }
+    Event <- Event + nEventnum
+  }
+  return(Event)
+}
+
+params_expected_event <- function() {
+  enroll_rate <- define_enroll_rate(
+    duration = c(50),
+    rate = c(10)
+  )
+
+  fail_rate <- define_fail_rate(
+    duration = c(10, 20, 10),
+    fail_rate = log(2) / c(5, 10, 5),
+    dropout_rate = c(0.1, 0.2, 0),
+    hr = 1
+  )
+
+  fail_rate$failRate <- fail_rate$fail_rate
+  fail_rate$dropoutRate <- fail_rate$dropout_rate
+  failRates <- fail_rate
+
+  total_duration <- 5
+  simple <- TRUE
+
+  list(
+    "enroll_rate" = enroll_rate,
+    "fail_rate" = fail_rate,
+    "failRates" = failRates,
+    "total_duration" = total_duration,
+    "simple" = simple
+  )
+}

--- a/tests/testthat/helper-expected_time.R
+++ b/tests/testthat/helper-expected_time.R
@@ -1,0 +1,27 @@
+# Helper functions used by test-independent-expected_time.R
+
+test_expected_time <- function() {
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 10),
+    rate = c(3, 6, 9) * 5
+  )
+
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    dropout_rate = rep(.001, 2),
+    hr = c(.9, .6)
+  )
+
+  target_event <- 150
+  interval <- c(.01, 100)
+
+  t1 <- expected_time(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    target_event = target_event,
+    interval = interval
+  )
+
+  list("enroll_rate" = enroll_rate, "fail_rate" = fail_rate, "t1" = t1)
+}

--- a/tests/testthat/helper-fixed_design.R
+++ b/tests/testthat/helper-fixed_design.R
@@ -1,0 +1,30 @@
+# Helper functions used by test-independent-fixed_design.R
+
+test_fixed_design <- function() {
+  # Enrollment rate
+  enroll_rate <- define_enroll_rate(
+    duration = 18,
+    rate = 20
+  )
+
+  # Failure rates
+  fail_rate <- define_fail_rate(
+    duration = c(4, 100),
+    fail_rate = log(2) / 12,
+    dropout_rate = .001,
+    hr = c(1, .6)
+  )
+
+  # Study duration in months
+  study_duration <- 36
+
+  # Experimental / Control randomization ratio
+  ratio <- 1
+
+  list(
+    "enroll_rate" = enroll_rate,
+    "fail_rate" = fail_rate,
+    "study_duration" = study_duration,
+    "ratio" = ratio
+  )
+}

--- a/tests/testthat/helper-gs_design_combo.R
+++ b/tests/testthat/helper-gs_design_combo.R
@@ -1,0 +1,97 @@
+# Helper functions used by test-independent-gs_design_combo.R
+
+test_gs_design_combo <- function() {
+  load("fixtures/sim_gsd_pMaxCombo_exp1_H0_test.Rdata")
+  load("fixtures/sim_gsd_pMaxCombo_exp1_H1_test.Rdata")
+
+  ratio <- 1
+  algorithm <- mvtnorm::GenzBretz(maxpts = 1e5, abseps = 1e-5)
+  alpha <- 0.025
+  beta <- 0.2
+  enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
+  fail_rate <- define_fail_rate(
+    duration = c(4, 100),
+    fail_rate = log(2) / 15, # Median survival 15 month
+    dropout_rate = 0.001,
+    hr = c(1, .6)
+  )
+
+  fh_test <- rbind(
+    data.frame(
+      rho = 0,
+      gamma = 0,
+      tau = -1,
+      test = 1,
+      analysis = 1:3,
+      analysis_time = c(12, 24, 36)
+    ),
+    data.frame(
+      rho = c(0, 0.5),
+      gamma = 0.5,
+      tau = -1,
+      test = 2:3,
+      analysis = 3,
+      analysis_time = 36
+    )
+  )
+
+  x <- gsDesign::gsSurv(
+    k = 3,
+    test.type = 4,
+    alpha = 0.025,
+    beta = 0.2,
+    astar = 0,
+    timing = c(1),
+    sfu = gsDesign::sfLDOF,
+    sfupar = c(0),
+    sfl = gsDesign::sfLDOF,
+    sflpar = c(0),
+    lambdaC = c(0.1),
+    hr = 0.6,
+    hr0 = 1,
+    eta = 0.01,
+    gamma = c(10),
+    R = c(12),
+    S = NULL,
+    T = 36,
+    minfup = 24,
+    ratio = 1
+  )
+
+  # User-defined boundary
+  gs_design_combo_test1 <- gs_design_combo(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    fh_test = fh_test,
+    alpha = alpha,
+    beta = beta,
+    ratio = 1,
+    binding = FALSE, # test.type = 4 non-binding futility bound
+    upar = x$upper$bound,
+    lpar = x$lower$bound
+  )
+
+  # Boundary derived by spending function testing
+  gs_design_combo_test2 <- gs_design_combo(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    fh_test = fh_test,
+    alpha = 0.025,
+    beta = 0.2,
+    ratio = 1,
+    binding = FALSE, # test.type = 4 non-binding futility bound
+    upper = gs_spending_combo,
+    upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025), # alpha spending
+    lower = gs_spending_combo,
+    lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2), # beta spending
+  )
+
+  list(
+    "alpha" = alpha,
+    "beta" = beta,
+    "enroll_rate" = enroll_rate,
+    "fail_rate" = fail_rate,
+    "fh_test" = fh_test,
+    "gs_design_combo_test2" = gs_design_combo_test2
+  )
+}

--- a/tests/testthat/helper-gs_design_npe.R
+++ b/tests/testthat/helper-gs_design_npe.R
@@ -1,0 +1,14 @@
+# Helper functions used by test-independent-gs_design_npe.R
+
+# Parameters used repeatedly
+params_gs_design_npe <- list(
+  K = 3,
+  timing = c(.45, .8, 1),
+  sfu = gsDesign::sfPower,
+  sfupar = 4,
+  sfl = gsDesign::sfHSD,
+  sflpar = 2,
+  delta = .2,
+  alpha = .02,
+  beta = .15
+)

--- a/tests/testthat/helper-gs_info_ahr.R
+++ b/tests/testthat/helper-gs_info_ahr.R
@@ -1,0 +1,16 @@
+# Helper functions used by test-independent-gs_info_ahr.R
+
+test_gs_info_ahr <- function() {
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 10),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    hr = c(0.9, 0.6),
+    dropout_rate = 0.001
+  )
+
+  list("enroll_rate" = enroll_rate, "fail_rate" = fail_rate)
+}

--- a/tests/testthat/helper-gs_info_combo.R
+++ b/tests/testthat/helper-gs_info_combo.R
@@ -1,0 +1,37 @@
+# Helper functions used by test-independent-gs_info_combo.R
+
+test_gs_info_combo <- function() {
+  rho <- c(1, 1, 0, 0)
+  gamma <- c(0, 1, 0, 1)
+  tau <- c(-1, -1, -1, -1)
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 30),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    dropout_rate = rep(.001, 2),
+    hr = c(.9, .6)
+  )
+  info_combo <- gsDesign2::gs_info_combo(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    ratio = 1, # Experimental:Control randomization ratio
+    event = NULL, # Events at analyses
+    analysis_time = 30, # Times of analyses
+    rho = rho,
+    gamma = gamma,
+    tau = rep(-1, length(rho)),
+    approx = "asymptotic"
+  )
+
+  list(
+    "rho" = rho,
+    "gamma" = gamma,
+    "tau" = tau,
+    "enroll_rate" = enroll_rate,
+    "fail_rate" = fail_rate,
+    "info_combo" = info_combo
+  )
+}

--- a/tests/testthat/helper-gs_power_ahr.R
+++ b/tests/testthat/helper-gs_power_ahr.R
@@ -1,0 +1,52 @@
+# Helper functions used by test-independent-gs_power_ahr.R
+
+test_gs_power_ahr <- function() {
+  x <- gsDesign::gsSurv(
+    k = 2,
+    test.type = 1,
+    alpha = 0.025,
+    beta = 0.2,
+    astar = 0,
+    timing = 0.7,
+    sfu = gsDesign::sfLDOF,
+    sfupar = c(0),
+    sfl = gsDesign::sfLDOF,
+    sflpar = c(0),
+    lambdaC = log(2) / 9,
+    hr = 0.65,
+    hr0 = 1,
+    eta = 0.001,
+    gamma = c(6, 12, 18, 24),
+    R = c(2, 2, 2, 6),
+    S = NULL,
+    T = NULL,
+    minfup = NULL,
+    ratio = 1
+  )
+
+  # Update x with gsDesign() to get integer event counts
+  x <- gsDesign::gsDesign(
+    k = x$k,
+    test.type = 1,
+    alpha = x$alpha,
+    beta = x$beta,
+    sfu = x$upper$sf,
+    sfupar = x$upper$param,
+    n.I = ceiling(x$n.I),
+    maxn.IPlan = ceiling(x$n.I[x$k]),
+    delta = x$delta,
+    delta1 = x$delta1,
+    delta0 = x$delta0
+  )
+  y <- gsDesign::gsBoundSummary(
+    x,
+    ratio = 1,
+    digits = 4,
+    ddigits = 2,
+    tdigits = 1,
+    timename = "Month",
+    logdelta = TRUE
+  )
+
+  list("x" = x, "y" = y)
+}

--- a/tests/testthat/helper-gs_power_combo.R
+++ b/tests/testthat/helper-gs_power_combo.R
@@ -1,0 +1,59 @@
+# Helper functions used by test-independent-gs_power_combo.R
+
+test_gs_power_combo <- function() {
+  enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
+
+  fail_rate <- define_fail_rate(
+    duration = c(4, 100),
+    fail_rate = log(2) / 15, # Median survival 15 month
+    dropout_rate = 0.001,
+    hr = c(1, .6)
+  )
+
+  fh_test <- rbind(
+    data.frame(
+      rho = 0,
+      gamma = 0,
+      tau = -1,
+      test = 1,
+      analysis = 1:3,
+      analysis_time = c(12, 24, 36)
+    ),
+    data.frame(
+      rho = c(0, 0.5),
+      gamma = 0.5,
+      tau = -1,
+      test = 2:3,
+      analysis = 3,
+      analysis_time = 36
+    )
+  )
+
+  # User-defined bound
+  gs_power_combo_test1 <- gsDesign2::gs_power_combo(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    fh_test = fh_test,
+    upper = gs_b, upar = c(3, 2, 1),
+    lower = gs_b, lpar = c(-1, 0, 1)
+  )
+
+  # Minimal Information Fraction derived bound
+  gs_power_combo_test2 <- gsDesign2::gs_power_combo(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    fh_test,
+    upper = gs_spending_combo,
+    upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
+    lower = gs_spending_combo,
+    lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2)
+  )
+
+  list(
+    "enroll_rate" = enroll_rate,
+    "fail_rate" = fail_rate,
+    "fh_test" = fh_test,
+    "gs_power_combo_test1" = gs_power_combo_test1,
+    "gs_power_combo_test2" = gs_power_combo_test2
+  )
+}

--- a/tests/testthat/helper-ppwe.R
+++ b/tests/testthat/helper-ppwe.R
@@ -1,0 +1,88 @@
+# Helper functions used by test-double_programming_ppwe.R
+
+test_ppwe <- function(
+    x = 0:20,
+    failRates = tibble::tibble(
+      duration = c(3, 100),
+      rate = log(2) / c(9, 18)
+    ),
+    lower.tail = FALSE) {
+  boundary <- cumsum(failRates$duration)
+  rate <- failRates$rate
+  xvals <- unique(c(x, boundary))
+  H <- numeric(length(xvals))
+  maxlen <- sum(failRates$duration)
+  max.x <- max(x)
+
+  if (length(x) <= maxlen) {
+    for (t in seq_along(xvals)) {
+      val <- xvals[t]
+      if (val <= boundary[1]) {
+        H[t] <- val * rate[1]
+      } else if (val <= boundary[2]) {
+        H[t] <- boundary[1] * rate[1] + (val - boundary[1]) * rate[2]
+      } else {
+        H[t] <- boundary[1] * rate[1] + (boundary[2] - boundary[1]) * rate[2]
+      }
+    }
+    surv <- exp(-H)
+  } else {
+    boundary1 <- boundary
+    boundary1[2] <- max.x
+    for (t in seq_along(xvals)) {
+      val <- xvals[t]
+      if (val <= boundary1[1]) {
+        H[t] <- val * rate[1]
+      } else if (val <= boundary1[2]) {
+        H[t] <- boundary1[1] * rate[1] + (val - boundary1[1]) * rate[2]
+      } else {
+        H[t] <- boundary1[1] * rate[1] + (boundary1[2] - boundary1[1]) * rate[2]
+      }
+    }
+    surv <- exp(-H)
+  }
+
+  ind <- !is.na(match(xvals, x))
+
+  if (lower.tail) {
+    return(1 - surv[ind])
+  } else {
+    return(surv[ind])
+  }
+}
+
+# Double programming of ppwe when there are 3 steps of failure rates.
+# The method is a simple extention of test_ppwe.
+test_2_ppwe <- function(
+    x = 0:20,
+    failRates = tibble::tibble(
+      duration = c(3, 20, 100),
+      rate = log(2) / c(9, 12, 18)
+    ),
+    lower.tail = FALSE) {
+  boundary <- cumsum(failRates$duration)
+  rate <- failRates$rate
+  xvals <- unique(c(x, boundary))
+  H <- numeric(length(xvals))
+  for (t in seq_along(xvals)) {
+    val <- xvals[t]
+    if (val <= boundary[1]) {
+      H[t] <- val * rate[1]
+    } else if (val <= boundary[2]) {
+      H[t] <- boundary[1] * rate[1] + (val - boundary[1]) * rate[2]
+    } else if (val <= boundary[3]) {
+      H[t] <- boundary[1] * rate[1] + (boundary[2] - boundary[1]) * rate[2] + (val - boundary[3]) * rate[3]
+    } else {
+      H[t] <- boundary[1] * rate[1] + (boundary[2] - boundary[1]) * rate[2] + (boundary[3] - boundary[2]) * rate[3]
+    }
+  }
+  surv <- exp(-H)
+
+  ind <- !is.na(match(xvals, x))
+
+  if (lower.tail) {
+    return(1 - surv[ind])
+  } else {
+    return(surv[ind])
+  }
+}

--- a/tests/testthat/helper-utility_combo.R
+++ b/tests/testthat/helper-utility_combo.R
@@ -1,0 +1,454 @@
+# Helper functions used by test-independent-utility_combo.R
+
+test_get_combo_weight <- function() {
+  rho <- c(1, 1, 0, 0)
+  gamma <- c(0, 1, 0, 1)
+  tau <- c(-1, -1, -1, -1)
+
+  weight <- gsDesign2:::get_combo_weight(rho, gamma, tau)
+  weight1_rho <- substring(weight[[1]], 125, 130)
+  weight2_rho <- substring(weight[[2]], 125, 130)
+  weight1_gamma <- substring(weight[[1]], 133, 140)
+  weight2_gamma <- substring(weight[[2]], 133, 140)
+  weight1_tau <- substring(weight[[1]], 143, 148)
+  weight2_tau <- substring(weight[[2]], 143, 148)
+
+  list(
+    "weight1_rho" = weight1_rho,
+    "weight2_rho" = weight2_rho,
+    "weight1_gamma" = weight1_gamma,
+    "weight2_gamma" = weight2_gamma
+  )
+}
+
+test_get_combo_weight_tau <- function() {
+  rho <- c(1, 1, 0, 0)
+  gamma <- c(0, 1, 0, 1)
+  tau <- c(1, 1, 0, 0)
+  weight <- gsDesign2:::get_combo_weight(rho, gamma, tau)
+  weight1_tau <- substring(weight[[1]], 143, 148)
+  weight3_tau <- substring(weight[[3]], 143, 148)
+
+  list(
+    "weight1_tau" = weight1_tau,
+    "weight3_tau" = weight3_tau
+  )
+}
+
+test_gs_delta_combo <- function() {
+  rho <- c(1, 1, 0, 0)
+  gamma <- c(0, 1, 0, 1)
+  tau <- c(-1, -1, -1, -1)
+
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 30),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    dropout_rate = rep(.001, 2),
+    hr = c(.9, .6)
+  )
+  arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1, total_time = 1e6)
+  delta <- gsDesign2:::gs_delta_combo(
+    arm0 = arm$arm0, arm1 = arm$arm1,
+    tmax = 30, rho = rho, gamma = gamma, tau = rep(-1, length(rho)),
+    approx = "asymptotic", normalization = FALSE
+  )
+
+  list(
+    "rho" = rho,
+    "gamma" = gamma,
+    "tau" = tau,
+    "arm" = arm,
+    "delta" = delta
+  )
+}
+
+test_gs_sigma2_combo <- function() {
+  rho <- c(1, 1, 0, 0)
+  gamma <- c(0, 1, 0, 1)
+  tau <- c(-1, -1, -1, -1)
+
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 30),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    dropout_rate = rep(.001, 2),
+    hr = c(.9, .6)
+  )
+  arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1, total_time = 1e6)
+
+  sigma2 <- gsDesign2:::gs_sigma2_combo(
+    arm0 = arm$arm0, arm1 = arm$arm1, tmax = 30,
+    rho = rho, gamma = gamma, tau = rep(-1, length(rho)),
+    approx = "asymptotic"
+  )
+  rho1 <- outer(rho, rho, function(x, y) (x + y) / 2)
+  gamma1 <- outer(gamma, gamma, function(x, y) (x + y) / 2)
+
+  list(
+    "rho1" = rho1,
+    "gamma1" = gamma1,
+    "tau" = tau,
+    "arm" = arm,
+    "sigma2" = sigma2
+  )
+}
+
+test_gs_info_combo <- function() {
+  rho <- c(1, 1, 0, 0)
+  gamma <- c(0, 1, 0, 1)
+  tau <- c(-1, -1, -1, -1)
+
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 30),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    dropout_rate = rep(.001, 2),
+    hr = c(.9, .6)
+  )
+
+  info_combo <- gsDesign2:::gs_info_combo(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    ratio = 1, # Experimental:Control randomization ratio
+    event = NULL, # Events at analyses
+    analysis_time = 30, # Times of analyses
+    rho = rho,
+    gamma = gamma,
+    tau = rep(-1, length(rho)),
+    approx = "asymptotic"
+  )
+
+  list(
+    "rho" = rho,
+    "gamma" = gamma,
+    "tau" = tau,
+    "enroll_rate" = enroll_rate,
+    "fail_rate" = fail_rate,
+    "info_combo" = info_combo
+  )
+}
+
+test_gs_prob_combo_1 <- function() {
+  lower <- -0.6
+  upper <- 0.4
+  rho <- c(1, 1, 0, 0)
+  gamma <- c(0, 1, 0, 1)
+  tau <- c(-1, -1, -1, -1)
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 30),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    dropout_rate = rep(.001, 2),
+    hr = c(.9, .6)
+  )
+  arm <- gs_create_arm(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    ratio = 1,
+    total_time = 1e6
+  )
+  sigma <- gsDesign2:::gs_sigma2_combo(
+    arm0 = arm$arm0,
+    arm1 = arm$arm1,
+    tmax = 30,
+    rho = rho,
+    gamma = gamma,
+    tau = rep(-1, length(rho)),
+    approx = "asymptotic"
+  )
+  corr <- cov2cor(sigma)
+  n_test <- length(rho)
+  theta <- rep(0, n_test)
+  analysis <- 1
+
+  prob <- gsDesign2:::gs_prob_combo(
+    lower_bound = rep(lower, n_test),
+    upper_bound = rep(upper, n_test),
+    analysis = analysis,
+    theta = theta,
+    corr = corr,
+    algorithm = GenzBretz(maxpts = 1e5, abseps = 1e-5)
+  )
+  p_efficacy <- gsDesign2:::pmvnorm_combo(
+    lower = rep(upper, n_test),
+    upper = rep(Inf, n_test),
+    group = analysis,
+    mean = theta,
+    corr = corr
+  )
+  p_futility <- gsDesign2:::pmvnorm_combo(
+    lower = rep(-Inf, n_test),
+    upper = rep(lower, n_test),
+    group = analysis,
+    mean = theta,
+    corr = corr
+  )
+
+  list("prob" = prob, "p_efficacy" = p_efficacy, "p_futility" = p_futility)
+}
+
+test_gs_prob_combo_2 <- function() {
+  lower <- c(-0.2, -0.3)
+  upper <- c(0.3, 0.4)
+  rho <- c(1, 1, 0, 0)
+  gamma <- c(0, 1, 0, 1)
+  tau <- c(-1, -1, -1, -1)
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 30),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    dropout_rate = rep(.001, 2),
+    hr = c(.9, .6)
+  )
+  arm <- gs_create_arm(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    ratio = 1,
+    total_time = 1e6
+  )
+  sigma <- gsDesign2:::gs_sigma2_combo(
+    arm0 = arm$arm0,
+    arm1 = arm$arm1,
+    tmax = 30,
+    rho = rho,
+    gamma = gamma,
+    tau = rep(-1, length(rho)),
+    approx = "asymptotic"
+  )
+  corr <- cov2cor(sigma)
+  n_test <- length(rho)
+  theta <- rep(0, n_test)
+  analysis <- c(1, 2)
+  prob <- gsDesign2:::gs_prob_combo(
+    lower_bound = rep(lower, n_test),
+    upper_bound = rep(upper, n_test),
+    analysis = analysis,
+    theta = theta,
+    corr = corr,
+    algorithm = GenzBretz(maxpts = 1e5, abseps = 1e-5)
+  )
+  c <- c(1, 3)
+  corr1 <- corr[c, c]
+  p_efficacy_1 <- gsDesign2:::pmvnorm_combo(
+    lower = rep(upper[1], 2),
+    upper = rep(Inf, 2),
+    group = 1,
+    mean = theta[c],
+    corr = corr1
+  )
+  p_futility_1 <- gsDesign2:::pmvnorm_combo(
+    lower = rep(-Inf, 2),
+    upper = rep(lower[1], 2),
+    group = 1,
+    mean = theta[c],
+    corr = corr1
+  )
+  p_efficacy_2 <- gsDesign2:::pmvnorm_combo(
+    lower = c(lower[1], upper[2]),
+    upper = c(upper[1], Inf),
+    group = analysis,
+    mean = theta,
+    corr = corr
+  )
+  p_futility_2 <- gsDesign2:::pmvnorm_combo(
+    lower = c(lower[1], -Inf),
+    upper = c(upper[1], lower[2]),
+    group = analysis,
+    mean = theta,
+    corr = corr
+  )
+
+  list(
+    "prob" = prob,
+    "p_efficacy_1" = p_efficacy_1,
+    "p_efficacy_2" = p_efficacy_2,
+    "p_futility_1" = p_futility_1,
+    "p_futility_2" = p_futility_2
+  )
+}
+
+test_pmvnorm_combo <- function() {
+  lower <- -Inf
+  upper <- 0
+  mean <- 0.3
+  n_test <- 4
+  rho <- c(1, 1, 0, 0)
+  gamma <- c(0, 1, 0, 1)
+  tau <- c(-1, -1, -1, -1)
+
+  enroll_rate <- define_enroll_rate(
+    stratum = "All",
+    duration = c(2, 2, 10),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    dropout_rate = rep(.001, 2),
+    hr = c(.9, .6)
+  )
+  arm <- gs_create_arm(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    ratio = 1,
+    total_time = 1e6
+  )
+  sigma <- gsDesign2:::gs_sigma2_combo(
+    arm0 = arm$arm0,
+    arm1 = arm$arm1,
+    tmax = 30,
+    rho = rho,
+    gamma = gamma,
+    tau = rep(-1, length(rho)),
+    approx = "asymptotic"
+  )
+  corr <- cov2cor(sigma)
+
+  p <- gsDesign2:::pmvnorm_combo(
+    lower = rep(lower, n_test),
+    upper = rep(upper, n_test),
+    group = 2,
+    mean = rep(mean, n_test),
+    corr = corr,
+    algorithm = mvtnorm::GenzBretz(maxpts = 1e5, abseps = 1e-5)
+  )
+
+  p_test <- mvtnorm::pmvnorm(
+    lower = rep(lower, n_test),
+    upper = rep(upper, n_test),
+    mean = rep(mean, n_test),
+    corr = corr,
+    sigma = NULL,
+    algorithm = mvtnorm::GenzBretz(maxpts = 1e5, abseps = 1e-5)
+  )
+
+  list("p" = p, "p_test" = p_test)
+}
+
+test_gs_utility_combo <- function() {
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 30),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    dropout_rate = rep(.001, 2),
+    hr = c(.9, .6)
+  )
+  analysis_time <- c(12, 24, 36)
+  n_analysis <- length(analysis_time)
+  fh_test <- rbind(data.frame(
+    rho = 0,
+    gamma = 0,
+    tau = -1,
+    test = 1,
+    analysis = 1:3,
+    analysis_time = analysis_time
+  ))
+  gs_arm <- gs_create_arm(
+    enroll_rate,
+    fail_rate,
+    ratio = 1, # Randomization ratio
+    total_time = max(analysis_time) # Total study duration
+  )
+
+  utility_combo <- gsDesign2:::gs_utility_combo(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    fh_test = fh_test,
+    ratio = 1,
+    algorithm = GenzBretz(maxpts = 1e5, abseps = 1e-5)
+  )
+
+  info_combo_test <- gsDesign2:::gs_info_combo(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    ratio = 1,
+    analysis_time = analysis_time,
+    rho = 0,
+    gamma = 0
+  )
+
+  list(
+    "n_analysis" = n_analysis,
+    "utility_combo" = utility_combo,
+    "info_combo_test" = info_combo_test
+  )
+}
+
+test_gs_utility_combo_multiple <- function() {
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 30),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    dropout_rate = rep(.001, 2),
+    hr = c(.9, .6)
+  )
+  analysis_time <- 36
+  n_analysis <- length(analysis_time)
+  rho <- c(0, 0.5, 1)
+  gamma <- c(0.5, 0.5, 0.5)
+  tau <- c(-1, -1, -1)
+  fh_test <- rbind(data.frame(
+    rho = rho,
+    gamma = gamma,
+    tau = tau,
+    test = 1:3,
+    analysis = 1,
+    analysis_time = analysis_time
+  ))
+  gs_arm <- gs_create_arm(
+    enroll_rate,
+    fail_rate,
+    ratio = 1, # Randomization ratio
+    total_time = max(analysis_time) # Total study duration
+  )
+
+  utility_combo <- gsDesign2:::gs_utility_combo(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    fh_test = fh_test,
+    ratio = 1,
+    algorithm = GenzBretz(maxpts = 1e5, abseps = 1e-5)
+  )
+
+  info_combo_test <- gsDesign2:::gs_info_combo(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    ratio = 1,
+    analysis_time = analysis_time,
+    rho = rho,
+    gamma = gamma
+  )
+
+  list(
+    "rho" = rho,
+    "gamma" = gamma,
+    "tau" = tau,
+    "analysis_time" = analysis_time,
+    "n_analysis" = n_analysis,
+    "gs_arm" = gs_arm,
+    "utility_combo" = utility_combo,
+    "info_combo_test" = info_combo_test
+  )
+}

--- a/tests/testthat/test-developer-gs_power_npe.R
+++ b/tests/testthat/test-developer-gs_power_npe.R
@@ -179,7 +179,6 @@ test_that("Re-use these bounds under alternate hypothesis - Always use binding =
   expect_equal(x1, x2)
 })
 
-
 test_that("info != info0 != info1 - If one inputs info in upar", {
   x1_a <- gs_power_npe(
     theta = c(.1, .2, .3),

--- a/tests/testthat/test-double_programming_ppwe.R
+++ b/tests/testthat/test-double_programming_ppwe.R
@@ -1,92 +1,5 @@
-test_ppwe <- function(
-    x = 0:20,
-    failRates = tibble::tibble(
-      duration = c(3, 100),
-      rate = log(2) / c(9, 18)
-    ),
-    lower.tail = FALSE) {
-  boundary <- cumsum(failRates$duration)
-  rate <- failRates$rate
-  xvals <- unique(c(x, boundary))
-  H <- numeric(length(xvals))
-  maxlen <- sum(failRates$duration)
-  max.x <- max(x)
-
-  if (length(x) <= maxlen) {
-    for (t in seq_along(xvals)) {
-      val <- xvals[t]
-      if (val <= boundary[1]) {
-        H[t] <- val * rate[1]
-      } else if (val <= boundary[2]) {
-        H[t] <- boundary[1] * rate[1] + (val - boundary[1]) * rate[2]
-      } else {
-        H[t] <- boundary[1] * rate[1] + (boundary[2] - boundary[1]) * rate[2]
-      }
-    }
-    surv <- exp(-H)
-  } else {
-    boundary1 <- boundary
-    boundary1[2] <- max.x
-    for (t in seq_along(xvals)) {
-      val <- xvals[t]
-      if (val <= boundary1[1]) {
-        H[t] <- val * rate[1]
-      } else if (val <= boundary1[2]) {
-        H[t] <- boundary1[1] * rate[1] + (val - boundary1[1]) * rate[2]
-      } else {
-        H[t] <- boundary1[1] * rate[1] + (boundary1[2] - boundary1[1]) * rate[2]
-      }
-    }
-    surv <- exp(-H)
-  }
-
-  ind <- !is.na(match(xvals, x))
-
-  if (lower.tail) {
-    return(1 - surv[ind])
-  } else {
-    return(surv[ind])
-  }
-}
-
-# Double programming of ppwe when there are 3 steps of failure rates.
-# The method is a simple extention of test_ppwe.
-test_2_ppwe <- function(
-    x = 0:20,
-    failRates = tibble::tibble(
-      duration = c(3, 20, 100),
-      rate = log(2) / c(9, 12, 18)
-    ),
-    lower.tail = FALSE) {
-  boundary <- cumsum(failRates$duration)
-  rate <- failRates$rate
-  xvals <- unique(c(x, boundary))
-  H <- numeric(length(xvals))
-  for (t in seq_along(xvals)) {
-    val <- xvals[t]
-    if (val <= boundary[1]) {
-      H[t] <- val * rate[1]
-    } else if (val <= boundary[2]) {
-      H[t] <- boundary[1] * rate[1] + (val - boundary[1]) * rate[2]
-    } else if (val <= boundary[3]) {
-      H[t] <- boundary[1] * rate[1] + (boundary[2] - boundary[1]) * rate[2] + (val - boundary[3]) * rate[3]
-    } else {
-      H[t] <- boundary[1] * rate[1] + (boundary[2] - boundary[1]) * rate[2] + (boundary[3] - boundary[2]) * rate[3]
-    }
-  }
-  surv <- exp(-H)
-
-  ind <- !is.na(match(xvals, x))
-
-  if (lower.tail) {
-    return(1 - surv[ind])
-  } else {
-    return(surv[ind])
-  }
-}
-
-testthat::test_that("ppwe is incorrect when there are 2-step fail rates", {
-  testthat::expect_equal(
+test_that("ppwe is incorrect when there are 2-step fail rates", {
+  expect_equal(
     gsDesign2::ppwe(
       x = 0:20,
       duration = c(13, 100),
@@ -101,8 +14,8 @@ testthat::test_that("ppwe is incorrect when there are 2-step fail rates", {
   )
 })
 
-testthat::test_that("ppwe is incorrect if varable x is longer than the max duration of fail rates", {
-  testthat::expect_equal(
+test_that("ppwe is incorrect if varable x is longer than the max duration of fail rates", {
+  expect_equal(
     gsDesign2::ppwe(
       x = 0:80,
       duration = c(13, 50),
@@ -117,8 +30,8 @@ testthat::test_that("ppwe is incorrect if varable x is longer than the max durat
   )
 })
 
-testthat::test_that("ppwe is incorrect when there are 3-step fail rates", {
-  testthat::expect_equal(
+test_that("ppwe is incorrect when there are 3-step fail rates", {
+  expect_equal(
     ppwe(
       x = 0:20,
       duration = c(3, 20, 100),
@@ -135,7 +48,7 @@ testthat::test_that("ppwe is incorrect when there are 3-step fail rates", {
 
 # Add the following test case
 
-testthat::test_that("ppwe fail to identify a non-numerical input", {
+test_that("ppwe fail to identify a non-numerical input", {
   x <- c(0:20, "NA")
   expect_error(expect_message(
     gsDesign2::ppwe(x = x, duration = 1, rate = 1),
@@ -143,7 +56,7 @@ testthat::test_that("ppwe fail to identify a non-numerical input", {
   ))
 })
 
-testthat::test_that("ppwe fail to identify a negative input", {
+test_that("ppwe fail to identify a negative input", {
   x <- -20:-1
   expect_error(expect_message(
     gsDesign2::ppwe(x = x, duration = 1, rate = 1),
@@ -151,7 +64,7 @@ testthat::test_that("ppwe fail to identify a negative input", {
   ))
 })
 
-testthat::test_that("ppwe fail to identify a non-increasing input", {
+test_that("ppwe fail to identify a non-increasing input", {
   x <- 20:1
   expect_error(expect_message(
     ppwe(x = x, duration = 1, rate = 1),

--- a/tests/testthat/test-independent-AHR.R
+++ b/tests/testthat/test-independent-AHR.R
@@ -1,47 +1,49 @@
-load("fixtures/simulation_test_data.Rdata")
+test_that("AHR results are consistent with simulation results for single stratum and multiple cutoff", {
+  res <- test_ahr()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  simulation_ahr1 <- res$simulation_ahr1
 
-enroll_rate <- define_enroll_rate(
-  duration = c(2, 2, 10),
-  rate = c(3, 6, 9)
-)
-fail_rate <- define_fail_rate(
-  stratum = "All",
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
-)
-
-testthat::test_that("AHR results are consistent with simulation results for single stratum and multiple cutoff", {
   actual <- ahr(
     enroll_rate = enroll_rate,
     fail_rate = fail_rate,
     total_duration = c(12, 24, 36)
   )
 
-  testthat::expect_true(all.equal(simulation_AHR1$AHR, actual$ahr, tolerance = 0.005))
-  testthat::expect_true(all.equal(simulation_AHR1$Events, actual$event, tolerance = 0.005))
+  expect_true(all.equal(simulation_ahr1$AHR, actual$ahr, tolerance = 0.005))
+  expect_true(all.equal(simulation_ahr1$Events, actual$event, tolerance = 0.005))
 })
 
-testthat::test_that("AHR results are consistent with simulation results for single stratum and single cutoff", {
+test_that("AHR results are consistent with simulation results for single stratum and single cutoff", {
+  res <- test_ahr()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  simulation_ahr2 <- res$simulation_ahr2
+
   total_duration <- 30
   actual <- ahr(
     enroll_rate = enroll_rate,
     fail_rate = fail_rate,
     total_duration = total_duration
   )
-  testthat::expect_true(all.equal(simulation_AHR2$AHR, actual$ahr, tolerance = 1e-3))
-  testthat::expect_true(all.equal(simulation_AHR2$Events, actual$event, tolerance = 2e-3))
+
+  expect_true(all.equal(simulation_ahr2$AHR, actual$ahr, tolerance = 1e-3))
+  expect_true(all.equal(simulation_ahr2$Events, actual$event, tolerance = 2e-3))
 })
 
-testthat::test_that("AHR results are consistent with simulation results for single stratum and multiple cutoff", {
-  total_duration <- c(15, 30)
+test_that("AHR results are consistent with simulation results for single stratum and multiple cutoff", {
+  res <- test_ahr()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  simulation_ahr3 <- res$simulation_ahr3
 
+  total_duration <- c(15, 30)
   actual <- ahr(
     enroll_rate = enroll_rate,
     fail_rate = fail_rate,
     total_duration = total_duration
   )
-  testthat::expect_true(all.equal(simulation_AHR3$AHR, actual$ahr, tolerance = 5e-3))
-  testthat::expect_true(all.equal(simulation_AHR3$Events, actual$event, tolerance = 7e-3))
+
+  expect_true(all.equal(simulation_ahr3$AHR, actual$ahr, tolerance = 5e-3))
+  expect_true(all.equal(simulation_ahr3$Events, actual$event, tolerance = 7e-3))
 })

--- a/tests/testthat/test-independent-check_arg.R
+++ b/tests/testthat/test-independent-check_arg.R
@@ -112,7 +112,7 @@ test_that("check event", {
   expect_error(check_event(c(20, 10)))
 })
 
-testthat::test_that("check total_duration", {
+test_that("check total_duration", {
   expect_error(check_total_duration("a"))
   expect_error(check_total_duration(c(-10, 10)))
 })

--- a/tests/testthat/test-independent-expected_accrual.R
+++ b/tests/testthat/test-independent-expected_accrual.R
@@ -1,30 +1,5 @@
-test_eAccrual <- function(x, enroll_rate) {
-  boundary <- cumsum(enroll_rate$duration)
-  rate <- enroll_rate$rate
-  xvals <- unique(c(x, boundary))
-
-  eAc2 <- numeric(length(xvals))
-  for (t in seq_along(xvals)) {
-    val <- xvals[t]
-    if (val <= boundary[1]) {
-      eAc2[t] <- val * rate[1]
-    } else if (val <= boundary[2]) {
-      eAc2[t] <- boundary[1] * rate[1] + (val - boundary[1]) * rate[2]
-    } else if (val <= boundary[3]) {
-      eAc2[t] <- boundary[1] * rate[1] +
-        (boundary[2] - boundary[1]) * rate[2] + (val - boundary[2]) * rate[3]
-    } else {
-      eAc2[t] <- boundary[1] * rate[1] +
-        (boundary[2] - boundary[1]) * rate[2] + (boundary[3] - boundary[2]) * rate[3]
-    }
-  }
-
-  ind <- !is.na(match(xvals, x))
-  return(eAc2[ind])
-}
-
-testthat::test_that("expect_accrua doesn't match with the double programming e_Acurral function", {
-  testthat::expect_equal(
+test_that("expected_accrual doesn't match with the double programming test_eAccrual function", {
+  expect_equal(
     expected_accrual(
       time = 0:30,
       enroll_rate = define_enroll_rate(
@@ -42,7 +17,7 @@ testthat::test_that("expect_accrua doesn't match with the double programming e_A
   )
 })
 
-testthat::test_that("expect_accrual fail to identify a non-numerical input", {
+test_that("expected_accrual fail to identify a non-numerical input", {
   x <- c(0:20, "NA")
   expect_error(expect_message(
     expected_accrual(time = x),
@@ -50,7 +25,7 @@ testthat::test_that("expect_accrual fail to identify a non-numerical input", {
   ))
 })
 
-testthat::test_that("expect_accrual fail to identify a negative input", {
+test_that("expected_accrual fail to identify a negative input", {
   x <- -20:-1
   expect_error(expect_message(
     expected_accrual(time = x),
@@ -58,7 +33,7 @@ testthat::test_that("expect_accrual fail to identify a negative input", {
   ))
 })
 
-testthat::test_that("expect_accrual fail to identify a non-increasing input", {
+test_that("expected_accrual fail to identify a non-increasing input", {
   x <- 20:1
   expect_error(expect_message(
     expected_accrual(time = x),
@@ -67,7 +42,7 @@ testthat::test_that("expect_accrual fail to identify a non-increasing input", {
 })
 
 # Add test cases for stratified design
-testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
+test_that("expected_accrual fail to identify a non-dataframe input", {
   x <- expected_accrual(
     time = 40,
     enroll_rate = define_enroll_rate(
@@ -79,7 +54,7 @@ testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
   expect_equal(x, 33 * 30 * 2)
 })
 
-testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
+test_that("expected_accrual fail to identify a non-dataframe input", {
   x <- expected_accrual(
     time = 33,
     enroll_rate = define_enroll_rate(
@@ -91,7 +66,7 @@ testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
   expect_equal(x, 33 * 30 * 2)
 })
 
-testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
+test_that("expected_accrual fail to identify a non-dataframe input", {
   x <- expected_accrual(
     time = 30,
     enroll_rate = define_enroll_rate(
@@ -103,7 +78,7 @@ testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
   expect_equal(x, 30 * 30 * 2)
 })
 
-testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
+test_that("expected_accrual fail to identify a non-dataframe input", {
   x <- expected_accrual(
     time = 10,
     enroll_rate = define_enroll_rate(
@@ -115,7 +90,7 @@ testthat::test_that("expect_accrua fail to identify a non-dataframe input", {
   expect_equal(x, 10 * 30 * 2)
 })
 
-testthat::test_that("expect_accrual fail to identify a non-dataframe input", {
+test_that("expected_accrual fail to identify a non-dataframe input", {
   x <- expected_accrual(
     time = c(5, 10, 20, 33, 50),
     enroll_rate = define_enroll_rate(

--- a/tests/testthat/test-independent-expected_event.R
+++ b/tests/testthat/test-independent-expected_event.R
@@ -2,175 +2,130 @@ test_that("expected events is different from gsDesign::eEvents and expected_even
   enroll_rate <- define_enroll_rate(duration = c(2, 1, 2), rate = c(5, 10, 20))
   fail_rate <- define_fail_rate(duration = c(1, 1, 1), fail_rate = c(.05, .02, .01), hr = 1, dropout_rate = .01)
   total_duration <- 20
-  testthat::expect_equal(
+
+  expect_equal(
     expected_event(
-      enroll_rate,
-      fail_rate,
-      total_duration,
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
+      total_duration = total_duration,
       simple = TRUE
     ),
     gsDesign::eEvents(
-      lambda = fail_rate$fail_rate, S = fail_rate$duration[1:(nrow(fail_rate) - 1)],
-      eta = fail_rate$dropout_rate, gamma = enroll_rate$rate,
-      R = enroll_rate$duration, T = total_duration
+      lambda = fail_rate$fail_rate,
+      S = fail_rate$duration[1:(nrow(fail_rate) - 1)],
+      eta = fail_rate$dropout_rate,
+      gamma = enroll_rate$rate,
+      R = enroll_rate$duration,
+      T = total_duration
     )$d,
     ignore_attr = TRUE
   )
 })
 
 test_that("data frame returned from expected_event not as expected", {
-  # test case from gsSurvNPH
+  # Test case from gsSurvNPH
   enroll_rate <- define_enroll_rate(duration = c(1, 1, 8), rate = c(3, 2, 0))
   fail_rate <- define_fail_rate(duration = c(4, Inf), fail_rate = c(.03, .06), dropout_rate = c(.001, .002), hr = 1)
   total_duration <- 7
 
   xx <- expected_event(
-    enroll_rate,
-    fail_rate,
-    total_duration,
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    total_duration = total_duration,
     simple = FALSE
   ) %>%
     data.frame()
-  # expected checked with alternate calculations in gsSurvNPH vignette
+  # Expected checked with alternate calculations in gsSurvNPH vignette
   expected <- data.frame(
     t = c(0, 4),
     fail_rate = c(0.03, 0.06),
     event = c(0.5642911, 0.5194821)
   )
-  testthat::expect_equal(xx, expected)
+  expect_equal(xx, expected)
 })
 
 # Double programming tests
-nEvent <- function(followup) {
-  failduration <- failRates$duration
-  failtime <- cumsum(failduration)
-  failRate <- failRates$failRate
-  dropoutRate <- failRates$dropoutRate
-  lamda <- failRate + dropoutRate
-  lamda1 <- c(lamda, dplyr::last(lamda))
-  failRate1 <- c(failRate, dplyr::last(failRate))
 
-  failtimeend <- c(0, failtime[failtime < followup], followup)
-  failtimeend1 <- c(failtime[failtime < followup], followup)
-  lamda2 <- lamda1[c(1:(length(failtimeend) - 1))]
-  failRate2 <- failRate1[c(1:(length(failtimeend) - 1))]
+# Test 1: with multiple fail rates, short FU
+test_that("expected events is different from double-programmed vs. expected_event, with mutiple failrates, short FU", {
+  res <- params_expected_event()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  failRates <- res$failRates
+  total_duration <- res$total_duration
+  simple <- res$simple
 
-  failduration <- diff(failtimeend)
-  failduration2 <- followup - failtimeend1
-
-  fail <- lamda2 * failduration
-  sumfail <- cumsum(fail)
-  Bi1 <- c(1, exp(-sumfail))
-  diffbi <- diff(Bi1)
-  Bi <- Bi1[c(1:(length(Bi1) - 1))]
-
-  totalevent <- diffbi * (1 / lamda2 - failduration2) + Bi * failduration
-
-  failevent <- totalevent * (failRate2 / lamda2)
-  return(sum(failevent))
-}
-
-test_Event <- function(enrollRates, failRates, totalDuration) {
-  enrolltime <- c(0, cumsum(enrollRates$duration))
-  Event <- 0
-  for (i in seq_along(enrollRates$duration)) {
-    enrollmentstart <- 0
-    enrollmentend <- enrollRates$duration[i]
-    enrollrate <- enrollRates$rate[i]
-    followup <- totalDuration - enrolltime[i]
-    nEventnum <- 0
-
-    if (followup > 0 && followup <= enrollmentend) {
-      nEventnum <- nEvent(followup) * enrollrate
-    } else if (followup > 0 && followup > enrollmentend) {
-      nEventnum <- (nEvent(followup) - nEvent(followup - enrollmentend)) * enrollrate
-    } else {
-      nEventnum <- 0
-    }
-    Event <- Event + nEventnum
-  }
-  return(Event)
-}
-
-enroll_rate <- define_enroll_rate(
-  duration = c(50),
-  rate = c(10)
-)
-
-fail_rate <- define_fail_rate(
-  duration = c(10, 20, 10),
-  fail_rate = log(2) / c(5, 10, 5),
-  dropout_rate = c(0.1, 0.2, 0),
-  hr = 1
-)
-fail_rate$failRate <- fail_rate$fail_rate
-fail_rate$dropoutRate <- fail_rate$dropout_rate
-failRates <- fail_rate
-
-total_duration <- 5
-simple <- TRUE
-
-### test1:with mutiple failrates, short FU
-testthat::test_that(
-  "expected events is different from double-programmed vs expected_event, with mutiple failrates, short FU",
-  {
-    testthat::expect_equal(
-      test_Event(enroll_rate, fail_rate, total_duration),
-      expected_event(
-        enroll_rate,
-        fail_rate,
-        total_duration,
-        simple
-      )
+  expect_equal(
+    test_expected_event(
+      enrollRates = enroll_rate,
+      failRates = failRates,
+      totalDuration = total_duration
+    ),
+    expected_event(
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
+      total_duration = total_duration,
+      simple = simple
     )
-  }
-)
+  )
+})
 
-### test2:with mutiple failrates, long FU
-testthat::test_that(
-  "expected events is different from double-programmed vs expected_event, with mutiple failrates, long FU",
-  {
-    total_duration <- 80
-    testthat::expect_equal(
-      test_Event(enroll_rate, fail_rate, total_duration),
-      expected_event(
-        enroll_rate,
-        fail_rate,
-        total_duration,
-        simple
-      )
-    )
-  }
-)
+# Test 2: with multiple fail rates, long FU
+test_that("expected events is different from double-programmed vs. expected_event, with mutiple failrates, long FU", {
+  res <- params_expected_event()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  failRates <- res$failRates
+  total_duration <- 80
+  simple <- res$simple
 
-### test3:with mutiple failrates and with multiple enrollment duration
-testthat::test_that(
-  "expected events is different from double-programmed vs expected_event, with mutiple enrollment duration",
-  {
-    enrollRates <- define_enroll_rate(
-      duration = c(50, 10),
-      rate = c(10, 5)
+  expect_equal(
+    test_expected_event(
+      enrollRates = enroll_rate,
+      failRates = failRates,
+      totalDuration = total_duration
+    ),
+    expected_event(
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
+      total_duration = total_duration,
+      simple = simple
     )
-    failRates <- define_fail_rate(
-      duration = c(10, 20, 10),
-      fail_rate = log(2) / c(5, 10, 5),
-      dropout_rate = c(0.1, 0.2, 0),
-      hr = 1
-    )
+  )
+})
 
-    fail_rate$failRate <- fail_rate$fail_rate
-    fail_rate$dropoutRate <- fail_rate$dropout_rate
-    failRates <- fail_rate
+# Test 3: with multiple fail rates and with multiple enrollment duration
+test_that("expected events is different from double-programmed vs. expected_event, with mutiple enrollment duration", {
+  enroll_rate <- define_enroll_rate(
+    duration = c(50, 10),
+    rate = c(10, 5)
+  )
 
-    total_duration <- 80
-    testthat::expect_equal(
-      test_Event(enroll_rate, fail_rate, total_duration),
-      expected_event(
-        enroll_rate,
-        fail_rate,
-        total_duration,
-        simple
-      )
+  fail_rate <- define_fail_rate(
+    duration = c(10, 20, 10),
+    fail_rate = log(2) / c(5, 10, 5),
+    dropout_rate = c(0.1, 0.2, 0),
+    hr = 1
+  )
+
+  fail_rate$failRate <- fail_rate$fail_rate
+  fail_rate$dropoutRate <- fail_rate$dropout_rate
+  failRates <- fail_rate
+
+  total_duration <- 80
+  simple <- TRUE
+
+  expect_equal(
+    test_expected_event(
+      enrollRates = enroll_rate,
+      failRates = failRates,
+      totalDuration = total_duration
+    ),
+    expected_event(
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
+      total_duration = total_duration,
+      simple = simple
     )
-  }
-)
+  )
+})

--- a/tests/testthat/test-independent-expected_time.R
+++ b/tests/testthat/test-independent-expected_time.R
@@ -1,27 +1,10 @@
-enroll_rate <- define_enroll_rate(
-  duration = c(2, 2, 10),
-  rate = c(3, 6, 9) * 5
-)
+test_that("expected_time equal to test_event result", {
+  res <- test_expected_time()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  t1 <- res$t1
 
-fail_rate <- define_fail_rate(
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  dropout_rate = rep(.001, 2),
-  hr = c(.9, .6)
-)
-
-target_event <- 150
-interval <- c(.01, 100)
-
-t1 <- expected_time(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  target_event = target_event,
-  interval = interval
-)
-
-testthat::test_that("expected_time equal to test_event result", {
-  testthat::expect_equal(
+  expect_equal(
     t1$event,
     test_event(
       enroll_rate = enroll_rate,
@@ -31,8 +14,13 @@ testthat::test_that("expected_time equal to test_event result", {
   )
 })
 
-testthat::test_that("expected_time euqal to AHR's result", {
-  testthat::expect_equal(
+test_that("expected_time euqal to AHR's result", {
+  res <- test_expected_time()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  t1 <- res$t1
+
+  expect_equal(
     t1$event,
     ahr(
       enroll_rate = enroll_rate,

--- a/tests/testthat/test-independent-fixed_design.R
+++ b/tests/testthat/test-independent-fixed_design.R
@@ -1,52 +1,56 @@
-# Enrollment rate
-enroll_rate <- define_enroll_rate(
-  duration = 18,
-  rate = 20
-)
-
-# Failure rates
-fail_rate <- define_fail_rate(
-  duration = c(4, 100),
-  fail_rate = log(2) / 12,
-  dropout_rate = .001,
-  hr = c(1, .6)
-)
-
-# Study duration in months
-study_duration <- 36
-
-# Experimental / Control randomization ratio
-ratio <- 1
-
 test_that("AHR", {
+  res <- test_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
+
   x <- fixed_design_ahr(
-    alpha = 0.025, power = 0.9,
-    enroll_rate = enroll_rate, fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio
+    alpha = 0.025,
+    power = 0.9,
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio
   )
 
   y <- fixed_design_ahr(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration),
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio
   )
 
   expect_equal(y$analysis$power, 0.9)
 })
 
 test_that("FH", {
+  res <- test_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
+
   x <- fixed_design_fh(
-    alpha = 0.025, power = 0.9,
-    enroll_rate = enroll_rate, fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio,
-    rho = 0.5, gamma = 0.5
+    alpha = 0.025,
+    power = 0.9,
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio,
+    rho = 0.5,
+    gamma = 0.5
   ) |> to_integer()
 
   y <- fixed_design_fh(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio,
-    rho = 0.5, gamma = 0.5
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration),
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio,
+    rho = 0.5,
+    gamma = 0.5
   )
 
   expect_true(y$analysis$power >= 0.9)
@@ -54,17 +58,28 @@ test_that("FH", {
 })
 
 test_that("MB", {
+  res <- test_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
+
   x <- fixed_design_mb(
-    alpha = 0.025, power = 0.9,
-    enroll_rate = enroll_rate, fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio,
+    alpha = 0.025,
+    power = 0.9,
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio,
     tau = 8
   ) |> to_integer()
 
   y <- fixed_design_mb(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio,
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration),
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio,
     tau = 8
   )
 
@@ -73,26 +88,46 @@ test_that("MB", {
 })
 
 test_that("LF", {
+  res <- test_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
+
   x <- fixed_design_lf(
-    alpha = 0.025, power = 0.9,
-    enroll_rate = enroll_rate, fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio
+    alpha = 0.025,
+    power = 0.9,
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio
   ) |> to_integer()
 
   y <- fixed_design_lf(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration),
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio
   )
 
   expect_equal(y$analysis$power, 0.9, tolerance = 0.01)
 })
 
 test_that("MaxCombo", {
+  res <- test_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
+
   x <- fixed_design_maxcombo(
-    alpha = 0.025, power = 0.9,
-    enroll_rate = enroll_rate, fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio,
+    alpha = 0.025,
+    power = 0.9,
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio,
     rho = c(0, 0.5, 0.5),
     gamma = c(0, 0, 0.5),
     tau = c(-1, 4, 6)
@@ -100,8 +135,10 @@ test_that("MaxCombo", {
 
   y <- fixed_design_maxcombo(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio,
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration),
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio,
     rho = c(0, 0.5, 0.5),
     gamma = c(0, 0, 0.5),
     tau = c(-1, 4, 6)
@@ -111,17 +148,28 @@ test_that("MaxCombo", {
 })
 
 test_that("RMST", {
+  res <- test_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
+
   x <- fixed_design_rmst(
-    alpha = 0.025, power = 0.9,
-    enroll_rate = enroll_rate, fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio,
+    alpha = 0.025,
+    power = 0.9,
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio,
     tau = 18
   )
 
   y <- fixed_design_rmst(
     alpha = 0.025,
-    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration), fail_rate = fail_rate,
-    study_duration = study_duration, ratio = ratio,
+    enroll_rate = enroll_rate %>% dplyr::mutate(rate = x$analysis$n / duration),
+    fail_rate = fail_rate,
+    study_duration = study_duration,
+    ratio = ratio,
     tau = 18
   )
 
@@ -129,14 +177,28 @@ test_that("RMST", {
 })
 
 test_that("RD", {
+  res <- test_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
+
   x <- fixed_design_rd(
-    alpha = 0.025, power = 0.9,
-    p_c = .15, p_e = .1, rd0 = 0, ratio = ratio
+    alpha = 0.025,
+    power = 0.9,
+    p_c = .15,
+    p_e = .1,
+    rd0 = 0,
+    ratio = ratio
   )
 
   y <- fixed_design_rd(
-    alpha = 0.025, n = x$analysis$n,
-    p_c = .15, p_e = .1, rd0 = 0, ratio = ratio
+    alpha = 0.025,
+    n = x$analysis$n,
+    p_c = .15,
+    p_e = .1,
+    rd0 = 0,
+    ratio = ratio
   )
 
   expect_equal(y$analysis$power, 0.9, tolerance = testthat_tolerance() * 2e+5)

--- a/tests/testthat/test-independent-gs_b.R
+++ b/tests/testthat/test-independent-gs_b.R
@@ -14,7 +14,7 @@ test_that("gs_b() returns values as expected", {
   expect_equal(par[5], gs_b(par, k = k))
 })
 
-testthat::test_that("gs_b() returns NA if the number of interim analysis is larger than the length of par", {
+test_that("gs_b() returns NA if the number of interim analysis is larger than the length of par", {
   IF <- c(.8, 1)
   par <- gsDesign::gsDesign(
     alpha = .025,

--- a/tests/testthat/test-independent-gs_bound.R
+++ b/tests/testthat/test-independent-gs_bound.R
@@ -1,4 +1,4 @@
-testthat::test_that("compare with results from gsDesign, 3 analyses, equal IA timing", {
+test_that("compare with results from gsDesign, 3 analyses, equal IA timing", {
   x <- gsDesign::gsSurv(
     k = 3, test.type = 4, alpha = 0.025,
     beta = 0.2, timing = 1,
@@ -24,7 +24,7 @@ testthat::test_that("compare with results from gsDesign, 3 analyses, equal IA ti
   expect_equal(object = unlist(test1[2], use.names = FALSE), expected = xbound[, 2], tolerance = 0.05)
 })
 
-testthat::test_that("compare with results from gsDesign, 3 analyses, unequal IA timing", {
+test_that("compare with results from gsDesign, 3 analyses, unequal IA timing", {
   y <- gsDesign::gsSurv(
     k = 3, test.type = 4, alpha = 0.025,
     beta = 0.2, timing = c(0.6, 0.8),

--- a/tests/testthat/test-independent-gs_design_ahr.R
+++ b/tests/testthat/test-independent-gs_design_ahr.R
@@ -1,6 +1,6 @@
 # Test 1: compare results with AHR ####
 
-testthat::test_that("compare results with AHR in the situation of single analysis", {
+test_that("compare results with AHR in the situation of single analysis", {
   enroll_rate <- define_enroll_rate(
     duration = c(2, 2, 10),
     rate = c(3, 6, 9)
@@ -20,7 +20,7 @@ testthat::test_that("compare results with AHR in the situation of single analysi
     analysis_time = analysis_time
   )
 
-  testthat::expect_equal(
+  expect_equal(
     out$analysis %>% dplyr::select(time, ahr) %>% as.data.frame(),
     ahr(
       enroll_rate = enroll_rate,
@@ -34,7 +34,7 @@ testthat::test_that("compare results with AHR in the situation of single analysi
   # update enroll_rate for AHR to make Events/info/info0 also match in outputs
   enroll_rate1 <- enroll_rate %>% dplyr::mutate(rate = rate * c(out$analysis$n / (duration %*% rate)))
 
-  testthat::expect_equal(
+  expect_equal(
     out$analysis %>% dplyr::select(time, ahr, event, info, info0) %>% as.data.frame(),
     ahr(
       enroll_rate = enroll_rate1,
@@ -46,57 +46,54 @@ testthat::test_that("compare results with AHR in the situation of single analysi
   )
 })
 
-testthat::test_that(
-  "compare results with gsDesign2::AHR in the situation with IF and multiple analysis times specified",
-  {
-    enroll_rate <- define_enroll_rate(
-      duration = c(2, 2, 10),
-      rate = c(3, 6, 9)
-    )
-    fail_rate <- define_fail_rate(
-      duration = c(3, 100),
-      fail_rate = log(2) / c(9, 18),
-      dropout_rate = rep(0.001, 2),
-      hr = c(0.9, 0.6)
-    )
-    total_duration <- c(12, 25, 36)
-    analysis_time <- total_duration
+test_that("compare results with gsDesign2::AHR in the situation with IF and multiple analysis times specified", {
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 10),
+    rate = c(3, 6, 9)
+  )
+  fail_rate <- define_fail_rate(
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    dropout_rate = rep(0.001, 2),
+    hr = c(0.9, 0.6)
+  )
+  total_duration <- c(12, 25, 36)
+  analysis_time <- total_duration
 
-    out <- gs_design_ahr(
+  out <- gs_design_ahr(
+    enroll_rate = enroll_rate,
+    fail_rate = fail_rate,
+    analysis_time = analysis_time
+  )
+
+  expect_equal(
+    out$analysis %>%
+      dplyr::select(time, ahr) %>%
+      dplyr::distinct(.keep_all = TRUE) %>%
+      as.data.frame(),
+    ahr(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
-      analysis_time = analysis_time
-    )
+      total_duration = total_duration
+    ) %>%
+      dplyr::select(time, ahr) %>%
+      as.data.frame()
+  )
 
-    testthat::expect_equal(
-      out$analysis %>%
-        dplyr::select(time, ahr) %>%
-        dplyr::distinct(.keep_all = TRUE) %>%
-        as.data.frame(),
-      ahr(
-        enroll_rate = enroll_rate,
-        fail_rate = fail_rate,
-        total_duration = total_duration
-      ) %>%
-        dplyr::select(time, ahr) %>%
-        as.data.frame()
-    )
+  # update enroll_rate for AHR to make Events/info/info0 also match in outputs
+  enroll_rate1 <- enroll_rate %>% dplyr::mutate(rate = rate * c(max(out$analysis$n) / (duration %*% rate)))
 
-    # update enroll_rate for AHR to make Events/info/info0 also match in outputs
-    enroll_rate1 <- enroll_rate %>% dplyr::mutate(rate = rate * c(max(out$analysis$n) / (duration %*% rate)))
-
-    testthat::expect_equal(
-      out$analysis %>%
-        dplyr::select(time, ahr, event, info, info0) %>%
-        dplyr::distinct(.keep_all = TRUE) %>%
-        as.data.frame(),
-      ahr(
-        enroll_rate = enroll_rate1,
-        fail_rate = fail_rate,
-        total_duration = total_duration
-      ) %>%
-        dplyr::select(time, ahr, event, info, info0) %>%
-        as.data.frame()
-    )
-  }
-)
+  expect_equal(
+    out$analysis %>%
+      dplyr::select(time, ahr, event, info, info0) %>%
+      dplyr::distinct(.keep_all = TRUE) %>%
+      as.data.frame(),
+    ahr(
+      enroll_rate = enroll_rate1,
+      fail_rate = fail_rate,
+      total_duration = total_duration
+    ) %>%
+      dplyr::select(time, ahr, event, info, info0) %>%
+      as.data.frame()
+  )
+})

--- a/tests/testthat/test-independent-gs_design_combo.R
+++ b/tests/testthat/test-independent-gs_design_combo.R
@@ -1,104 +1,29 @@
-load("fixtures/sim_gsd_pMaxCombo_exp1_H0_test.Rdata")
-load("fixtures/sim_gsd_pMaxCombo_exp1_H1_test.Rdata")
+params_gs_design_combo <- test_gs_design_combo()
 
-ratio <- 1
-algorithm <- GenzBretz(
-  maxpts = 1e5,
-  abseps = 1e-5
-)
-alpha <- 0.025
-beta <- 0.2
-enroll_rate <- define_enroll_rate(
-  duration = 12,
-  rate = 500 / 12
-)
+test_that("calculate analysis number as planned", {
+  res <- params_gs_design_combo
+  fh_test <- res$fh_test
+  gs_design_combo_test2 <- res$gs_design_combo_test2
 
-fail_rate <- define_fail_rate(
-  duration = c(4, 100),
-  fail_rate = log(2) / 15, # median survival 15 month
-  dropout_rate = 0.001,
-  hr = c(1, .6)
-)
-
-fh_test <- rbind(
-  data.frame(
-    rho = 0,
-    gamma = 0,
-    tau = -1,
-    test = 1,
-    analysis = 1:3,
-    analysis_time = c(12, 24, 36)
-  ),
-  data.frame(
-    rho = c(0, 0.5),
-    gamma = 0.5,
-    tau = -1,
-    test = 2:3,
-    analysis = 3,
-    analysis_time = 36
-  )
-)
-
-x <- gsDesign::gsSurv(
-  k = 3,
-  test.type = 4,
-  alpha = 0.025,
-  beta = 0.2,
-  astar = 0,
-  timing = c(1),
-  sfu = gsDesign::sfLDOF,
-  sfupar = c(0),
-  sfl = gsDesign::sfLDOF,
-  sflpar = c(0),
-  lambdaC = c(0.1),
-  hr = 0.6,
-  hr0 = 1,
-  eta = 0.01,
-  gamma = c(10),
-  R = c(12),
-  S = NULL,
-  T = 36,
-  minfup = 24,
-  ratio = 1
-)
-
-# User-defined boundary
-gs_design_combo_test1 <- gs_design_combo(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  fh_test = fh_test,
-  alpha = alpha,
-  beta = beta,
-  ratio = 1,
-  binding = FALSE, # test.type = 4 non-binding futility bound
-  upar = x$upper$bound,
-  lpar = x$lower$bound
-)
-
-#### Boundary derived by spending function testing
-gs_design_combo_test2 <- gs_design_combo(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  fh_test = fh_test,
-  alpha = 0.025,
-  beta = 0.2,
-  ratio = 1,
-  binding = FALSE, # test.type = 4 non-binding futility bound
-  upper = gs_spending_combo,
-  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025), # alpha spending
-  lower = gs_spending_combo,
-  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2), # beta spending
-)
-
-testthat::test_that("calculate analysis number as planned", {
   expect_equal(max(fh_test$analysis), max(gs_design_combo_test2$analysis$analysis))
 })
-testthat::test_that("calculate analysisTimes as planned", {
+
+test_that("calculate analysisTimes as planned", {
+  res <- params_gs_design_combo
+  fh_test <- res$fh_test
+  gs_design_combo_test2 <- res$gs_design_combo_test2
+
   expect_equal(unique(fh_test$analysis_time), unique(gs_design_combo_test2$analysis$time))
 })
 
-for (i in 1:max(fh_test$analysis)) {
-  testthat::test_that("calculate N and each analysis Events N as planned", {
+test_that("calculate N and each analysis Events N as planned", {
+  res <- params_gs_design_combo
+  fh_test <- res$fh_test
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  gs_design_combo_test2 <- res$gs_design_combo_test2
+
+  for (i in 1:max(fh_test$analysis)) {
     event <- test_event(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
@@ -106,11 +31,20 @@ for (i in 1:max(fh_test$analysis)) {
     )
     enrollsum <- enroll_rate$duration * enroll_rate$rate
     N <- max(gs_design_combo_test2$analysis$n)
-    expect_equal(event * N / enrollsum, unique(gs_design_combo_test2$analysis$event)[i], tolerance = 0.01)
-  })
-}
 
-testthat::test_that("calculate probability under alternative", {
+    expect_equal(
+      event * N / enrollsum,
+      unique(gs_design_combo_test2$analysis$event)[i],
+      tolerance = 0.01
+    )
+  }
+})
+
+test_that("calculate probability under alternative", {
+  res <- params_gs_design_combo
+  beta <- res$beta
+  gs_design_combo_test2 <- res$gs_design_combo_test2
+
   expect_equal(
     1 - beta,
     max((gs_design_combo_test2$bounds %>% dplyr::filter(bound == "upper"))$probability),
@@ -118,7 +52,11 @@ testthat::test_that("calculate probability under alternative", {
   )
 })
 
-testthat::test_that("calculate probability under null", {
+test_that("calculate probability under null", {
+  res <- params_gs_design_combo
+  alpha <- res$alpha
+  gs_design_combo_test2 <- res$gs_design_combo_test2
+
   expect_equal(
     alpha,
     max((gs_design_combo_test2$bounds %>% dplyr::filter(bound == "upper"))$probability0),
@@ -126,7 +64,7 @@ testthat::test_that("calculate probability under null", {
   )
 })
 
-testthat::test_that("arguments are passed via ... to mvtnorm::pmvnorm()", {
+test_that("arguments are passed via ... to mvtnorm::pmvnorm()", {
   x1 <- gs_design_combo(seed = 1)
   x2 <- gs_design_combo(seed = 1)
   x3 <- gs_design_combo(seed = 2)

--- a/tests/testthat/test-independent-gs_design_npe.R
+++ b/tests/testthat/test-independent-gs_design_npe.R
@@ -1,16 +1,15 @@
-# Parameters used repeatedly
-
-K <- 3
-timing <- c(.45, .8, 1)
-sfu <- gsDesign::sfPower
-sfupar <- 4
-sfl <- gsDesign::sfHSD
-sflpar <- 2
-delta <- .2
-alpha <- .02
-beta <- .15
-
 test_that("One-sided design fails to reproduce gsDesign package bounds", {
+  params <- params_gs_design_npe
+  K <- params$K
+  timing <- params$timing
+  sfu <- params$sfu
+  sfupar <- params$sfupar
+  sfl <- params$sfl
+  sflpar <- params$sflpar
+  delta <- params$delta
+  alpha <- params$alpha
+  beta <- params$beta
+
   gsd <- gsDesign::gsDesign(
     test.type = 1, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
     delta = delta, alpha = alpha, beta = beta
@@ -23,20 +22,30 @@ test_that("One-sided design fails to reproduce gsDesign package bounds", {
     lpar = rep(-Inf, K)
   ) %>% dplyr::filter(bound == "upper")
 
-  # compare boundaries
+  # Compare boundaries
   expect_equal(gsd$upper$bound, gsdv$z, tolerance = 7e-6)
   expect_equal(gsd$n.I, gsdv$info, tolerance = .001)
 
-  # compare statistical information
+  # Compare statistical information
   # While tolerance should not be problematic, it seems large
   expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
-  # compare crossing boundaries probability
+  # Compare crossing boundaries probability
   expect_equal(gsdv$probability0, sfu(alpha = alpha, t = timing, param = sfupar)$spend)
 })
 
-
 test_that("Two-sided symmetric design fails to reproduce gsDesign test.type=2 bounds", {
+  params <- params_gs_design_npe
+  K <- params$K
+  timing <- params$timing
+  sfu <- params$sfu
+  sfupar <- params$sfupar
+  sfl <- params$sfl
+  sflpar <- params$sflpar
+  delta <- params$delta
+  alpha <- params$alpha
+  beta <- params$beta
+
   gsd <- gsDesign::gsDesign(
     test.type = 2, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
     delta = delta, alpha = alpha, beta = beta, tol = 1e-6
@@ -51,15 +60,15 @@ test_that("Two-sided symmetric design fails to reproduce gsDesign test.type=2 bo
     lpar = list(sf = sfu, total_spend = alpha, param = sfupar),
     tol = 1e-6
   )
-  # compare boundaries
+  # Compare boundaries
   expect_equal(gsd$upper$bound, (gsdv %>% dplyr::filter(bound == "upper"))$z, tolerance = 7e-6)
   expect_equal(gsd$lower$bound, (gsdv %>% dplyr::filter(bound == "lower"))$z, tolerance = 7e-6)
 
-  # compare statistical information
+  # Compare statistical information
   # While tolerance should not be problematic, it seems large
   expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
-  # compare crossing boundaries probability
+  # Compare crossing boundaries probability
   expect_equal(
     (gsdv %>% dplyr::filter(bound == "upper"))$probability0,
     sfu(alpha = alpha, t = timing, param = sfupar)$spend
@@ -67,6 +76,17 @@ test_that("Two-sided symmetric design fails to reproduce gsDesign test.type=2 bo
 })
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=3 bounds", {
+  params <- params_gs_design_npe
+  K <- params$K
+  timing <- params$timing
+  sfu <- params$sfu
+  sfupar <- params$sfupar
+  sfl <- params$sfl
+  sflpar <- params$sflpar
+  delta <- params$delta
+  alpha <- params$alpha
+  beta <- params$beta
+
   gsd <- gsDesign::gsDesign(
     test.type = 3, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
     delta = delta, alpha = alpha, beta = beta
@@ -80,15 +100,15 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=3 b
     lower = gs_spending_bound,
     lpar = list(sf = sfl, total_spend = beta, param = sflpar)
   )
-  # compare boundaries
+  # Compare boundaries
   expect_equal(gsd$upper$bound, (gsdv %>% dplyr::filter(bound == "upper"))$z, tolerance = 7e-6)
   expect_equal(gsd$lower$bound, (gsdv %>% dplyr::filter(bound == "lower"))$z, tolerance = 9e-6)
 
-  # compare statistical information
+  # Compare statistical information
   # While tolerance should not be problematic, it seems large
   expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
-  # compare crossing boundaries probability under null hypothesis (theta = 0)
+  # Compare crossing boundaries probability under null hypothesis (theta = 0)
   expect_equal(
     (gsdv %>% dplyr::filter(bound == "upper"))$probability0,
     sfu(alpha = alpha, t = timing, param = sfupar)$spend
@@ -100,6 +120,17 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=3 b
 })
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 bounds", {
+  params <- params_gs_design_npe
+  K <- params$K
+  timing <- params$timing
+  sfu <- params$sfu
+  sfupar <- params$sfupar
+  sfl <- params$sfl
+  sflpar <- params$sflpar
+  delta <- params$delta
+  alpha <- params$alpha
+  beta <- params$beta
+
   gsd <- gsDesign::gsDesign(
     test.type = 4, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
     delta = delta, alpha = alpha, beta = beta
@@ -114,15 +145,15 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 b
     lpar = list(sf = sfl, total_spend = beta, param = sflpar)
   )
 
-  # compare boundaries
+  # Compare boundaries
   expect_equal(gsd$upper$bound, (gsdv %>% dplyr::filter(bound == "upper"))$z, tolerance = 7e-6)
   expect_equal(gsd$lower$bound, (gsdv %>% dplyr::filter(bound == "lower"))$z, tolerance = 9e-6)
 
-  # compare statistical information
+  # Compare statistical information
   # While tolerance should not be problematic, it seems large
   expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
-  # compare crossing boundaries probability under null hypothesis (theta = 0)
+  # Compare crossing boundaries probability under null hypothesis (theta = 0)
   expect_equal(
     gsdv$probability0,
     gsDesign::gsBoundSummary(gsd) %>%
@@ -144,8 +175,18 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 b
   )
 })
 
-
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 bounds", {
+  params <- params_gs_design_npe
+  K <- params$K
+  timing <- params$timing
+  sfu <- params$sfu
+  sfupar <- params$sfupar
+  sfl <- params$sfl
+  sflpar <- params$sflpar
+  delta <- params$delta
+  alpha <- params$alpha
+  beta <- params$beta
+
   astar <- 0.2
   gsd <- gsDesign::gsDesign(
     test.type = 5, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
@@ -161,15 +202,15 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 b
     lpar = list(sf = sfl, total_spend = astar, param = sflpar)
   )
 
-  # compare boundaries
+  # Compare boundaries
   expect_equal(gsd$upper$bound, (gsdv %>% dplyr::filter(bound == "upper"))$z, tolerance = 7e-6)
   expect_equal(gsd$lower$bound, (gsdv %>% dplyr::filter(bound == "lower"))$z, tolerance = 9e-6)
 
-  # compare statistical information
+  # Compare statistical information
   # While tolerance should not be problematic, it seems large
   expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
-  # compare crossing boundaries probability under null hypothesis (theta = 0)
+  # Compare crossing boundaries probability under null hypothesis (theta = 0)
   expect_equal(
     (gsdv %>% dplyr::filter(bound == "upper"))$probability0,
     sfu(alpha = alpha, t = timing, param = sfupar)$spend
@@ -191,6 +232,17 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 b
 })
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=6 bounds", {
+  params <- params_gs_design_npe
+  K <- params$K
+  timing <- params$timing
+  sfu <- params$sfu
+  sfupar <- params$sfupar
+  sfl <- params$sfl
+  sflpar <- params$sflpar
+  delta <- params$delta
+  alpha <- params$alpha
+  beta <- params$beta
+
   astar <- 0.2
   gsd <- gsDesign::gsDesign(
     test.type = 6, k = K, sfu = sfu, sfupar = sfupar, sfl = sfl, sflpar = sflpar, timing = timing,
@@ -206,15 +258,15 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=6 b
     lpar = list(sf = sfl, total_spend = astar, param = sflpar)
   )
 
-  # compare boundaries
+  # Compare boundaries
   expect_equal(gsd$upper$bound, (gsdv %>% dplyr::filter(bound == "upper"))$z, tolerance = 7e-6)
   expect_equal(gsd$lower$bound, (gsdv %>% dplyr::filter(bound == "lower"))$z, tolerance = 9e-6)
 
-  # compare statistical information
+  # Compare statistical information
   # While tolerance should not be problematic, it seems large
   expect_equal(gsd$n.I, (gsdv %>% dplyr::filter(bound == "upper"))$info, tolerance = .04)
 
-  # compare crossing boundaries probability under null hypothesis (theta = 0)
+  # Compare crossing boundaries probability under null hypothesis (theta = 0)
   expect_equal(
     (gsdv %>% dplyr::filter(bound == "upper"))$probability0,
     sfu(alpha = alpha, t = timing, param = sfupar)$spend,

--- a/tests/testthat/test-independent-gs_info_ahr.R
+++ b/tests/testthat/test-independent-gs_info_ahr.R
@@ -1,20 +1,12 @@
-enroll_rate <- define_enroll_rate(
-  duration = c(2, 2, 10),
-  rate = c(3, 6, 9)
-)
-fail_rate <- define_fail_rate(
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  hr = c(0.9, 0.6),
-  dropout_rate = 0.001
-)
+# Test 1: independent test using AHR to check outputs of gs_info_ahr
 
-# Test 1: independent test using AHR to check outputs of gs_info_ahr ####
-
-testthat::test_that("results match if only put in targeted analysis times", {
+test_that("results match if only put in targeted analysis times", {
+  res <- test_gs_info_ahr()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
   total_duration <- c(18, 27, 36)
 
-  testthat::expect_equal(
+  expect_equal(
     gs_info_ahr(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
@@ -28,15 +20,17 @@ testthat::test_that("results match if only put in targeted analysis times", {
   )
 })
 
-
-testthat::test_that("results match if only put in targeted events", {
+test_that("results match if only put in targeted events", {
+  res <- test_gs_info_ahr()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
   event <- c(30, 40, 50)
 
   out1 <- gs_info_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, event = event)
 
   total_duration <- out1$time
 
-  testthat::expect_equal(
+  expect_equal(
     out1 %>% dplyr::select(time, ahr, event, info, info0),
     ahr(
       enroll_rate = enroll_rate,
@@ -45,14 +39,17 @@ testthat::test_that("results match if only put in targeted events", {
     )
   )
 
-  # since above test is based on the output "time", here is to check whether the output "Time" is reasonable
+  # Since above test is based on the output "time", here is to check whether
+  # the output "Time" is reasonable.
 
   # "Time" should be at the time points when targeted event numbers are achieved
-  testthat::expect_equal(round(out1$event), round(event))
+  expect_equal(round(out1$event), round(event))
 })
 
-
-testthat::test_that("results match if put in both analysis time and targeted events", {
+test_that("results match if put in both analysis time and targeted events", {
+  res <- test_gs_info_ahr()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
   event <- c(30, 40, 50)
   analysis_time <- c(16, 19, 26)
 
@@ -65,7 +62,7 @@ testthat::test_that("results match if put in both analysis time and targeted eve
 
   total_duration <- out1$time
 
-  testthat::expect_equal(
+  expect_equal(
     out1 %>% dplyr::select(time, ahr, event, info, info0),
     ahr(
       enroll_rate = enroll_rate,
@@ -74,19 +71,19 @@ testthat::test_that("results match if put in both analysis time and targeted eve
     )
   )
 
-  # since above test is based on the output "Time",
-  # here is to check whether the output "Time" is reasonable
+  # Since above test is based on the output "Time",
+  # here is to check whether the output "Time" is reasonable.
 
-  # either being equal to the corresponding element in the input
-  # analysis_time or at the time point when targeted event number achieved
-  testthat::expect_equal(
+  # Either being equal to the corresponding element in the input
+  # analysis_time or at the time point when targeted event number achieved.
+  expect_equal(
     max((1 - (out1$time == analysis_time)) * (1 - (round(out1$event) == round(event)))),
     0
   )
 
   # "Time" >= input analysis_time
-  testthat::expect_gte(max(out1$time - analysis_time), 0)
+  expect_gte(max(out1$time - analysis_time), 0)
 
   # "Events" >= input events
-  testthat::expect_gte(max(round(out1$event) - round(event)), 0)
+  expect_gte(max(round(out1$event) - round(event)), 0)
 })

--- a/tests/testthat/test-independent-gs_info_combo.R
+++ b/tests/testthat/test-independent-gs_info_combo.R
@@ -1,41 +1,23 @@
-rho <- c(1, 1, 0, 0)
-gamma <- c(0, 1, 0, 1)
-tau <- c(-1, -1, -1, -1)
-enroll_rate <- define_enroll_rate(
-  duration = c(2, 2, 30),
-  rate = c(3, 6, 9)
-)
-fail_rate <- define_fail_rate(
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  dropout_rate = rep(.001, 2),
-  hr = c(.9, .6)
-)
-info_combo <- gsDesign2::gs_info_combo(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  ratio = 1, # Experimental:Control randomization ratio
-  event = NULL, # Events at analyses
-  analysis_time = 30, # Times of analyses
-  rho = rho,
-  gamma = gamma,
-  tau = rep(-1, length(rho)),
-  approx = "asymptotic"
-)
+test_that("gs_info_combo correctly use gs_info_wlr 1", {
+  res <- test_gs_info_combo()
+  rho <- res$rho
+  gamma <- res$gamma
+  tau <- res$tau
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  info_combo <- res$info_combo
 
-for (i in 1:4) {
-  weight_test_i <- gsDesign2:::get_combo_weight(rho[i], gamma[i], tau[i])
-  info_wlr <- gsDesign2::gs_info_wlr(
-    enroll_rate = enroll_rate,
-    fail_rate = fail_rate,
-    ratio = 1, # Experimental:Control randomization ratio
-    event = NULL, # Events at analyses
-    analysis_time = 30, # Times of analyses
-    weight = eval(parse(text = weight_test_i)),
-    approx = "asymptotic"
-  )
-
-  test_that("gs_info_combo correctly use gs_info_wlr 1", {
+  for (i in 1:4) {
+    weight_test_i <- gsDesign2:::get_combo_weight(rho[i], gamma[i], tau[i])
+    info_wlr <- gsDesign2::gs_info_wlr(
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
+      ratio = 1, # Experimental:Control randomization ratio
+      event = NULL, # Events at analyses
+      analysis_time = 30, # Times of analyses
+      weight = eval(parse(text = weight_test_i)),
+      approx = "asymptotic"
+    )
     expect_equal(info_combo$info[i], info_wlr$info[1])
-  })
-}
+  }
+})

--- a/tests/testthat/test-independent-gs_power_ahr.R
+++ b/tests/testthat/test-independent-gs_power_ahr.R
@@ -1,52 +1,9 @@
-# Test 1: compare with gsDesign under proportional hazard ####
+# Test 1: compare with gsDesign under proportional hazard
+test_that("under same number of events, compare the power", {
+  res <- test_gs_power_ahr()
+  x <- res$x
+  y <- res$y
 
-x <- gsDesign::gsSurv(
-  k = 2,
-  test.type = 1,
-  alpha = 0.025,
-  beta = 0.2,
-  astar = 0,
-  timing = 0.7,
-  sfu = gsDesign::sfLDOF,
-  sfupar = c(0),
-  sfl = gsDesign::sfLDOF,
-  sflpar = c(0),
-  lambdaC = log(2) / 9,
-  hr = 0.65,
-  hr0 = 1,
-  eta = 0.001,
-  gamma = c(6, 12, 18, 24),
-  R = c(2, 2, 2, 6),
-  S = NULL,
-  T = NULL,
-  minfup = NULL,
-  ratio = 1
-)
-
-# update x with gsDesign() to get integer event counts
-x <- gsDesign::gsDesign(
-  k = x$k,
-  test.type = 1,
-  alpha = x$alpha,
-  beta = x$beta,
-  sfu = x$upper$sf,
-  sfupar = x$upper$param,
-  n.I = ceiling(x$n.I),
-  maxn.IPlan = ceiling(x$n.I[x$k]),
-  delta = x$delta,
-  delta1 = x$delta1,
-  delta0 = x$delta0
-)
-y <- gsDesign::gsBoundSummary(x,
-  ratio = 1,
-  digits = 4,
-  ddigits = 2,
-  tdigits = 1,
-  timename = "Month",
-  logdelta = TRUE
-)
-
-testthat::test_that("under same number of events, compare the power", {
   out <- gs_power_ahr(
     enroll_rate = define_enroll_rate(
       duration = c(2, 2, 2, 6),
@@ -59,7 +16,7 @@ testthat::test_that("under same number of events, compare the power", {
       dropout_rate = 0.001
     ),
     ratio = 1,
-    # set number of events the same as the design x above from gsDesign()
+    # Set number of events the same as the design x above from gsDesign()
     event = x$n.I,
     analysis_time = NULL,
     binding = FALSE,
@@ -71,10 +28,13 @@ testthat::test_that("under same number of events, compare the power", {
     test_lower = FALSE
   )
 
-  testthat::expect_equal(out$bound$probability[1:2], y$Efficacy[c(5, 10)], tolerance = 0.02)
+  expect_equal(out$bound$probability[1:2], y$Efficacy[c(5, 10)], tolerance = 0.02)
 })
 
-testthat::test_that("under same power setting, compare the number of events", {
+test_that("under same power setting, compare the number of events", {
+  res <- test_gs_power_ahr()
+  x <- res$x
+
   out <- gs_power_ahr(
     enroll_rate = define_enroll_rate(
       duration = c(2, 2, 2, 6),
@@ -88,7 +48,8 @@ testthat::test_that("under same power setting, compare the number of events", {
     ),
     ratio = 1,
     event = NULL,
-    # adjust the times s.t. power ~= 0.801 and information fraction ~= 0.7 (same as the design x above from gsDesign())
+    # Adjust the times s.t. power ~= 0.801 and information fraction ~= 0.7
+    # (same as the design x above from gsDesign())
     analysis_time = c(21, 34.9),
     binding = FALSE,
     upper = gs_spending_bound,
@@ -98,6 +59,7 @@ testthat::test_that("under same power setting, compare the number of events", {
     test_upper = TRUE,
     test_lower = FALSE
   )
-  # in case test fails, check whether caused by small tolerance
-  testthat::expect_equal(out$analysis$event[1:2], x$n.I, tolerance = 0.02)
+
+  # In case test fails, check whether caused by small tolerance
+  expect_equal(out$analysis$event[1:2], x$n.I, tolerance = 0.02)
 })

--- a/tests/testthat/test-independent-gs_power_combo.R
+++ b/tests/testthat/test-independent-gs_power_combo.R
@@ -1,92 +1,72 @@
-enroll_rate <- define_enroll_rate(duration = 12, rate = 500 / 12)
-
-fail_rate <- define_fail_rate(
-  duration = c(4, 100),
-  fail_rate = log(2) / 15, # median survival 15 month
-  dropout_rate = 0.001,
-  hr = c(1, .6)
-)
-
-fh_test <- rbind(
-  data.frame(
-    rho = 0,
-    gamma = 0,
-    tau = -1,
-    test = 1,
-    analysis = 1:3,
-    analysis_time = c(12, 24, 36)
-  ),
-  data.frame(
-    rho = c(0, 0.5),
-    gamma = 0.5,
-    tau = -1,
-    test = 2:3,
-    analysis = 3,
-    analysis_time = 36
-  )
-)
-
-# User-defined bound
-gs_power_combo_test1 <- gsDesign2::gs_power_combo(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  fh_test = fh_test,
-  upper = gs_b, upar = c(3, 2, 1),
-  lower = gs_b, lpar = c(-1, 0, 1)
-)
+params_gs_power_combo <- test_gs_power_combo()
 
 test_that("calculate analysis number as planned", {
+  res <- params_gs_power_combo
+  fh_test <- res$fh_test
+  gs_power_combo_test1 <- res$gs_power_combo_test1
+
   expect_equal(max(fh_test$analysis), max(gs_power_combo_test1$analysis$analysis))
 })
 
 test_that("calculate analysisTimes as planned", {
+  res <- params_gs_power_combo
+  fh_test <- res$fh_test
+  gs_power_combo_test1 <- res$gs_power_combo_test1
+
   expect_equal(unique(fh_test$analysis_time), unique(gs_power_combo_test1$analysis$time))
 })
 
+test_that("calculate N and each analysis Events N as planned", {
+  res <- params_gs_power_combo
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  fh_test <- res$fh_test
+  gs_power_combo_test1 <- res$gs_power_combo_test1
 
-for (i in 1:max(fh_test$analysis)) {
-  test_that("calculate N and each analysis Events N as planned", {
+  for (i in 1:max(fh_test$analysis)) {
     event <- test_event(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
       td = unique(fh_test$analysis_time)[i]
     )
     expect_equal(event, unique(gs_power_combo_test1$analysis$event)[i], tolerance = 0.01)
-  })
-}
-
-
-# Minimal Information Fraction derived bound
-gs_power_combo_test2 <- gsDesign2::gs_power_combo(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  fh_test,
-  upper = gs_spending_combo,
-  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
-  lower = gs_spending_combo,
-  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2)
-)
+  }
+})
 
 test_that("calculate analysis number as planned", {
+  res <- params_gs_power_combo
+  fh_test <- res$fh_test
+  gs_power_combo_test2 <- res$gs_power_combo_test2
+
   expect_equal(max(fh_test$analysis), max(gs_power_combo_test2$analysis$analysis))
 })
 
 test_that("calculate analysisTimes as planned", {
+  res <- params_gs_power_combo
+  fh_test <- res$fh_test
+  gs_power_combo_test2 <- res$gs_power_combo_test2
+
   expect_equal(unique(fh_test$analysis_time), unique(gs_power_combo_test2$analysis$time))
 })
 
-for (i in 1:max(fh_test$analysis)) {
-  test_that("calculate N and each analysis Events N as planned", {
+test_that("calculate N and each analysis Events N as planned", {
+  res <- params_gs_power_combo
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  fh_test <- res$fh_test
+  gs_power_combo_test2 <- res$gs_power_combo_test2
+
+  for (i in 1:max(fh_test$analysis)) {
     event <- test_event(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
       td = unique(fh_test$analysis_time)[i]
     )
     expect_equal(event, unique(gs_power_combo_test2$analysis$event)[i], tolerance = 0.01)
-  })
-}
+  }
+})
 
-testthat::test_that("arguments are passed via ... to mvtnorm::pmvnorm()", {
+test_that("arguments are passed via ... to mvtnorm::pmvnorm()", {
   x1 <- gs_power_combo(seed = 1)
   x2 <- gs_power_combo(seed = 1)
   x3 <- gs_power_combo(seed = 2)

--- a/tests/testthat/test-independent-gs_power_npe.R
+++ b/tests/testthat/test-independent-gs_power_npe.R
@@ -57,7 +57,6 @@ test_that("expect equal with mvtnorm for efficacy and futility bounds", {
   expect_equal(object = test2$probability, expected = cumsum(c(a.ia$spend, pa)), tolerance = 0.001)
 })
 
-
 test_that("expect equal with gsDesign::gsProbability outcome for efficacy bounds", {
   info <- c(40, 150, 200)
 

--- a/tests/testthat/test-independent-gs_spending_bound.R
+++ b/tests/testthat/test-independent-gs_spending_bound.R
@@ -97,7 +97,6 @@ test_that("compare gs_spending_bound with gsDesign results with equal IA timing 
   expect_equal(object = as.numeric(test2), expected = x$lower$bound, tolerance = 0.0001)
 })
 
-
 test_that("compare gs_spending_bound with gsDesign results with unequal IA timing for upper and lower bound", {
   y <- gsDesign::gsSurv(
     k = 3,

--- a/tests/testthat/test-independent-hupdate.R
+++ b/tests/testthat/test-independent-hupdate.R
@@ -1,12 +1,13 @@
 test_that("gsDesign2:::hupdate() returns results as expected ", {
-  # the design
+  # The design
   gstry <- gsDesign::gsDesign(
     k = 3,
     sfl = gsDesign::sfLDOF,
     delta = 0
   )
-  # probabilities calculated based on function gsDesign2:::h1(), IA1 needs to full between low and upper bound
-  # in order to continue to IA2
+  # Probabilities calculated based on function gsDesign2:::h1(),
+  # IA1 needs to full between low and upper bound
+  # in order to continue to IA2.
   null.01 <- gsDesign2:::h1(
     theta = gstry$theta[1],
     info = gstry$n.I[1],
@@ -60,7 +61,7 @@ test_that("gsDesign2:::hupdate() returns results as expected ", {
     a = -Inf,
     b = gstry$lower$bound[2]
   )$h)
-  # probabilities calculated based on function gsProbability
+  # Probabilities calculated based on function gsProbability
   x <- gsDesign::gsProbability(
     k = 3,
     a = gstry$lower$bound,
@@ -71,14 +72,19 @@ test_that("gsDesign2:::hupdate() returns results as expected ", {
 
   expect_equal(object = as.numeric(c(lower.null.02, lower.alt.02)), expected = x$lower$prob[2, ], tolerance = 0.0001)
   expect_equal(object = as.numeric(c(upper.null.02, upper.alt.02)), expected = x$upper$prob[2, ], tolerance = 0.0001)
-  # problem with below code on extreme case:
-  # gsDesign2:::theta = gstry$theta[1], thetam1= gstry$theta[1],
-  #     info=gstry$n.I[1]+0.00000000000001,im1=gstry$n.I[1],gm1=null.01,
-  #     a = gstry$upper$bound[2],b=Inf) %>% summarise(p = sum(h))
+  # Problem with below code on extreme case:
+  # gsDesign2:::hupdate(
+  #   theta = gstry$theta[1],
+  #   thetam1 = gstry$theta[1],
+  #   info = gstry$n.I[1] + 0.00000000000001,
+  #   im1 = gstry$n.I[1],
+  #   gm1 = null.01,
+  #   a = gstry$upper$bound[2],
+  #   b = Inf) %>% summarise(p = sum(h))
 })
 
-test_that("gsDesign2:::) returns probability almost zero for extreme case", {
-  # the design
+test_that("gsDesign2:::hupdate() returns probability almost zero for extreme case", {
+  # The design
   gstry <- gsDesign::gsDesign(
     k = 3,
     sfl = gsDesign::sfLDOF,
@@ -91,7 +97,7 @@ test_that("gsDesign2:::) returns probability almost zero for extreme case", {
     b = gstry$upper$bound[1]
   )
   # IA2 to reject H0, we integrate from upper bound to Inf
-  #-8 is an arbitrary extreme case for theta
+  # -8 is an arbitrary extreme case for theta
   poor.02 <- sum(gsDesign2:::hupdate(
     theta = -8,
     thetam1 = gstry$theta[1],
@@ -102,7 +108,7 @@ test_that("gsDesign2:::) returns probability almost zero for extreme case", {
     b = Inf
   )$h)
   # IA2 to accept H0, we integrate from -Inf to lower bound
-  #-8 is an arbitrary extreme case for the bound
+  # -8 is an arbitrary extreme case for the bound
   high.02 <- sum(gsDesign2:::hupdate(
     theta = gstry$theta[2],
     thetam1 = gstry$theta[2],

--- a/tests/testthat/test-independent-rmst.R
+++ b/tests/testthat/test-independent-rmst.R
@@ -30,7 +30,6 @@ test_that("given sample size, the output power arrives at the target", {
   expect_equal(x1$bound$probability, x2)
 })
 
-
 test_that("given power, the output sample size arrives at the target power", {
   # set enrollment rates
   enroll_rate <- tibble::tibble(stratum = "All", duration = 12, rate = 500 / 12)

--- a/tests/testthat/test-independent-utility_combo.R
+++ b/tests/testthat/test-independent-utility_combo.R
@@ -1,486 +1,242 @@
-# test get_combo_weight
-rho <- c(1, 1, 0, 0)
-gamma <- c(0, 1, 0, 1)
-tau <- c(-1, -1, -1, -1)
-
-weight <- gsDesign2:::get_combo_weight(rho, gamma, tau)
-weight1_rho <- substring(weight[[1]], 125, 130)
-weight2_rho <- substring(weight[[2]], 125, 130)
-weight1_gamma <- substring(weight[[1]], 133, 140)
-weight2_gamma <- substring(weight[[2]], 133, 140)
-weight1_tau <- substring(weight[[1]], 143, 148)
-weight2_tau <- substring(weight[[2]], 143, 148)
-
+# Test get_combo_weight ----
 test_that("get_combo_weight output correct rho1", {
-  expect_equal(weight1_rho, "rho =1")
+  res <- test_get_combo_weight()
+  expect_equal(res$weight1_rho, "rho =1")
 })
+
 test_that("get_combo_weight output correct rho2", {
-  expect_equal(weight2_rho, "rho =1")
+  res <- test_get_combo_weight()
+  expect_equal(res$weight2_rho, "rho =1")
 })
 
 test_that("get_combo_weight output correct gamma1", {
-  expect_equal(weight1_gamma, "gamma =0")
+  res <- test_get_combo_weight()
+  expect_equal(res$weight1_gamma, "gamma =0")
 })
+
 test_that("get_combo_weight output correct gamma2", {
-  expect_equal(weight2_gamma, "gamma =1")
+  res <- test_get_combo_weight()
+  expect_equal(res$weight2_gamma, "gamma =1")
 })
 
-# test get_combo_weight tau not equal to -1
-rho <- c(1, 1, 0, 0)
-gamma <- c(0, 1, 0, 1)
-tau <- c(1, 1, 0, 0)
-weight <- gsDesign2:::get_combo_weight(rho, gamma, tau)
-weight1_tau <- substring(weight[[1]], 143, 148)
-weight3_tau <- substring(weight[[3]], 143, 148)
-
+# Test get_combo_weight tau not equal to -1 ----
 test_that("get_combo_weight output correct tau1", {
-  expect_equal(weight1_tau, "tau =1")
+  res <- test_get_combo_weight_tau()
+  expect_equal(res$weight1_tau, "tau =1")
 })
+
 test_that("get_combo_weight output correct tau3", {
-  expect_equal(weight3_tau, "tau =0")
+  res <- test_get_combo_weight_tau()
+  expect_equal(res$weight3_tau, "tau =0")
 })
 
-# test gs_delta_combo
-rho <- c(1, 1, 0, 0)
-gamma <- c(0, 1, 0, 1)
-tau <- c(-1, -1, -1, -1)
+# Test gs_delta_combo ----
+test_that("gs_delta_combo correctly use gs_delta_wlr 1", {
+  res <- test_gs_delta_combo()
+  rho <- res$rho
+  gamma <- res$gamma
+  tau <- res$tau
+  arm <- res$arm
+  delta <- res$delta
 
-enroll_rate <- define_enroll_rate(
-  duration = c(2, 2, 30),
-  rate = c(3, 6, 9)
-)
-fail_rate <- define_fail_rate(
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  dropout_rate = rep(.001, 2),
-  hr = c(.9, .6)
-)
-arm <- gs_create_arm(enroll_rate, fail_rate, ratio = 1, total_time = 1e6)
-delta <- gsDesign2:::gs_delta_combo(
-  arm0 = arm$arm0, arm1 = arm$arm1,
-  tmax = 30, rho = rho, gamma = gamma, tau = rep(-1, length(rho)),
-  approx = "asymptotic", normalization = FALSE
-)
-
-for (i in 1:4) {
-  weight_test1 <- gsDesign2:::get_combo_weight(rho[i], gamma[i], tau[i])
-  delta_test1 <- gsDesign2:::gs_delta_wlr(
-    arm0 = arm$arm0, arm1 = arm$arm1,
-    tmax = 30, weight = eval(parse(text = weight_test1)),
-    approx = "asymptotic", normalization = FALSE
-  )
-  test_that("gs_delta_combo correctly use gs_delta_wlr 1", {
-    expect_identical(delta[i], delta_test1)
-  })
-}
-
-# test gs_sigma2_combo
-sigma2 <- gsDesign2:::gs_sigma2_combo(
-  arm0 = arm$arm0, arm1 = arm$arm1, tmax = 30,
-  rho = rho, gamma = gamma, tau = rep(-1, length(rho)),
-  approx = "asymptotic"
-)
-rho1 <- outer(rho, rho, function(x, y) (x + y) / 2)
-gamma1 <- outer(gamma, gamma, function(x, y) (x + y) / 2)
-for (i in 1:4) {
-  for (j in 1:4) {
-    weight_test_ij <- gsDesign2:::get_combo_weight(rho1[i, j], gamma1[i, j], tau[i])
-    sigma_ij <- gsDesign2:::gs_sigma2_wlr(
+  for (i in 1:4) {
+    weight_test1 <- gsDesign2:::get_combo_weight(rho[i], gamma[i], tau[i])
+    delta_test1 <- gsDesign2:::gs_delta_wlr(
       arm0 = arm$arm0, arm1 = arm$arm1,
-      tmax = 30, weight = eval(parse(text = weight_test_ij)),
+      tmax = 30, weight = eval(parse(text = weight_test1)),
+      approx = "asymptotic", normalization = FALSE
+    )
+
+    expect_identical(delta[i], delta_test1)
+  }
+})
+
+# Test gs_sigma2_combo ----
+test_that("gs_sigma2_combo correctly use gs_sigma2_wlr 1", {
+  res <- test_gs_sigma2_combo()
+  rho1 <- res$rho1
+  gamma1 <- res$gamma1
+  tau <- res$tau
+  arm <- res$arm
+  sigma2 <- res$sigma2
+
+  for (i in 1:4) {
+    for (j in 1:4) {
+      weight_test_ij <- gsDesign2:::get_combo_weight(rho1[i, j], gamma1[i, j], tau[i])
+      sigma_ij <- gsDesign2:::gs_sigma2_wlr(
+        arm0 = arm$arm0, arm1 = arm$arm1,
+        tmax = 30, weight = eval(parse(text = weight_test_ij)),
+        approx = "asymptotic"
+      )
+
+      expect_equal(sigma2[i, j], sigma_ij)
+    }
+  }
+})
+
+# Test gs_info_combo ----
+test_that("gs_info_combo correctly use gs_info_wlr 1", {
+  res <- test_gs_info_combo()
+  rho <- res$rho
+  gamma <- res$gamma
+  tau <- res$tau
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  info_combo <- res$info_combo
+
+  for (i in 1:4) {
+    weight_test_i <- gsDesign2:::get_combo_weight(rho[i], gamma[i], tau[i])
+    info_wlr <- gsDesign2::gs_info_wlr(
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
+      ratio = 1, # Experimental:Control randomization ratio
+      event = NULL, # Events at analyses
+      analysis_time = 30, # Times of analyses
+      weight = eval(parse(text = weight_test_i)),
       approx = "asymptotic"
     )
-    test_that("gs_sigma2_combo correctly use gs_sigma2_wlr 1", {
-      expect_equal(sigma2[i, j], sigma_ij)
-    })
-  }
-}
 
-
-# test gs_info_combo
-rho <- c(1, 1, 0, 0)
-gamma <- c(0, 1, 0, 1)
-tau <- c(-1, -1, -1, -1)
-enroll_rate <- define_enroll_rate(
-  duration = c(2, 2, 30),
-  rate = c(3, 6, 9)
-)
-fail_rate <- define_fail_rate(
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  dropout_rate = rep(.001, 2),
-  hr = c(.9, .6)
-)
-info_combo <- gsDesign2:::gs_info_combo(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  ratio = 1, # Experimental:Control randomization ratio
-  event = NULL, # Events at analyses
-  analysis_time = 30, # Times of analyses
-  rho = rho,
-  gamma = gamma,
-  tau = rep(-1, length(rho)),
-  approx = "asymptotic"
-)
-for (i in 1:4) {
-  weight_test_i <- gsDesign2:::get_combo_weight(rho[i], gamma[i], tau[i])
-  info_wlr <- gsDesign2::gs_info_wlr(
-    enroll_rate = enroll_rate,
-    fail_rate = fail_rate,
-    ratio = 1, # Experimental:Control randomization ratio
-    event = NULL, # Events at analyses
-    analysis_time = 30, # Times of analyses
-    weight = eval(parse(text = weight_test_i)),
-    approx = "asymptotic"
-  )
-  test_that("gs_info_combo correctly use gs_info_wlr 1", {
     expect_equal(info_combo$info[i], info_wlr$info[1])
-  })
-}
+  }
+})
 
-# test gs_prob_combo
-####### 1 analysis scenario#####
-lower <- -0.6
-upper <- 0.4
-rho <- c(1, 1, 0, 0)
-gamma <- c(0, 1, 0, 1)
-tau <- c(-1, -1, -1, -1)
-enroll_rate <- define_enroll_rate(
-  duration = c(2, 2, 30),
-  rate = c(3, 6, 9)
-)
-fail_rate <- define_fail_rate(
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  dropout_rate = rep(.001, 2),
-  hr = c(.9, .6)
-)
-arm <- gs_create_arm(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  ratio = 1,
-  total_time = 1e6
-)
-sigma <- gsDesign2:::gs_sigma2_combo(
-  arm0 = arm$arm0,
-  arm1 = arm$arm1,
-  tmax = 30,
-  rho = rho,
-  gamma = gamma,
-  tau = rep(-1, length(rho)),
-  approx = "asymptotic"
-)
-corr <- cov2cor(sigma)
-n_test <- length(rho)
-theta <- rep(0, n_test)
-analysis <- 1
-prob <- gsDesign2:::gs_prob_combo(
-  lower_bound = rep(lower, n_test),
-  upper_bound = rep(upper, n_test),
-  analysis = analysis,
-  theta = theta,
-  corr = corr,
-  algorithm = GenzBretz(maxpts = 1e5, abseps = 1e-5)
-)
-
-p_efficacy <- gsDesign2:::pmvnorm_combo(
-  lower = rep(upper, n_test),
-  upper = rep(Inf, n_test),
-  group = analysis,
-  mean = theta,
-  corr = corr
-)
-p_futility <- gsDesign2:::pmvnorm_combo(
-  lower = rep(-Inf, n_test),
-  upper = rep(lower, n_test),
-  group = analysis,
-  mean = theta,
-  corr = corr
-)
+# Test gs_prob_combo ----
+## 1 analysis scenario ----
 test_that("p efficacy", {
+  res <- test_gs_prob_combo_1()
+  prob <- res$prob
+  p_efficacy <- res$p_efficacy
+
   expect_equal(prob$probability[1], p_efficacy[1], tolerance = 0.001)
 })
+
 test_that("p futility", {
+  res <- test_gs_prob_combo_1()
+  prob <- res$prob
+  p_futility <- res$p_futility
+
   expect_equal(prob$probability[2], p_futility[1], tolerance = 0.001)
 })
 
-####### 2 analysis scenario#####
-lower <- c(-0.2, -0.3)
-upper <- c(0.3, 0.4)
-rho <- c(1, 1, 0, 0)
-gamma <- c(0, 1, 0, 1)
-tau <- c(-1, -1, -1, -1)
-enroll_rate <- define_enroll_rate(
-  duration = c(2, 2, 30),
-  rate = c(3, 6, 9)
-)
-fail_rate <- define_fail_rate(
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  dropout_rate = rep(.001, 2),
-  hr = c(.9, .6)
-)
-arm <- gs_create_arm(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  ratio = 1,
-  total_time = 1e6
-)
-sigma <- gsDesign2:::gs_sigma2_combo(
-  arm0 = arm$arm0,
-  arm1 = arm$arm1,
-  tmax = 30,
-  rho = rho,
-  gamma = gamma,
-  tau = rep(-1, length(rho)),
-  approx = "asymptotic"
-)
-corr <- cov2cor(sigma)
-n_test <- length(rho)
-theta <- rep(0, n_test)
-analysis <- c(1, 2)
-prob <- gsDesign2:::gs_prob_combo(
-  lower_bound = rep(lower, n_test),
-  upper_bound = rep(upper, n_test),
-  analysis = analysis,
-  theta = theta,
-  corr = corr,
-  algorithm = GenzBretz(maxpts = 1e5, abseps = 1e-5)
-)
-c <- c(1, 3)
-corr1 <- corr[c, c]
-p_efficacy_1 <- gsDesign2:::pmvnorm_combo(
-  lower = rep(upper[1], 2),
-  upper = rep(Inf, 2),
-  group = 1,
-  mean = theta[c],
-  corr = corr1
-)
-p_futility_1 <- gsDesign2:::pmvnorm_combo(
-  lower = rep(-Inf, 2),
-  upper = rep(lower[1], 2),
-  group = 1,
-  mean = theta[c],
-  corr = corr1
-)
-p_efficacy_2 <- gsDesign2:::pmvnorm_combo(
-  lower = c(lower[1], upper[2]),
-  upper = c(upper[1], Inf),
-  group = analysis,
-  mean = theta,
-  corr = corr
-)
-p_futility_2 <- gsDesign2:::pmvnorm_combo(
-  lower = c(lower[1], -Inf),
-  upper = c(upper[1], lower[2]),
-  group = analysis,
-  mean = theta,
-  corr = corr
-)
+## 2 analysis scenario ----
 test_that("p efficacy1", {
+  res <- test_gs_prob_combo_2()
+  prob <- res$prob
+  p_efficacy_1 <- res$p_efficacy_1
+
   expect_equal(prob$probability[1], p_efficacy_1[1], tolerance = 0.001)
 })
+
 test_that("p futility1", {
+  res <- test_gs_prob_combo_2()
+  prob <- res$prob
+  p_futility_1 <- res$p_futility_1
+
   expect_equal(prob$probability[3], p_futility_1[1], tolerance = 0.001)
 })
+
 test_that("p efficacy2", {
+  res <- test_gs_prob_combo_2()
+  prob <- res$prob
+  p_efficacy_1 <- res$p_efficacy_1
+  p_efficacy_2 <- res$p_efficacy_2
+
   expect_equal(prob$probability[2], p_efficacy_1[1] + p_efficacy_2[1], tolerance = 0.001)
 })
+
 test_that("p futility2", {
+  res <- test_gs_prob_combo_2()
+  prob <- res$prob
+  p_futility_1 <- res$p_futility_1
+  p_futility_2 <- res$p_futility_2
+
   expect_equal(prob$probability[4], p_futility_1[1] + p_futility_2[1], tolerance = 0.001)
 })
 
-# test pmvtnorm_combo
-lower <- -Inf
-upper <- 0
-mean <- 0.3
-n_test <- 4
-rho <- c(1, 1, 0, 0)
-gamma <- c(0, 1, 0, 1)
-tau <- c(-1, -1, -1, -1)
+# Test pmvnorm_combo ----
+test_that("pmvnorm_combo calculate p for One test for all group or lower bound is -Inf.", {
+  res <- test_pmvnorm_combo()
+  p <- res$p
+  p_test <- res$p_test
 
-enroll_rate <- define_enroll_rate(
-  stratum = "All",
-  duration = c(2, 2, 10),
-  rate = c(3, 6, 9)
-)
-fail_rate <- define_fail_rate(
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  dropout_rate = rep(.001, 2),
-  hr = c(.9, .6)
-)
-arm <- gs_create_arm(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  ratio = 1,
-  total_time = 1e6
-)
-sigma <- gsDesign2:::gs_sigma2_combo(
-  arm0 = arm$arm0,
-  arm1 = arm$arm1,
-  tmax = 30,
-  rho = rho,
-  gamma = gamma,
-  tau = rep(-1, length(rho)),
-  approx = "asymptotic"
-)
-corr <- cov2cor(sigma)
-
-p <- gsDesign2:::pmvnorm_combo(
-  lower = rep(lower, n_test),
-  upper = rep(upper, n_test),
-  group = 2,
-  mean = rep(mean, n_test),
-  corr = corr,
-  algorithm = mvtnorm::GenzBretz(maxpts = 1e5, abseps = 1e-5)
-)
-
-p_test <- mvtnorm::pmvnorm(
-  lower = rep(lower, n_test),
-  upper = rep(upper, n_test),
-  mean = rep(mean, n_test),
-  corr = corr,
-  sigma = NULL,
-  algorithm = mvtnorm::GenzBretz(maxpts = 1e5, abseps = 1e-5)
-)
-
-test_that("pmvnorm_comb calculate p for One test for all group or lower bound is -Inf.", {
   expect_equal(p[1], p_test[1], tolerance = 0.001)
 })
 
-# test gs_utility_combo
-##### log-rank multiple analysis#####
-enroll_rate <- define_enroll_rate(
-  duration = c(2, 2, 30),
-  rate = c(3, 6, 9)
-)
-fail_rate <- define_fail_rate(
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  dropout_rate = rep(.001, 2),
-  hr = c(.9, .6)
-)
-analysis_time <- c(12, 24, 36)
-n_analysis <- length(analysis_time)
-fh_test <- rbind(data.frame(
-  rho = 0,
-  gamma = 0,
-  tau = -1,
-  test = 1,
-  analysis = 1:3,
-  analysis_time = analysis_time
-))
-gs_arm <- gs_create_arm(enroll_rate,
-  fail_rate,
-  ratio = 1, # Randomization ratio
-  total_time = max(analysis_time)
-) # Total study duration
-
-utility_combo <- gsDesign2:::gs_utility_combo(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  fh_test = fh_test,
-  ratio = 1,
-  algorithm = GenzBretz(maxpts = 1e5, abseps = 1e-5)
-)
-
-info_combo_test <- gsDesign2:::gs_info_combo(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  ratio = 1,
-  analysis_time = analysis_time,
-  rho = 0,
-  gamma = 0
-)
+# Log-rank multiple analysis ----
+## Test gs_utility_combo ----
 test_that("gs_utility_combo output correct info as gs_info_combo", {
+  res <- test_gs_utility_combo()
+  utility_combo <- res$utility_combo
+  info_combo_test <- res$info_combo_test
+
   expect_equal(utility_combo$info[1:11], info_combo_test[1:11])
 })
 
-theta_test <- (-info_combo_test$delta) / sqrt(info_combo_test$sigma2)
 test_that("gs_utility_combo output correct theta effect as gs_info_combo", {
+  res <- test_gs_utility_combo()
+  utility_combo <- res$utility_combo
+  info_combo_test <- res$info_combo_test
+  theta_test <- (-info_combo_test$delta) / sqrt(info_combo_test$sigma2)
+
   expect_equal(utility_combo$theta, theta_test)
 })
 
-info <- info_combo_test[[10]]
-cov <- matrix(0, n_analysis, n_analysis)
-for (i in 1:n_analysis) {
-  for (j in 1:n_analysis) {
-    k <- min(i, j)
-    cov[i, j] <- info[k] / (info[i] * info[j])
-  }
-}
-corr_test <- cov2cor(cov)
 test_that("gs_utility_combo output correct correlation matrix as gs_info_combo", {
+  res <- test_gs_utility_combo()
+  n_analysis <- res$n_analysis
+  utility_combo <- res$utility_combo
+  info_combo_test <- res$info_combo_test
+
+  info <- info_combo_test[[10]]
+  cov <- matrix(0, n_analysis, n_analysis)
+  for (i in 1:n_analysis) {
+    for (j in 1:n_analysis) {
+      k <- min(i, j)
+      cov[i, j] <- info[k] / (info[i] * info[j])
+    }
+  }
+  corr_test <- cov2cor(cov)
+
   expect_equal(utility_combo$corr, corr_test)
 })
 
-
-##### multiple test analysis#####
-enroll_rate <- define_enroll_rate(
-  duration = c(2, 2, 30),
-  rate = c(3, 6, 9)
-)
-fail_rate <- define_fail_rate(
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  dropout_rate = rep(.001, 2),
-  hr = c(.9, .6)
-)
-analysis_time <- 36
-n_analysis <- length(analysis_time)
-rho <- c(0, 0.5, 1)
-gamma <- c(0.5, 0.5, 0.5)
-tau <- c(-1, -1, -1)
-fh_test <- rbind(data.frame(
-  rho = rho,
-  gamma = gamma,
-  tau = tau,
-  test = 1:3,
-  analysis = 1,
-  analysis_time = analysis_time
-))
-gs_arm <- gs_create_arm(
-  enroll_rate,
-  fail_rate,
-  ratio = 1, # Randomization ratio
-  total_time = max(analysis_time)
-) # Total study duration
-
-utility_combo <- gsDesign2:::gs_utility_combo(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  fh_test = fh_test,
-  ratio = 1,
-  algorithm = GenzBretz(maxpts = 1e5, abseps = 1e-5)
-)
-
-info_combo_test <- gsDesign2:::gs_info_combo(
-  enroll_rate = enroll_rate,
-  fail_rate = fail_rate,
-  ratio = 1,
-  analysis_time = analysis_time,
-  rho = rho,
-  gamma = gamma
-)
+## Multiple test analysis ----
 test_that("gs_utility_combo output correct info as gs_info_combo", {
+  res <- test_gs_utility_combo_multiple()
+  utility_combo <- res$utility_combo
+  info_combo_test <- res$info_combo_test
+
   expect_equal(utility_combo$info[1:11], info_combo_test[1:11])
 })
 
-theta_test <- (-info_combo_test$delta) / sqrt(info_combo_test$sigma2)
 test_that("gs_utility_combo output correct theta effect as gs_info_combo", {
+  res <- test_gs_utility_combo_multiple()
+  utility_combo <- res$utility_combo
+  info_combo_test <- res$info_combo_test
+  theta_test <- (-info_combo_test$delta) / sqrt(info_combo_test$sigma2)
+
   expect_equal(utility_combo$theta, theta_test)
 })
 
-sigma2 <- gsDesign2:::gs_sigma2_combo(
-  arm0 = gs_arm$arm0,
-  arm1 = gs_arm$arm1,
-  tmax = analysis_time,
-  rho = rho,
-  gamma = gamma,
-  tau = tau
-)
-corr_test <- cov2cor(sigma2)
 test_that("gs_utility_combo output correct correlation matrix as gs_info_combo", {
+  res <- test_gs_utility_combo_multiple()
+  rho <- res$rho
+  gamma <- res$gamma
+  tau <- res$tau
+  analysis_time <- res$analysis_time
+  n_analysis <- res$n_analysis
+  gs_arm <- res$gs_arm
+  utility_combo <- res$utility_combo
+
+  sigma2 <- gsDesign2:::gs_sigma2_combo(
+    arm0 = gs_arm$arm0,
+    arm1 = gs_arm$arm1,
+    tmax = analysis_time,
+    rho = rho,
+    gamma = gamma,
+    tau = tau
+  )
+  corr_test <- cov2cor(sigma2)
+
   expect_equal(utility_combo$corr, corr_test)
 })

--- a/tests/testthat/test-independent_test_s2pwe.R
+++ b/tests/testthat/test-independent_test_s2pwe.R
@@ -1,4 +1,4 @@
-testthat::test_that("s2pwe fails to come up with the correct answer", {
+test_that("s2pwe fails to come up with the correct answer", {
   time <- c(1, 5, 6, 8, 10)
   survival <- c(0.5, 0.4, 0.3, 0.2, 0.1)
   expect_equal(
@@ -8,7 +8,7 @@ testthat::test_that("s2pwe fails to come up with the correct answer", {
   )
 })
 
-testthat::test_that("s2pwe fails to identify non-numeric value", {
+test_that("s2pwe fails to identify non-numeric value", {
   times <- c(1, "NA")
   survival <- c(0.5, 0.4)
   expect_error(
@@ -19,7 +19,7 @@ testthat::test_that("s2pwe fails to identify non-numeric value", {
   )
 })
 
-testthat::test_that("s2pwe fails to identify non-positive value", {
+test_that("s2pwe fails to identify non-positive value", {
   times2 <- c(1, NA)
   survival <- c(0.5, 0.4)
   expect_error(
@@ -30,7 +30,7 @@ testthat::test_that("s2pwe fails to identify non-positive value", {
   )
 })
 
-testthat::test_that("s2pwe fails to identify infinity value", {
+test_that("s2pwe fails to identify infinity value", {
   times3 <- c(1, Inf)
   survival <- c(0.5, 0.4)
   expect_error(
@@ -41,7 +41,7 @@ testthat::test_that("s2pwe fails to identify infinity value", {
   )
 })
 
-testthat::test_that("s2pwe fails to identify non-increasing value", {
+test_that("s2pwe fails to identify non-increasing value", {
   times4 <- c(1, 2, 1)
   survival <- c(0.5, 0.4, 0.3)
   expect_error(
@@ -52,7 +52,7 @@ testthat::test_that("s2pwe fails to identify non-increasing value", {
   )
 })
 
-testthat::test_that("s2pwe fails to identify non-numerical survival", {
+test_that("s2pwe fails to identify non-numerical survival", {
   times5 <- c(1, 2)
   survival <- c(0.5, "NA")
   expect_error(
@@ -63,7 +63,7 @@ testthat::test_that("s2pwe fails to identify non-numerical survival", {
   )
 })
 
-testthat::test_that("s2pwe survival and time should have the same length", {
+test_that("s2pwe survival and time should have the same length", {
   times6 <- c(1, 2, 5)
   survival <- c(0.5, 0.3)
   expect_error(
@@ -74,7 +74,7 @@ testthat::test_that("s2pwe survival and time should have the same length", {
   )
 })
 
-testthat::test_that("s2pwe fails to identify non-positive survival", {
+test_that("s2pwe fails to identify non-positive survival", {
   times <- c(1, 3)
   survival2 <- c(0.5, -0.1)
   expect_error(
@@ -88,7 +88,7 @@ testthat::test_that("s2pwe fails to identify non-positive survival", {
   )
 })
 
-testthat::test_that("s2pwe fails to identify large than 1 survival", {
+test_that("s2pwe fails to identify large than 1 survival", {
   times <- c(1, 3)
   survival3 <- c(0.5, 1.5)
   expect_error(
@@ -102,7 +102,7 @@ testthat::test_that("s2pwe fails to identify large than 1 survival", {
   )
 })
 
-testthat::test_that("s2pwe fails to identify an increasing survival series", {
+test_that("s2pwe fails to identify an increasing survival series", {
   times <- c(1, 3)
   survival4 <- c(0.5, 0.9)
   expect_error(


### PR DESCRIPTION
As recommended by [R Packages](https://r-pkgs.org/testing-design.html), this PR makes all existing tests self-contained by creating helper functions to wrap the top-level logic that used to have awkward "test file scope".

Now all test files only contain individual `test_that()` blocks. There are a few exceptions where a few test files containing one/two-liner batch `source()` calls or running computationally expensive helper functions at the top.