### PR TITLE
Add license for all imports

### DIFF
--- a/LICENSES_THIRD_PARTY
+++ b/LICENSES_THIRD_PARTY
@@ -12,5 +12,27 @@ Third party R packages listed by License type
 --------------------------------------------------
 
 MIT / X11 License (or adaptations) (https://www.opensource.org/licenses/MIT)
-  * tibble - https://tibble.tidyverse.org/LICENSE.html
   * dplyr - https://dplyr.tidyverse.org/LICENSE.html
+  * gt - https://gt.rstudio.com/LICENSE.html
+  * tibble - https://tibble.tidyverse.org/LICENSE.html
+  * tidyr - https://tidyr.tidyverse.org/LICENSE.html
+
+GPL-2 (https://opensource.org/license/gpl-2-0)
+  * mvtnorm - https://cran.r-project.org/package=mvtnorm
+  * npsurvSS - https://cran.r-project.org/package=npsurvSS
+
+GPL-2 | GPL-3 (https://opensource.org/license/gpl-2-0)
+  * Rcpp - https://cran.r-project.org/package=Rcpp
+  * methods - https://www.r-project.org/COPYING
+  * stats - https://www.r-project.org/COPYING
+  * utils - https://www.r-project.org/COPYING
+
+GPL (>= 3) (https://opensource.org/license/gpl-3-0)
+  * corpcor - https://cran.r-project.org/package=corpcor
+  * gsDesign - https://cran.r-project.org/package=gsDesign
+
+GPL-3 (https://opensource.org/license/gpl-3-0)
+  * r2rtf - https://github.com/Merck/r2rtf/blob/master/LICENSE
+
+MPL-2.0 (https://opensource.org/license/mpl-2-0/)
+  * data.table - https://rdatatable.gitlab.io/data.table/LICENSE-text.html


### PR DESCRIPTION
This PR updates `LICENSES_THIRD_PARTY` to include license information for all current imports.