### PR TITLE
Self contained tests

### DIFF
--- a/tests/testthat/helper-support-ahr.R
+++ b/tests/testthat/helper-support-ahr.R
@@ -1,0 +1,24 @@
+params_ahr <- function() {
+  load("fixtures/simulation_test_data.Rdata")
+
+  enroll_rate <- define_enroll_rate(
+    duration = c(2, 2, 10),
+    rate = c(3, 6, 9)
+  )
+
+  fail_rate <- define_fail_rate(
+    stratum = "All",
+    duration = c(3, 100),
+    fail_rate = log(2) / c(9, 18),
+    hr = c(.9, .6),
+    dropout_rate = rep(.001, 2)
+  )
+
+  test_ahr <- list(
+    "simulation_ahr1" = simulation_AHR1,
+    "simulation_ahr2" = simulation_AHR2,
+    "simulation_ahr3" = simulation_AHR3,
+    "enroll_rate" = enroll_rate,
+    "fail_rate" = fail_rate
+  )
+}

--- a/tests/testthat/helper-support-as_gt.R
+++ b/tests/testthat/helper-support-as_gt.R
@@ -1,0 +1,1 @@
+gt_to_latex <- function(data) cat(as.character(gt::as_latex(data)))

--- a/tests/testthat/helper-support-fixed_design.R
+++ b/tests/testthat/helper-support-fixed_design.R
@@ -1,0 +1,28 @@
+params_fixed_design <- function() {
+  # Enroll rates
+  enroll_rate <- define_enroll_rate(
+    duration = 18,
+    rate = 20
+  )
+
+  # Failure rates
+  fail_rate <- define_fail_rate(
+    duration = c(4, 100),
+    fail_rate = log(2) / 12,
+    dropout_rate = .001,
+    hr = c(1, .6)
+  )
+
+  # Study duration in months
+  study_duration <- 36
+
+  # Experimental / Control randomization ratio
+  ratio <- 1
+
+  list(
+    "enroll_rate" = enroll_rate,
+    "fail_rate" = fail_rate,
+    "study_duration" = study_duration,
+    "ratio" = ratio
+  )
+}

--- a/tests/testthat/helper-support-gs_design_npe.R
+++ b/tests/testthat/helper-support-gs_design_npe.R
@@ -1,0 +1,13 @@
+params_gs_design_npe <- function() {
+  list(
+    K = 3,
+    timing = c(.45, .8, 1),
+    sfu = gsDesign::sfPower,
+    sfupar = 4,
+    sfl = gsDesign::sfHSD,
+    sflpar = 2,
+    delta = .2,
+    alpha = .02,
+    beta = .15
+  )
+}

--- a/tests/testthat/helper-support-gs_power_ahr.R
+++ b/tests/testthat/helper-support-gs_power_ahr.R
@@ -1,0 +1,52 @@
+# Helper functions used by test-independent-gs_power_ahr.R
+
+test_gs_power_ahr <- function() {
+  x <- gsDesign::gsSurv(
+    k = 2,
+    test.type = 1,
+    alpha = 0.025,
+    beta = 0.2,
+    astar = 0,
+    timing = 0.7,
+    sfu = gsDesign::sfLDOF,
+    sfupar = c(0),
+    sfl = gsDesign::sfLDOF,
+    sflpar = c(0),
+    lambdaC = log(2) / 9,
+    hr = 0.65,
+    hr0 = 1,
+    eta = 0.001,
+    gamma = c(6, 12, 18, 24),
+    R = c(2, 2, 2, 6),
+    S = NULL,
+    T = NULL,
+    minfup = NULL,
+    ratio = 1
+  )
+
+  # Update x with gsDesign() to get integer event counts
+  x <- gsDesign::gsDesign(
+    k = x$k,
+    test.type = 1,
+    alpha = x$alpha,
+    beta = x$beta,
+    sfu = x$upper$sf,
+    sfupar = x$upper$param,
+    n.I = ceiling(x$n.I),
+    maxn.IPlan = ceiling(x$n.I[x$k]),
+    delta = x$delta,
+    delta1 = x$delta1,
+    delta0 = x$delta0
+  )
+  y <- gsDesign::gsBoundSummary(
+    x,
+    ratio = 1,
+    digits = 4,
+    ddigits = 2,
+    tdigits = 1,
+    timename = "Month",
+    logdelta = TRUE
+  )
+
+  list("x" = x, "y" = y)
+}

--- a/tests/testthat/test-independent-ahr.R
+++ b/tests/testthat/test-independent-ahr.R
@@ -1,29 +1,5 @@
-load("fixtures/simulation_test_data.Rdata")
-
-enroll_rate <- define_enroll_rate(
-  duration = c(2, 2, 10),
-  rate = c(3, 6, 9)
-)
-
-fail_rate <- define_fail_rate(
-  stratum = "All",
-  duration = c(3, 100),
-  fail_rate = log(2) / c(9, 18),
-  hr = c(.9, .6),
-  dropout_rate = rep(.001, 2)
-  )
-
-test_ahr <- list(
-  "simulation_ahr1" = simulation_AHR1,
-  "simulation_ahr2" = simulation_AHR2,
-  "simulation_ahr3" = simulation_AHR3,
-  "enroll_rate" = enroll_rate,
-  "fail_rate" = fail_rate
-)
-
-
 test_that("AHR results are consistent with simulation results for single stratum and multiple cutoff", {
-  res <- test_ahr
+  res <- params_ahr()
   enroll_rate <- res$enroll_rate
   fail_rate <- res$fail_rate
   simulation_ahr1 <- res$simulation_ahr1
@@ -39,7 +15,7 @@ test_that("AHR results are consistent with simulation results for single stratum
 })
 
 test_that("AHR results are consistent with simulation results for single stratum and single cutoff", {
-  res <- test_ahr
+  res <- params_ahr()
   enroll_rate <- res$enroll_rate
   fail_rate <- res$fail_rate
   simulation_ahr2 <- res$simulation_ahr2
@@ -56,7 +32,7 @@ test_that("AHR results are consistent with simulation results for single stratum
 })
 
 test_that("AHR results are consistent with simulation results for single stratum and multiple cutoff", {
-  res <- test_ahr
+  res <- params_ahr()
   enroll_rate <- res$enroll_rate
   fail_rate <- res$fail_rate
   simulation_ahr3 <- res$simulation_ahr3

--- a/tests/testthat/test-independent-fixed_design.R
+++ b/tests/testthat/test-independent-fixed_design.R
@@ -1,23 +1,9 @@
-enroll_rate <- define_enroll_rate(
-  duration = 18,
-  rate = 20
-)
-
-# Failure rates
-fail_rate <- define_fail_rate(
-  duration = c(4, 100),
-  fail_rate = log(2) / 12,
-  dropout_rate = .001,
-  hr = c(1, .6)
-)
-
-# Study duration in months
-study_duration <- 36
-
-# Experimental / Control randomization ratio
-ratio <- 1
-
 test_that("AHR", {
+  res <- params_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
 
   x <- fixed_design_ahr(
     alpha = 0.025,
@@ -40,6 +26,11 @@ test_that("AHR", {
 })
 
 test_that("FH", {
+  res <- params_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
 
   x <- fixed_design_fh(
     alpha = 0.025,
@@ -67,6 +58,11 @@ test_that("FH", {
 })
 
 test_that("MB", {
+  res <- params_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
 
   x <- fixed_design_mb(
     alpha = 0.025,
@@ -92,6 +88,11 @@ test_that("MB", {
 })
 
 test_that("LF", {
+  res <- params_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
 
   x <- fixed_design_lf(
     alpha = 0.025,
@@ -114,6 +115,11 @@ test_that("LF", {
 })
 
 test_that("MaxCombo", {
+  res <- params_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
 
   x <- fixed_design_maxcombo(
     alpha = 0.025,
@@ -142,6 +148,11 @@ test_that("MaxCombo", {
 })
 
 test_that("RMST", {
+  res <- params_fixed_design()
+  enroll_rate <- res$enroll_rate
+  fail_rate <- res$fail_rate
+  study_duration <- res$study_duration
+  ratio <- res$ratio
 
   x <- fixed_design_rmst(
     alpha = 0.025,
@@ -166,6 +177,8 @@ test_that("RMST", {
 })
 
 test_that("RD", {
+  res <- params_fixed_design()
+  ratio <- res$ratio
 
   x <- fixed_design_rd(
     alpha = 0.025,

--- a/tests/testthat/test-independent-gs_design_combo.R
+++ b/tests/testthat/test-independent-gs_design_combo.R
@@ -1,6 +1,5 @@
-params_gs_design_combo <- test_gs_design_combo()
-
 test_that("calculate analysis number as planned", {
+  params_gs_design_combo <- test_gs_design_combo()
   res <- params_gs_design_combo
   fh_test <- res$fh_test
   gs_design_combo_test2 <- res$gs_design_combo_test2
@@ -9,6 +8,7 @@ test_that("calculate analysis number as planned", {
 })
 
 test_that("calculate analysisTimes as planned", {
+  params_gs_design_combo <- test_gs_design_combo()
   res <- params_gs_design_combo
   fh_test <- res$fh_test
   gs_design_combo_test2 <- res$gs_design_combo_test2
@@ -17,6 +17,7 @@ test_that("calculate analysisTimes as planned", {
 })
 
 test_that("calculate N and each analysis Events N as planned", {
+  params_gs_design_combo <- test_gs_design_combo()
   res <- params_gs_design_combo
   fh_test <- res$fh_test
   enroll_rate <- res$enroll_rate
@@ -41,6 +42,7 @@ test_that("calculate N and each analysis Events N as planned", {
 })
 
 test_that("calculate probability under alternative", {
+  params_gs_design_combo <- test_gs_design_combo()
   res <- params_gs_design_combo
   beta <- res$beta
   gs_design_combo_test2 <- res$gs_design_combo_test2
@@ -53,6 +55,7 @@ test_that("calculate probability under alternative", {
 })
 
 test_that("calculate probability under null", {
+  params_gs_design_combo <- test_gs_design_combo()
   res <- params_gs_design_combo
   alpha <- res$alpha
   gs_design_combo_test2 <- res$gs_design_combo_test2

--- a/tests/testthat/test-independent-gs_design_npe.R
+++ b/tests/testthat/test-independent-gs_design_npe.R
@@ -1,17 +1,5 @@
-params_gs_design_npe <- list(
-  K = 3,
-  timing = c(.45, .8, 1),
-  sfu = gsDesign::sfPower,
-  sfupar = 4,
-  sfl = gsDesign::sfHSD,
-  sflpar = 2,
-  delta = .2,
-  alpha = .02,
-  beta = .15
-)
-
 test_that("One-sided design fails to reproduce gsDesign package bounds", {
-  params <- params_gs_design_npe
+  params <- params_gs_design_npe()
   K <- params$K
   timing <- params$timing
   sfu <- params$sfu
@@ -47,7 +35,7 @@ test_that("One-sided design fails to reproduce gsDesign package bounds", {
 })
 
 test_that("Two-sided symmetric design fails to reproduce gsDesign test.type=2 bounds", {
-  params <- params_gs_design_npe
+  params <- params_gs_design_npe()
   K <- params$K
   timing <- params$timing
   sfu <- params$sfu
@@ -88,7 +76,7 @@ test_that("Two-sided symmetric design fails to reproduce gsDesign test.type=2 bo
 })
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=3 bounds", {
-  params <- params_gs_design_npe
+  params <- params_gs_design_npe()
   K <- params$K
   timing <- params$timing
   sfu <- params$sfu
@@ -132,7 +120,7 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=3 b
 })
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 bounds", {
-  params <- params_gs_design_npe
+  params <- params_gs_design_npe()
   K <- params$K
   timing <- params$timing
   sfu <- params$sfu
@@ -188,7 +176,7 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=4 b
 })
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 bounds", {
-  params <- params_gs_design_npe
+  params <- params_gs_design_npe()
   K <- params$K
   timing <- params$timing
   sfu <- params$sfu
@@ -244,7 +232,7 @@ test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=5 b
 })
 
 test_that("Two-sided asymmetric design fails to reproduce gsDesign test.type=6 bounds", {
-  params <- params_gs_design_npe
+  params <- params_gs_design_npe()
   K <- params$K
   timing <- params$timing
   sfu <- params$sfu

--- a/tests/testthat/test-independent-gs_power_ahr.R
+++ b/tests/testthat/test-independent-gs_power_ahr.R
@@ -1,54 +1,6 @@
-x <- gsDesign::gsSurv(
-  k = 2,
-  test.type = 1,
-  alpha = 0.025,
-  beta = 0.2,
-  astar = 0,
-  timing = 0.7,
-  sfu = gsDesign::sfLDOF,
-  sfupar = c(0),
-  sfl = gsDesign::sfLDOF,
-  sflpar = c(0),
-  lambdaC = log(2) / 9,
-  hr = 0.65,
-  hr0 = 1,
-  eta = 0.001,
-  gamma = c(6, 12, 18, 24),
-  R = c(2, 2, 2, 6),
-  S = NULL,
-  T = NULL,
-  minfup = NULL,
-  ratio = 1
-)
-
-# Update x with gsDesign() to get integer event counts
-x <- gsDesign::gsDesign(
-  k = x$k,
-  test.type = 1,
-  alpha = x$alpha,
-  beta = x$beta,
-  sfu = x$upper$sf,
-  sfupar = x$upper$param,
-  n.I = ceiling(x$n.I),
-  maxn.IPlan = ceiling(x$n.I[x$k]),
-  delta = x$delta,
-  delta1 = x$delta1,
-  delta0 = x$delta0
-)
-y <- gsDesign::gsBoundSummary(
-  x,
-  ratio = 1,
-  digits = 4,
-  ddigits = 2,
-  tdigits = 1,
-  timename = "Month",
-  logdelta = TRUE
-)
-
-res <- list("x" = x, "y" = y)
-
 # Test 1: compare with gsDesign under proportional hazard
 test_that("under same number of events, compare the power", {
+  res <- test_gs_power_ahr()
   x <- res$x
   y <- res$y
 
@@ -80,6 +32,7 @@ test_that("under same number of events, compare the power", {
 })
 
 test_that("under same power setting, compare the number of events", {
+  res <- test_gs_power_ahr()
   x <- res$x
 
   out <- gs_power_ahr(

--- a/tests/testthat/test-independent-utility_combo.R
+++ b/tests/testthat/test-independent-utility_combo.R
@@ -1,6 +1,5 @@
 # Test get_combo_weight ----
 test_that("get_combo_weight output correct rho1, rho2, gamma1, gamm2", {
-
   rho <- c(1, 1, 0, 0)
   gamma <- c(0, 1, 0, 1)
   tau <- c(-1, -1, -1, -1)
@@ -33,10 +32,8 @@ test_that("get_combo_weight output correct rho1, rho2, gamma1, gamm2", {
   expect_equal(res$weight2_gamma, "gamma =1")
 })
 
-
 # Test get_combo_weight tau not equal to -1 ----
 test_that("get_combo_weight output correct tau1, tau3", {
-
   rho <- c(1, 1, 0, 0)
   gamma <- c(0, 1, 0, 1)
   tau <- c(1, 1, 0, 0)
@@ -58,7 +55,6 @@ test_that("get_combo_weight output correct tau1, tau3", {
 
 # Test gs_delta_combo ----
 test_that("gs_delta_combo correctly use gs_delta_wlr 1", {
-
   rho <- c(1, 1, 0, 0)
   gamma <- c(0, 1, 0, 1)
   tau <- c(-1, -1, -1, -1)
@@ -111,7 +107,6 @@ test_that("gs_delta_combo correctly use gs_delta_wlr 1", {
 
 # Test gs_sigma2_combo ----
 test_that("gs_sigma2_combo correctly use gs_sigma2_wlr 1", {
-
   rho <- c(1, 1, 0, 0)
   gamma <- c(0, 1, 0, 1)
   tau <- c(-1, -1, -1, -1)
@@ -228,7 +223,6 @@ test_that("gs_info_combo correctly use gs_info_wlr 1", {
 # Test gs_prob_combo ----
 ## 1 analysis scenario ----
 test_that("p efficacy", {
-
   lower <- -0.6
   upper <- 0.4
   rho <- c(1, 1, 0, 0)
@@ -297,8 +291,6 @@ test_that("p efficacy", {
   # p futility
   expect_equal(res$prob$probability[2], res$p_futility[1], tolerance = 0.001)
 })
-
-
 
 ## 2 analysis scenario ----
 test_that("p efficacy1", {
@@ -395,7 +387,6 @@ test_that("p efficacy1", {
   # p futility2
   expect_equal(res$prob$probability[4], res$p_futility_1[1] + res$p_futility_2[1], tolerance = 0.001)
 })
-
 
 # Test pmvnorm_combo ----
 test_that("pmvnorm_combo calculate p for One test for all group or lower bound is -Inf.", {
@@ -540,9 +531,6 @@ test_that("gs_utility_combo output correct info as gs_info_combo", {
   expect_equal(utility_combo$corr, corr_test)
 })
 
-
-
-
 ## Multiple test analysis ----
 test_that("gs_utility_combo output correct info as gs_info_combo", {
   enroll_rate <- define_enroll_rate(
@@ -636,4 +624,3 @@ test_that("gs_utility_combo output correct info as gs_info_combo", {
 
   expect_equal(utility_combo$corr, corr_test)
 })
-

--- a/tests/testthat/test-independent_as_gt.R
+++ b/tests/testthat/test-independent_as_gt.R
@@ -1,5 +1,3 @@
-gt_to_latex <- function(data) cat(as.character(gt::as_latex(data)))
-
 test_that("enroll_rate produces the expected output", {
   expected_result <- tibble::tibble(stratum = "All", duration = 18, rate = 20)
 

--- a/tests/testthat/test-independent_test_gs_design_wlr.R
+++ b/tests/testthat/test-independent_test_gs_design_wlr.R
@@ -1,5 +1,5 @@
 # NOTE: all reference numbers come from simulation results in
-# https://keaven.github.io/gsd-deming/wlr.html#wlr
+# https://keaven.github.io/gsd-deming/wlr.html
 # Please look for sections titled "Simulation results based on 10,000 replications".
 
 test_that("Validate the function based on examples with simulation results", {


### PR DESCRIPTION
Fixes #393

This PR makes all tests self-contained (again), following [recommendations from the R Packages book](https://r-pkgs.org/testing-design.html).

This resulted in the creation of a third category of test helper files named `helper-support-*.R`, besides the current two categories `helper-double-programming-*.R` and `helper-old-version-*.R`.