### PR TITLE
Enable passing named vector of analysis_decimals to summary.gs_design()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.2.7
+Version: 1.1.2.8
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/man/summary.Rd
+++ b/man/summary.Rd
@@ -24,7 +24,10 @@
 
 \item{analysis_vars}{The variables to be put at the summary header of each analysis.}
 
-\item{analysis_decimals}{The displayed number of digits of \code{analysis_vars}.}
+\item{analysis_decimals}{The displayed number of digits of \code{analysis_vars}.
+If the vector is unnamed, it must match the length of \code{analysis_vars}. If
+the vector is named, you only have to specify the number of digits for the
+variables you want to be displayed differently than the defaults.}
 
 \item{col_vars}{The variables to be displayed.}
 

--- a/tests/testthat/helper-developer-summary.R
+++ b/tests/testthat/helper-developer-summary.R
@@ -1,0 +1,3 @@
+# Helper functions used by test-developer-summary.R
+
+extract_summary_analysis <- function(x) x[["Analysis"]][1]

--- a/tests/testthat/test-developer-summary.R
+++ b/tests/testthat/test-developer-summary.R
@@ -1,0 +1,62 @@
+# See helper functions in helper-developer-summary.R
+
+# Maintain previous behavior
+test_that("summary.gs_design() accepts same-length vectors for analysis_vars and analysis_decimals", {
+  x <- gs_design_ahr(analysis_time = c(12, 24))
+
+  # default decimals
+  observed <- x |> summary() |> attr("groups") |> extract_summary_analysis()
+  expect_identical(
+    observed,
+    "Analysis: 1 Time: 12 N: 707.3 Event: 160.4 AHR: 0.81 Information fraction: 0.42"
+  )
+
+  # specify the decimals for each variable
+  observed <- x |>
+    summary(analysis_vars = c("time", "n", "event", "ahr", "info_frac"),
+            analysis_decimals = c(2, 0, 0, 4, 4)) |>
+    attr("groups") |>
+    extract_summary_analysis()
+  expect_identical(
+    observed,
+    "Analysis: 1 Time: 12 N: 707 Event: 160 AHR: 0.8108 Information fraction: 0.4191"
+  )
+
+  # Drop variables and also specify the decimals
+  observed <- x |>
+    summary(analysis_vars = c("ahr", "info_frac"),
+            analysis_decimals = c(4, 4)) |>
+    attr("groups") |>
+    extract_summary_analysis()
+  expect_identical(
+    observed,
+    "Analysis: 1 AHR: 0.8108 Information fraction: 0.4191"
+  )
+})
+
+test_that("summary.gs_design() accepts a named vector for analysis_decimals", {
+  x <- gs_design_ahr(analysis_time = c(12, 24))
+
+  # Specify decimals
+  observed <- x |>
+    summary(analysis_decimals = c(ahr = 4, info_frac = 4)) |>
+    attr("groups") |>
+    extract_summary_analysis()
+  expect_identical(
+    observed,
+    "Analysis: 1 Time: 12 N: 707.3 Event: 160.4 AHR: 0.8108 Information fraction: 0.4191"
+  )
+
+  # Specify decimals and also drop some variables
+  observed <- x |>
+    summary(
+      analysis_vars = c("event", "ahr", "info_frac"),
+      analysis_decimals = c(ahr = 4, info_frac = 4)
+    ) |>
+    attr("groups") |>
+    extract_summary_analysis()
+  expect_identical(
+    observed,
+    "Analysis: 1 Event: 160.4 AHR: 0.8108 Information fraction: 0.4191"
+  )
+})

--- a/tests/testthat/test-developer-summary.R
+++ b/tests/testthat/test-developer-summary.R
@@ -5,7 +5,10 @@ test_that("summary.gs_design() accepts same-length vectors for analysis_vars and
   x <- gs_design_ahr(analysis_time = c(12, 24))
 
   # default decimals
-  observed <- x |> summary() |> attr("groups") |> extract_summary_analysis()
+  observed <- x |>
+    summary() |>
+    attr("groups") |>
+    extract_summary_analysis()
   expect_identical(
     observed,
     "Analysis: 1 Time: 12 N: 707.3 Event: 160.4 AHR: 0.81 Information fraction: 0.42"
@@ -13,8 +16,10 @@ test_that("summary.gs_design() accepts same-length vectors for analysis_vars and
 
   # specify the decimals for each variable
   observed <- x |>
-    summary(analysis_vars = c("time", "n", "event", "ahr", "info_frac"),
-            analysis_decimals = c(2, 0, 0, 4, 4)) |>
+    summary(
+      analysis_vars = c("time", "n", "event", "ahr", "info_frac"),
+      analysis_decimals = c(2, 0, 0, 4, 4)
+    ) |>
     attr("groups") |>
     extract_summary_analysis()
   expect_identical(
@@ -24,13 +29,28 @@ test_that("summary.gs_design() accepts same-length vectors for analysis_vars and
 
   # Drop variables and also specify the decimals
   observed <- x |>
-    summary(analysis_vars = c("ahr", "info_frac"),
-            analysis_decimals = c(4, 4)) |>
+    summary(
+      analysis_vars = c("ahr", "info_frac"),
+      analysis_decimals = c(4, 4)
+    ) |>
     attr("groups") |>
     extract_summary_analysis()
   expect_identical(
     observed,
     "Analysis: 1 AHR: 0.8108 Information fraction: 0.4191"
+  )
+
+  # Rearrange variables
+  observed <- x |>
+    summary(
+      analysis_vars = c("info_frac", "ahr", "event", "n", "time"),
+      analysis_decimals = c(4, 4, 0, 0, 2)
+    ) |>
+    attr("groups") |>
+    extract_summary_analysis()
+  expect_identical(
+    observed,
+    "Analysis: 1 Information fraction: 0.4191 AHR: 0.8108 Event: 160 N: 707 Time: 12"
   )
 })
 
@@ -58,5 +78,18 @@ test_that("summary.gs_design() accepts a named vector for analysis_decimals", {
   expect_identical(
     observed,
     "Analysis: 1 Event: 160.4 AHR: 0.8108 Information fraction: 0.4191"
+  )
+
+  # Specify decimals and rearrange some variables
+  observed <- x |>
+    summary(
+      analysis_vars = c("info_frac", "ahr", "event"),
+      analysis_decimals = c(ahr = 4, info_frac = 4)
+    ) |>
+    attr("groups") |>
+    extract_summary_analysis()
+  expect_identical(
+    observed,
+    "Analysis: 1 Information fraction: 0.4191 AHR: 0.8108 Event: 160.4"
   )
 })

--- a/tests/testthat/test-developer-summary.R
+++ b/tests/testthat/test-developer-summary.R
@@ -52,6 +52,16 @@ test_that("summary.gs_design() accepts same-length vectors for analysis_vars and
     observed,
     "Analysis: 1 Information fraction: 0.4191 AHR: 0.8108 Event: 160 N: 707 Time: 12"
   )
+
+  # Throw error if unnamed analysis_decimals does not match length of analysis_vars
+  expect_error(
+    summary(
+      x,
+      analysis_vars = c("info_frac", "ahr", "event", "n", "time"),
+      analysis_decimals = c(4, 4),
+    ),
+    "summary: please input analysis_vars and analysis_decimals in pairs!"
+  )
 })
 
 test_that("summary.gs_design() accepts a named vector for analysis_decimals", {
@@ -91,5 +101,23 @@ test_that("summary.gs_design() accepts a named vector for analysis_decimals", {
   expect_identical(
     observed,
     "Analysis: 1 Information fraction: 0.4191 AHR: 0.8108 Event: 160.4"
+  )
+
+  # Only drop variables
+  observed <- x |>
+    summary(
+      analysis_vars = c("info_frac", "ahr", "event")
+    ) |>
+    attr("groups") |>
+    extract_summary_analysis()
+  expect_identical(
+    observed,
+    "Analysis: 1 Information fraction: 0.42 AHR: 0.81 Event: 160.4"
+  )
+
+  # Throw error is analysis_decimals is unnamed
+  expect_error(
+    summary(x, analysis_decimals = c(4, 4)),
+    "summary: analysis_decimals must be a named vector if analysis_vars is not provided"
   )
 })


### PR DESCRIPTION
Closes #388 

This is a work-in-progress. I want to confirm the new behavior before I clean up the code, add tests, and update the documentation (and also apply analogous updates to `col_vars` and `col_decimals`).

I've updated the behavior of the argument `analysis_decimals` to `summary.gs_design()` to accept a named vector. This enables the user to specifically adjust the number of displayed decimals places for specific variables without having to also include the default values for all the other analysis variables. However, I've also maintained the old behavior.

Here is how it currently functions with this PR:

```R

library("gsDesign2")
x <- gs_design_ahr(analysis_time = c(12, 24))

# Maintain previous behavior
x |> summary() |> attr("groups")
## # A tibble: 2 × 2
## Analysis                                                                              .rows
## <chr>                                                                           <list<int>>
## 1 Analysis: 1 Time: 12 N: 707.3 Event: 160.4 AHR: 0.81 Information fraction: 0.42         [2]
## 2 Analysis: 2 Time: 24 N: 848.8 Event: 385.6 AHR: 0.72 Information fraction: 1            [2]


x |>
  summary(analysis_vars = c("time", "n", "event", "ahr", "info_frac"),
          analysis_decimals = c(2, 0, 0, 4, 4)) |>
  attr("groups")
## # A tibble: 2 × 2
## Analysis                                                                              .rows
## <chr>                                                                           <list<int>>
## 1 Analysis: 1 Time: 12 N: 707 Event: 160 AHR: 0.8108 Information fraction: 0.4191         [2]
## 2 Analysis: 2 Time: 24 N: 849 Event: 386 AHR: 0.7152 Information fraction: 1              [2]

x |>
  summary(analysis_vars = c("ahr", "info_frac"),
          analysis_decimals = c(4, 4)) |>
  attr("groups")
## # A tibble: 2 × 2
## Analysis                                                   .rows
## <chr>                                                <list<int>>
## 1 Analysis: 1 AHR: 0.8108 Information fraction: 0.4191         [2]
## 2 Analysis: 2 AHR: 0.7152 Information fraction: 1              [2]

# New behavior
x |>
  summary(analysis_decimals = c(ahr = 4, info_frac = 4)) |>
  attr("groups")
## # A tibble: 2 × 2
## Analysis                                                                                 .rows
## <chr>                                                                               <list<int>
## 1 Analysis: 1 Time: 12 N: 707.3 Event: 160.4 AHR: 0.8108 Information fraction: 0.4191        [2]
## 2 Analysis: 2 Time: 24 N: 848.8 Event: 385.6 AHR: 0.7152 Information fraction: 1             [2]
```

