### PR TITLE
407 gs update ahr when futility bound is fixed the function does not work

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.2.8
+Version: 1.1.2.9
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/R/gs_update_ahr.R
+++ b/R/gs_update_ahr.R
@@ -332,7 +332,7 @@ gs_update_ahr <- function(
       upar_update$timing <- ustime
     } else {
       upar_update$timing <- ustime
-      if(!identical(x$input$lower, gs_b)) {
+      if(is.list(x$input$lpar)) {
         lpar_update$timing <- lstime
       }
     }

--- a/R/gs_update_ahr.R
+++ b/R/gs_update_ahr.R
@@ -230,17 +230,24 @@ gs_update_ahr <- function(
   # Check if is efficacy only
   one_sided <- all(x$bound$bound == "upper")
 
+  # Check if futility bound is fixed
+  fixed_futility_bound <- identical(x$input$lower, gs_b)
+
   # Check inputs ----
   if (is.null(x)) {
     stop("gs_update_ahr(): please input the original design created either by gs_design_ahr or gs_power_ahr.")
   }
 
-  if (!("ahr" %in% class(x))) {
-    stop("gs_update_ahr(): the original design must be created either by gs_design_ahr or gs_power_ahr.")
+  if (!any((c("ahr", "wlr") %in% class(x)))) {
+    stop("gs_update_ahr(): the original design must be created either by gs_design_ahr, gs_power_ahr, gs_design_wlr, or gs_power_wlr.")
   }
 
   if (one_sided && !is.null(lstime)) {
     stop("gs_update_ahr(): lstime is not needed for one-sided design.")
+  }
+
+  if (fixed_futility_bound && !is.null(lstime)) {
+    stop("gs_update_ahr(): lstime is not needed for two-sided design with fixed futility bounds.")
   }
 
   # Get the updated alpha ----
@@ -325,7 +332,9 @@ gs_update_ahr <- function(
       upar_update$timing <- ustime
     } else {
       upar_update$timing <- ustime
-      lpar_update$timing <- lstime
+      if(!identical(x$input$lower, gs_b)) {
+        lpar_update$timing <- lstime
+      }
     }
 
     upar_update$total_spend <- alpha_update


### PR DESCRIPTION
The following codes provide a two-sided design example with fixed futility bound. Because the futility bounds are fixed, it is not updated at the time of analysis.
```
 x <- gs_design_ahr(   
   enroll_rate = ..., fail_rate = ...,
   alpha = ..., beta = .., ratio = ...,
   info_scale = "h0_info",
   info_frac = NULL, analysis_time = c(20, 36),
   upper = gs_spending_bound,
   upar = list(sf = sfLDOF, total_spend = alpha),
   test_upper = TRUE,
   lower = gs_b,
   lpar = c(-1, 0),
   test_lower = c(TRUE, FALSE),
   binding = FALSE) |> to_integer()


 gs_update_ahr(
   x = x,
   ustime = ...,
   lstime = ...,
   observed_data = ...)
```