### PR TITLE
Robustly check if lower bound function is equivalent to fixed gs_b()

### DIFF
--- a/R/gs_update_ahr.R
+++ b/R/gs_update_ahr.R
@@ -230,8 +230,11 @@ gs_update_ahr <- function(
   # Check if is efficacy only
   one_sided <- all(x$bound$bound == "upper")
 
-  # Check if futility bound is fixed
-  fixed_futility_bound <- identical(x$input$lower, gs_b)
+  # Check if futility bound is fixed. In other words, check if is the provided
+  # function to compute lower bounds equivalent to gsDesign2::gs_b()
+  gs_b_observed <- try(x$input$lower(par = 4:2, k = 2), silent = TRUE)
+  gs_b_expected <- gs_b(par = 4:2, k = 2)
+  fixed_futility_bound <- identical(gs_b_observed, gs_b_expected)
 
   # Check inputs ----
   if (is.null(x)) {


### PR DESCRIPTION
Closes #411 
Follow-up to #408

Here's my attempt at robustly comparing the input lower bound function to `gs_b()`. Unfortunately there is no test case where `fixed_futility_bound` evaluates to `TRUE`. Here is a quick demonstration of how it works:

```R
devtools::load_all(".")

# Function that is equivalent to current gsDesign2::gs_b()
gs_b_yihui <- function(par = NULL, k = NULL, ...) {
  if (is.null(k)) par else par[k]
}

x <- list()
x$input$lower <- gs_b_yihui

gs_b_observed <- try(x$input$lower(par = 4:2, k = 2), silent = TRUE)
gs_b_expected <- gs_b(par = 4:2, k = 2)
fixed_futility_bound <- identical(gs_b_observed, gs_b_expected)
fixed_futility_bound
## [1] TRUE

# Function that is not equivalent to gsDesign2::gs_b()
x$input$lower <- gs_spending_bound

gs_b_observed <- try(x$input$lower(par = 4:2, k = 2), silent = TRUE)
gs_b_observed
## [1] "Error in par$timing : $ operator is invalid for atomic vectors\n"
## attr(,"class")
## [1] "try-error"
## attr(,"condition")
## <simpleError in par$timing: $ operator is invalid for atomic vectors>
gs_b_expected <- gs_b(par = 4:2, k = 2)
fixed_futility_bound <- identical(gs_b_observed, gs_b_expected)
fixed_futility_bound
## [1] FALSE
```

cc @yihui