### PR TITLE
Update documentation for `gs_b()`

### DIFF
--- a/R/gs_b.R
+++ b/R/gs_b.R
@@ -18,9 +18,10 @@
 
 #' Default boundary generation
 #'
-#' `gs_b()` is the simplest version of a function to be used with the
-#' `upper` and `lower` arguments in `gs_prob_combo()`,
-#' [`gs_power_npe()`] and [`gs_design_npe()`].
+#' `gs_b()` is the simplest version of a function to be used with the `upper`
+#' and `lower` arguments in [`gs_power_npe()`] and [`gs_design_npe()`] or the
+#' `upper_bound` and `lower_bound` arguments `gs_prob_combo()` and
+#' `pmvnorm_combo()`.
 #' It simply returns the vector of Z-values in the input vector `par` or,
 #' if `k` is specified, `par[k]` is returned.
 #' Note that if bounds need to change with changing information at analyses,

--- a/R/gs_b.R
+++ b/R/gs_b.R
@@ -19,13 +19,13 @@
 #' Default boundary generation
 #'
 #' `gs_b()` is the simplest version of a function to be used with the
-#' `upper` and `lower` arguments in `gs_prob()`,
-#' `gs_power_nph()` and `gs_design_nph()`;
-#' it simply returns the vector input in the input vector `Z` or,
-#' if `k` is specified, `par[k]j` is returned.
+#' `upper` and `lower` arguments in `gs_prob_combo()`,
+#' [`gs_power_npe()`] and [`gs_design_npe()`].
+#' It simply returns the vector of Z-values in the input vector `par` or,
+#' if `k` is specified, `par[k]` is returned.
 #' Note that if bounds need to change with changing information at analyses,
 #' `gs_b()` should not be used.
-#' For instance, for spending function bounds use.
+#' For instance, for spending function bounds use [gs_spending_bound()].
 #'
 #' @param par For `gs_b()`, this is just Z-values for the boundaries;
 #'   can include infinite values.

--- a/R/gs_b.R
+++ b/R/gs_b.R
@@ -20,7 +20,7 @@
 #'
 #' `gs_b()` is the simplest version of a function to be used with the `upper`
 #' and `lower` arguments in [`gs_power_npe()`] and [`gs_design_npe()`] or the
-#' `upper_bound` and `lower_bound` arguments `gs_prob_combo()` and
+#' `upper_bound` and `lower_bound` arguments in `gs_prob_combo()` and
 #' `pmvnorm_combo()`.
 #' It simply returns the vector of Z-values in the input vector `par` or,
 #' if `k` is specified, `par[k]` is returned.

--- a/man/gs_b.Rd
+++ b/man/gs_b.Rd
@@ -20,7 +20,7 @@ Returns the vector input \code{par} if \code{k} is \code{NULL}, otherwise, \code
 \description{
 \code{gs_b()} is the simplest version of a function to be used with the \code{upper}
 and \code{lower} arguments in \code{\link[=gs_power_npe]{gs_power_npe()}} and \code{\link[=gs_design_npe]{gs_design_npe()}} or the
-\code{upper_bound} and \code{lower_bound} arguments \code{gs_prob_combo()} and
+\code{upper_bound} and \code{lower_bound} arguments in \code{gs_prob_combo()} and
 \code{pmvnorm_combo()}.
 It simply returns the vector of Z-values in the input vector \code{par} or,
 if \code{k} is specified, \code{par[k]} is returned.

--- a/man/gs_b.Rd
+++ b/man/gs_b.Rd
@@ -19,13 +19,13 @@ Returns the vector input \code{par} if \code{k} is \code{NULL}, otherwise, \code
 }
 \description{
 \code{gs_b()} is the simplest version of a function to be used with the
-\code{upper} and \code{lower} arguments in \code{gs_prob()},
-\code{gs_power_nph()} and \code{gs_design_nph()};
-it simply returns the vector input in the input vector \code{Z} or,
-if \code{k} is specified, \verb{par[k]j} is returned.
+\code{upper} and \code{lower} arguments in \code{gs_prob_combo()},
+\code{\link[=gs_power_npe]{gs_power_npe()}} and \code{\link[=gs_design_npe]{gs_design_npe()}}.
+It simply returns the vector of Z-values in the input vector \code{par} or,
+if \code{k} is specified, \code{par[k]} is returned.
 Note that if bounds need to change with changing information at analyses,
 \code{gs_b()} should not be used.
-For instance, for spending function bounds use.
+For instance, for spending function bounds use \code{\link[=gs_spending_bound]{gs_spending_bound()}}.
 }
 \section{Specification}{
 

--- a/man/gs_b.Rd
+++ b/man/gs_b.Rd
@@ -18,9 +18,10 @@ can include infinite values.}
 Returns the vector input \code{par} if \code{k} is \code{NULL}, otherwise, \code{par[k]}.
 }
 \description{
-\code{gs_b()} is the simplest version of a function to be used with the
-\code{upper} and \code{lower} arguments in \code{gs_prob_combo()},
-\code{\link[=gs_power_npe]{gs_power_npe()}} and \code{\link[=gs_design_npe]{gs_design_npe()}}.
+\code{gs_b()} is the simplest version of a function to be used with the \code{upper}
+and \code{lower} arguments in \code{\link[=gs_power_npe]{gs_power_npe()}} and \code{\link[=gs_design_npe]{gs_design_npe()}} or the
+\code{upper_bound} and \code{lower_bound} arguments \code{gs_prob_combo()} and
+\code{pmvnorm_combo()}.
 It simply returns the vector of Z-values in the input vector \code{par} or,
 if \code{k} is specified, \code{par[k]} is returned.
 Note that if bounds need to change with changing information at analyses,


### PR DESCRIPTION
Closes #414

Notes:

* `gs_prob_combo()` has the tag `@noRd`, so I can't link to it
* The switch from `_nph` to `_npe` was purely a guess. If that's not correct, please let me know what to rename them
* I assumed that `gs_spending_bound()` was the function being hinted at by the final sentence
