### PR TITLE
Always include column "Bound" in summary.gs_design() output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.2.11
+Version: 1.1.2.12
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/R/summary.R
+++ b/R/summary.R
@@ -361,6 +361,14 @@ summary.gs_design <- function(object,
     }
   }
 
+  # "bound" is a required column
+  if (!"bound" %in% x_decimals$col_vars) {
+    x_decimals <- rbind(
+      tibble::tibble(col_vars = "bound", col_decimals = NA),
+      x_decimals
+    )
+  }
+
   # Prepare the analysis summary row ----
   # get the
   # (1) analysis variables to be displayed on the header

--- a/tests/testthat/test-developer-summary.R
+++ b/tests/testthat/test-developer-summary.R
@@ -121,3 +121,31 @@ test_that("summary.gs_design() accepts a named vector for analysis_decimals", {
     "summary: analysis_decimals must be a named vector if analysis_vars is not provided"
   )
 })
+
+test_that("The column 'Bound' is always included in summary.gs_design() output", {
+  x <- gs_design_ahr()
+
+  # without col_vars
+  observed <- summary(x)
+  expect_true("Bound" %in% colnames(observed))
+
+  # including "bound" in col_vars
+  observed <- summary(
+    x,
+    col_vars = c(
+      "bound", "z", "~hr at bound", "nominal p", "Alternate hypothesis", "Null hypothesis"
+    ),
+    col_decimals = c(NA, 4, 4, 4, 4, 4)
+  )
+  expect_true("Bound" %in% colnames(observed))
+
+  # excluding "bound" in col_vars
+  observed <- summary(
+    x,
+    col_vars = c(
+      "z", "~hr at bound", "nominal p", "Alternate hypothesis", "Null hypothesis"
+    ),
+    col_decimals = c(4, 4, 4, 4, 4)
+  )
+  expect_true("Bound" %in% colnames(observed))
+})


### PR DESCRIPTION
Closes #410

It is now optional to include `"bound"` in `col_vars` when passing it to `summary.gs_design()`