### PR TITLE
Enable passing named vector of col_decimals to summary.gs_design()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.2.13
+Version: 1.1.2.14
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/R/summary.R
+++ b/R/summary.R
@@ -243,6 +243,16 @@ summary.fixed_design <- function(object, ...) {
 #'
 #' # Customize the variables to be summarized for each analysis
 #' x_ahr %>% summary(analysis_vars = c("n", "event"), analysis_decimals = c(1, 1))
+#'
+#' # Customize the digits for the columns
+#' x_ahr %>% summary(col_decimals = c(z = 4))
+#'
+#' # Customize the columns to display
+#' x_ahr %>% summary(col_vars = c("z", "~hr at bound", "nominal p"))
+#'
+#' # Customize columns and digits
+#' x_ahr %>% summary(col_vars = c("z", "~hr at bound", "nominal p"),
+#'                   col_decimals = c(4, 2, 2))
 #' }
 #'
 #' # Example 2 ----

--- a/R/summary.R
+++ b/R/summary.R
@@ -318,20 +318,28 @@ summary.gs_design <- function(object,
 
   # Prepare the columns decimals ----
   if (method == "ahr") {
-    col_vars_default <- c("analysis", "bound", "z", "~hr at bound", "nominal p",
-                          "Alternate hypothesis", "Null hypothesis")
+    col_vars_default <- c(
+      "analysis", "bound", "z", "~hr at bound", "nominal p",
+      "Alternate hypothesis", "Null hypothesis"
+    )
     col_decimals_default <- c(NA, NA, 2, 4, 4, 4, 4)
   } else if (method == "wlr") {
-    col_vars_default <- c("analysis", "bound", "z", "~whr at bound", "nominal p",
-                          "Alternate hypothesis", "Null hypothesis")
+    col_vars_default <- c(
+      "analysis", "bound", "z", "~whr at bound", "nominal p",
+      "Alternate hypothesis", "Null hypothesis"
+    )
     col_decimals_default <- c(NA, NA, 2, 4, 4, 4, 4)
   } else if (method == "combo") {
-    col_vars_default <- c("analysis", "bound", "z", "nominal p",
-                          "Alternate hypothesis", "Null hypothesis")
+    col_vars_default <- c(
+      "analysis", "bound", "z", "nominal p",
+      "Alternate hypothesis", "Null hypothesis"
+    )
     col_decimals_default <- c(NA, NA, 2, 4, 4, 4)
   } else if (method == "rd") {
-    col_vars_default <- c("analysis", "bound", "z", "~risk difference at bound",
-      "nominal p", "Alternate hypothesis", "Null hypothesis")
+    col_vars_default <- c(
+      "analysis", "bound", "z", "~risk difference at bound",
+      "nominal p", "Alternate hypothesis", "Null hypothesis"
+    )
     col_decimals_default <- c(NA, NA, 2, 4, 4, 4, 4)
   } else {
     stop("Invalid method: ", method)

--- a/R/summary.R
+++ b/R/summary.R
@@ -315,50 +315,35 @@ summary.gs_design <- function(object,
 
   # Prepare the columns decimals ----
   if (method == "ahr") {
-    if (is.null(col_vars) && is.null(col_decimals)) {
-      x_decimals <- tibble::tibble(
-        col_vars = c("analysis", "bound", "z", "~hr at bound", "nominal p", "Alternate hypothesis", "Null hypothesis"),
-        col_decimals = c(NA, NA, 2, 4, 4, 4, 4)
-      )
-    } else {
-      x_decimals <- tibble::tibble(col_vars = col_vars, col_decimals = col_decimals)
-    }
+    col_vars_default <- c("analysis", "bound", "z", "~hr at bound", "nominal p",
+                          "Alternate hypothesis", "Null hypothesis")
+    col_decimals_default <- c(NA, NA, 2, 4, 4, 4, 4)
+  } else if (method == "wlr") {
+    col_vars_default <- c("analysis", "bound", "z", "~whr at bound", "nominal p",
+                          "Alternate hypothesis", "Null hypothesis")
+    col_decimals_default <- c(NA, NA, 2, 4, 4, 4, 4)
+  } else if (method == "combo") {
+    col_vars_default <- c("analysis", "bound", "z", "nominal p",
+                          "Alternate hypothesis", "Null hypothesis")
+    col_decimals_default <- c(NA, NA, 2, 4, 4, 4)
+  } else if (method == "rd") {
+    col_vars_default <- c("analysis", "bound", "z", "~risk difference at bound",
+      "nominal p", "Alternate hypothesis", "Null hypothesis")
+    col_decimals_default <- c(NA, NA, 2, 4, 4, 4, 4)
+  } else {
+    stop("Invalid method: ", method)
   }
 
-  if (method == "wlr") {
-    if (is.null(col_vars) && is.null(col_decimals)) {
-      x_decimals <- tibble::tibble(
-        col_vars = c("analysis", "bound", "z", "~whr at bound", "nominal p", "Alternate hypothesis", "Null hypothesis"),
-        col_decimals = c(NA, NA, 2, 4, 4, 4, 4)
-      )
-    } else {
-      x_decimals <- tibble::tibble(col_vars = col_vars, col_decimals = col_decimals)
-    }
-  }
-
-  if (method == "combo") {
-    if (is.null(col_vars) && is.null(col_decimals)) {
-      x_decimals <- tibble::tibble(
-        col_vars = c("analysis", "bound", "z", "nominal p", "Alternate hypothesis", "Null hypothesis"),
-        col_decimals = c(NA, NA, 2, 4, 4, 4)
-      )
-    } else {
-      x_decimals <- tibble::tibble(col_vars = col_vars, col_decimals = col_decimals)
-    }
-  }
-
-  if (method == "rd") {
-    if (is.null(col_vars) && is.null(col_decimals)) {
-      x_decimals <- tibble::tibble(
-        col_vars = c(
-          "analysis", "bound", "z", "~risk difference at bound",
-          "nominal p", "Alternate hypothesis", "Null hypothesis"
-        ),
-        col_decimals = c(NA, NA, 2, 4, 4, 4, 4)
-      )
-    } else {
-      x_decimals <- tibble::tibble(col_vars = col_vars, col_decimals = col_decimals)
-    }
+  if (is.null(col_vars) && is.null(col_decimals)) {
+    x_decimals <- tibble::tibble(
+      col_vars = col_vars_default,
+      col_decimals = col_decimals_default
+    )
+  } else {
+    x_decimals <- tibble::tibble(
+      col_vars = col_vars,
+      col_decimals = col_decimals
+    )
   }
 
   # "bound" is a required column

--- a/man/summary.Rd
+++ b/man/summary.Rd
@@ -175,6 +175,16 @@ x_ahr \%>\% summary(bound_names = c("A is better", "B is better"))
 
 # Customize the variables to be summarized for each analysis
 x_ahr \%>\% summary(analysis_vars = c("n", "event"), analysis_decimals = c(1, 1))
+
+# Customize the digits for the columns
+x_ahr \%>\% summary(col_decimals = c(z = 4))
+
+# Customize the columns to display
+x_ahr \%>\% summary(col_vars = c("z", "~hr at bound", "nominal p"))
+
+# Customize columns and digits
+x_ahr \%>\% summary(col_vars = c("z", "~hr at bound", "nominal p"),
+                  col_decimals = c(4, 2, 2))
 }
 
 # Example 2 ----

--- a/man/summary.Rd
+++ b/man/summary.Rd
@@ -31,7 +31,10 @@ variables you want to be displayed differently than the defaults.}
 
 \item{col_vars}{The variables to be displayed.}
 
-\item{col_decimals}{The decimals to be displayed for the displayed variables in \code{col_vars}.}
+\item{col_decimals}{The decimals to be displayed for the displayed variables in \code{col_vars}.
+If the vector is unnamed, it must match the length of \code{col_vars}. If the
+vector is named, you only have to specify the number of digits for the
+columns you want to be displayed differently than the defaults.}
 
 \item{bound_names}{Names for bounds; default is \code{c("Efficacy", "Futility")}.}
 }

--- a/tests/testthat/test-developer-summary.R
+++ b/tests/testthat/test-developer-summary.R
@@ -257,26 +257,26 @@ test_that("summary.gs_design() accepts a named vector for col_decimals", {
 
   # Specify decimals and also drop some variables
   x_sum <- summary(
-      x,
-      col_vars = c("z", "nominal p", "Null hypothesis"),
-      col_decimals = c(z = 0, `nominal p` = 0)
-    )
+    x,
+    col_vars = c("z", "nominal p", "Null hypothesis"),
+    col_decimals = c(z = 0, `nominal p` = 0)
+  )
   observed <- as.data.frame(x_sum)[, -1:-2]
   expected <- data.frame(Z = 2, `Nominal p` = 0, `Null hypothesis` = 0.025, check.names = FALSE)
   expect_equal(observed, expected)
 
   # Specify decimals and rearrange some variables
   x_sum <- summary(
-      x,
-      col_vars = c("Null hypothesis", "nominal p", "z"),
-      col_decimals = c(z = 0, `nominal p` = 0)
-    )
+    x,
+    col_vars = c("Null hypothesis", "nominal p", "z"),
+    col_decimals = c(z = 0, `nominal p` = 0)
+  )
   observed <- as.data.frame(x_sum)[, -1:-2]
   expected <- data.frame(`Null hypothesis` = 0.025, `Nominal p` = 0, Z = 2, check.names = FALSE)
   expect_equal(observed, expected)
 
   # Only drop variables
-  x_sum <- summary(x,col_vars = c("z", "nominal p", "Null hypothesis"))
+  x_sum <- summary(x, col_vars = c("z", "nominal p", "Null hypothesis"))
   observed <- as.data.frame(x_sum)[, -1:-2]
   expected <- data.frame(Z = 1.96, `Nominal p` = 0.025, `Null hypothesis` = 0.025, check.names = FALSE)
   expect_equal(observed, expected)

--- a/tests/testthat/test-developer-summary.R
+++ b/tests/testthat/test-developer-summary.R
@@ -150,7 +150,6 @@ test_that("The column 'Bound' is always included in summary.gs_design() output",
   expect_true("Bound" %in% colnames(observed))
 })
 
-
 test_that("The full alpha is correctly carried over", {
   a_level <- 0.02
   x <- gs_power_ahr(
@@ -166,4 +165,22 @@ test_that("The full alpha is correctly carried over", {
   observed <- summary(x)
 
   expect_equal(attributes(observed)$full_alpha, a_level)
+})
+
+test_that("col_vars and col_decimals can be passed 1:1", {
+  x <- gs_design_ahr()
+
+  observed <- summary(
+    x,
+    col_vars = c("z", "~hr at bound", "nominal p", "Alternate hypothesis"),
+    col_decimals = c(0, 0, 0, 0)
+  )
+
+  columns <- c("Z", "~HR at bound", "Nominal p", "Alternate hypothesis")
+  for (col in columns) {
+    expect_equal(observed[1, col, drop = TRUE], as.integer(observed[1, col]))
+  }
+
+  # Purposefully omitted "Null hypothesis" from col_vars above
+  expect_false("Null hypothesis" %in% colnames(observed))
 })

--- a/tests/testthat/test-developer-summary.R
+++ b/tests/testthat/test-developer-summary.R
@@ -167,20 +167,123 @@ test_that("The full alpha is correctly carried over", {
   expect_equal(attributes(observed)$full_alpha, a_level)
 })
 
-test_that("col_vars and col_decimals can be passed 1:1", {
+# Maintain previous behavior
+test_that("summary.gs_design() accepts same-length vectors for col_vars and col_decimals", {
   x <- gs_design_ahr()
 
-  observed <- summary(
-    x,
-    col_vars = c("z", "~hr at bound", "nominal p", "Alternate hypothesis"),
-    col_decimals = c(0, 0, 0, 0)
+  # default decimals
+  x_sum <- summary(x)
+  observed <- as.data.frame(x_sum)[, -1:-2]
+  expected <- data.frame(
+    Z = 1.96,
+    `~HR at bound` = 0.795,
+    `Nominal p` = 0.025,
+    `Alternate hypothesis` = 0.9,
+    `Null hypothesis` = 0.025,
+    check.names = FALSE
   )
+  expect_equal(observed, expected)
 
-  columns <- c("Z", "~HR at bound", "Nominal p", "Alternate hypothesis")
-  for (col in columns) {
-    expect_equal(observed[1, col, drop = TRUE], as.integer(observed[1, col]))
-  }
+  # specify the decimals for each variable
+  x_sum <- summary(
+    x,
+    col_vars = c("z", "~hr at bound", "nominal p", "Alternate hypothesis", "Null hypothesis"),
+    col_decimals = c(0, 0, 0, 0, 0)
+  )
+  observed <- as.data.frame(x_sum)[, -1:-2]
+  expected <- data.frame(
+    Z = 2,
+    `~HR at bound` = 1,
+    `Nominal p` = 0,
+    `Alternate hypothesis` = 1,
+    `Null hypothesis` = 0,
+    check.names = FALSE
+  )
+  expect_equal(observed, expected)
 
-  # Purposefully omitted "Null hypothesis" from col_vars above
-  expect_false("Null hypothesis" %in% colnames(observed))
+  # Drop variables and also specify the decimals
+  x_sum <- summary(
+    x,
+    col_vars = c("nominal p", "Null hypothesis"),
+    col_decimals = c(0, 0)
+  )
+  observed <- as.data.frame(x_sum)[, -1:-2]
+  expected <- data.frame(`Nominal p` = 0, `Null hypothesis` = 0, check.names = FALSE)
+  expect_equal(observed, expected)
+
+  # Rearrange variables
+  x_sum <- summary(
+    x,
+    col_vars = c("Null hypothesis", "Alternate hypothesis", "nominal p", "~hr at bound", "z"),
+    col_decimals = c(0, 0, 0, 0, 0)
+  )
+  observed <- as.data.frame(x_sum)[, -1:-2]
+  expected <- data.frame(
+    `Null hypothesis` = 0,
+    `Alternate hypothesis` = 1,
+    `Nominal p` = 0,
+    `~HR at bound` = 1,
+    Z = 2,
+    check.names = FALSE
+  )
+  expect_equal(observed, expected)
+
+  # Throw error if unnamed col_decimals does not match length of col_vars
+  expect_error(
+    summary(
+      x,
+      col_vars = c("Null hypothesis", "Alternate hypothesis", "nominal p"),
+      col_decimals = c(0, 0),
+    ),
+    "summary: please input col_vars and col_decimals in pairs!"
+  )
+})
+
+test_that("summary.gs_design() accepts a named vector for col_decimals", {
+  x <- gs_design_ahr()
+
+  # Specify decimals
+  x_sum <- summary(x, col_decimals = c(z = 0, `nominal p` = 0))
+  observed <- as.data.frame(x_sum)[, -1:-2]
+  expected <- data.frame(
+    Z = 2,
+    `~HR at bound` = 0.795,
+    `Nominal p` = 0,
+    `Alternate hypothesis` = 0.9,
+    `Null hypothesis` = 0.025,
+    check.names = FALSE
+  )
+  expect_equal(observed, expected)
+
+  # Specify decimals and also drop some variables
+  x_sum <- summary(
+      x,
+      col_vars = c("z", "nominal p", "Null hypothesis"),
+      col_decimals = c(z = 0, `nominal p` = 0)
+    )
+  observed <- as.data.frame(x_sum)[, -1:-2]
+  expected <- data.frame(Z = 2, `Nominal p` = 0, `Null hypothesis` = 0.025, check.names = FALSE)
+  expect_equal(observed, expected)
+
+  # Specify decimals and rearrange some variables
+  x_sum <- summary(
+      x,
+      col_vars = c("Null hypothesis", "nominal p", "z"),
+      col_decimals = c(z = 0, `nominal p` = 0)
+    )
+  observed <- as.data.frame(x_sum)[, -1:-2]
+  expected <- data.frame(`Null hypothesis` = 0.025, `Nominal p` = 0, Z = 2, check.names = FALSE)
+  expect_equal(observed, expected)
+
+  # Only drop variables
+  x_sum <- summary(x,col_vars = c("z", "nominal p", "Null hypothesis"))
+  observed <- as.data.frame(x_sum)[, -1:-2]
+  expected <- data.frame(Z = 1.96, `Nominal p` = 0.025, `Null hypothesis` = 0.025, check.names = FALSE)
+  expect_equal(observed, expected)
+
+  # Throw error is col_decimals is unnamed
+  expect_error(
+    summary(x, col_decimals = c(4, 4)),
+    "summary: col_decimals must be a named vector if col_vars is not provided"
+  )
 })

--- a/vignettes/articles/story-update-boundary.Rmd
+++ b/vignettes/articles/story-update-boundary.Rmd
@@ -131,13 +131,7 @@ gs_update_ahr(
   x = x,
   alpha = 0.025
   ) |>
-  summary(
-    col_vars = c(
-      "analysis", "bound", "z", "~hr at bound",
-      "nominal p", "Alternate hypothesis", "Null hypothesis"
-    ),
-    col_decimals = c(NA, NA, 4, 4, 4, 4, 4)
-  ) |>
+  summary(col_decimals = c(z = 4)) |>
   as_gt(title = "Updated design",
         subtitle = "For alternate alpha = 0.025")
 ```
@@ -184,13 +178,7 @@ gs_update_ahr(
   ustime = ustime,
   observed_data = list(observed_data_ia, observed_data_fa)
 ) |>
-  summary(
-    col_vars = c(
-      "analysis", "bound", "z", "~hr at bound",
-      "nominal p", "Alternate hypothesis", "Null hypothesis"
-    ),
-    col_decimals = c(NA, NA, 4, 4, 4, 4, 4)
-  ) |>
+  summary(col_decimals = c(z = 4)) |>
   as_gt(title = "Updated design",
         subtitle = paste0("With observed ", sum(observed_data_ia$event),
                           " events at IA and ", sum(observed_data_fa$event),
@@ -267,13 +255,7 @@ gs_update_ahr(
   x = x,
   alpha = 0.025
   ) |>
-  summary(
-    col_vars = c(
-      "analysis", "bound", "z", "~hr at bound",
-      "nominal p", "Alternate hypothesis", "Null hypothesis"
-    ),
-    col_decimals = c(NA, NA, 4, 4, 4, 4, 4)
-  ) |>
+  summary(col_decimals = c(z = 4)) |>
   as_gt(title = "Updated design",
         subtitle = "For alpha = 0.025")
 ```
@@ -294,13 +276,7 @@ gs_update_ahr(
   lstime = ustime, 
   observed_data = list(observed_data_ia, observed_data_fa)
   ) |>
-  summary(
-    col_vars = c(
-      "analysis", "bound", "z", "~hr at bound",
-      "nominal p", "Alternate hypothesis", "Null hypothesis"
-    ),
-    col_decimals = c(NA, NA, 4, 4, 4, 4, 4)
-  ) |>
+  summary(col_decimals = c(z = 4)) |>
   as_gt(title = "Updated design",
         subtitle = paste0("With observed ", sum(observed_data_ia$event),
                           " events at IA and ", sum(observed_data_fa$event),


### PR DESCRIPTION
Closes #430 

Modeled after #403 

xref: #428

You can now pass a named vector to `col_decimals` to avoid having to repeat the default values of `col_vars` and `col_decimals`

```R
library("gsDesign2")

before <- gs_power_ahr(lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1)) |>
  summary(
    col_vars = c("z", "~hr at bound", "nominal p", "Alternate hypothesis", "Null hypothesis"),
    col_decimals = c(4, 4, 4, 4, 4)
  )

after <- gs_power_ahr(lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1)) |>
  summary(col_decimals = c(z = 4))
## # A tibble: 6 × 7
## # Groups:   Analysis [3]
## Analysis       Bound      Z `~HR at bound` `Nominal p` `Alternate hypothesis` `Null hypothesis`
## <chr>          <chr>  <dbl>          <dbl>       <dbl>                  <dbl>             <dbl>
## 1 Analysis: 1 T… Futi… -1.17           1.54       0.879                  0.0349            0.121 
## 2 Analysis: 1 T… Effi…  2.67           0.374      0.0038                 0.0231            0.0038
## 3 Analysis: 2 T… Futi… -0.663          1.24       0.746                  0.0668            0.266 
## 4 Analysis: 2 T… Effi…  2.29           0.481      0.011                  0.0897            0.0122
## 5 Analysis: 3 T… Futi… -0.227          1.07       0.590                  0.101             0.430 
## 6 Analysis: 3 T… Effi…  2.03           0.560      0.0211                 0.207             0.025

identical(before, after)
## [1] TRUE
```