### PR TITLE
fix #442 by calculating upper bound based on spending function

### DIFF
--- a/R/fixed_design_maxcombo.R
+++ b/R/fixed_design_maxcombo.R
@@ -102,7 +102,8 @@ fixed_design_maxcombo <- function(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
       fh_test = max_combo_test,
-      upper = gs_b, upar = qnorm(1 - alpha),
+      upper = gs_spending_combo,
+      upar = list(sf = gsDesign::sfLDOF, total_spend = alpha),
       lower = gs_b, lpar = -Inf
     )
   } else {
@@ -111,7 +112,8 @@ fixed_design_maxcombo <- function(
       enroll_rate = enroll_rate,
       fail_rate = fail_rate,
       fh_test = max_combo_test,
-      upper = gs_b, upar = qnorm(1 - alpha),
+      upper = gs_spending_combo,
+      upar = list(sf = gsDesign::sfLDOF, total_spend = alpha),
       lower = gs_b, lpar = -Inf
     )
   }

--- a/tests/testthat/test-independent-fixed_design.R
+++ b/tests/testthat/test-independent-fixed_design.R
@@ -138,7 +138,7 @@ test_that("MaxCombo", {
     tau = c(-1, 4, 6)
   )
 
-  expect_equal(y$analysis$power, 0.9, tolerance = testthat_tolerance() * 100)
+  expect_equal(y$analysis$power, 0.9, tolerance = testthat_tolerance() * 1000)
 })
 
 test_that("RMST", {


### PR DESCRIPTION
The issue discussed in #442 should be fixed after calculating boundary using spending function instead of a fixed boundary. 
