### PR TITLE
Fix a typo: `seq_along()` should have been `seq_len()`

### DIFF
--- a/R/to_integer.R
+++ b/R/to_integer.R
@@ -492,7 +492,7 @@ to_integer.gs_design <- function(x, sample_size = TRUE, ...) {
 
   # Make n and event of x_new$analysis exactly integers
   if ("ahr" %in% class(x) || "wlr" %in% class(x)) {
-    for (i in seq_along(n_analysis)) {
+    for (i in seq_len(n_analysis)) {
       if (is_almost_k(x = x_new$analysis$n[i], k = round(x_new$analysis$n[i]))) {
         x_new$analysis$n[i] <- round(x_new$analysis$n[i])
       }
@@ -502,7 +502,7 @@ to_integer.gs_design <- function(x, sample_size = TRUE, ...) {
       }
     }
   } else if ("rd" %in% class(x)) {
-    for (i in seq_along(n_analysis)) {
+    for (i in seq_len(n_analysis)) {
       if (is_almost_k(x = x_new$analysis$n[i], k = round(x_new$analysis$n[i]))) {
         x_new$analysis$n[i] <- round(x_new$analysis$n[i])
       }


### PR DESCRIPTION
This fixes the macOS issue of simtrial on GHA: https://github.com/Merck/simtrial/pull/262

When `n_analysis = 2`, `seq_along(n_analysis)` is `1`, and only the first `n` in `x_new$analysis` is rounded. We should have rounded all elements in `n` that are close enough to integers, so the loop should go from `1` to `n_analysis`, i.e., the looping indices should be `seq_len(n_analysis)`.

This problem was originally introduced by d0159b9ea7b9ba1a5db74e90dde5c5d6c9c5d677.