### PR TITLE
Tweaking as_gt()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.2.19
+Version: 1.1.2.20
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/R/ahr_blinded.R
+++ b/R/ahr_blinded.R
@@ -84,14 +84,14 @@ ahr_blinded <- function(
     hr = c(1, .6),
     ratio = 1) {
   # Input checking
-  if (!is.vector(hr, mode = "numeric") || min(hr) <= 0) {
-    stop("ahr_blinded: hr must be a vector of positive numbers.")
+  if (!is.numeric(hr) || min(hr) <= 0) {
+    stop("'hr' must be a vector of positive numbers.")
   }
-  if (!is.vector(intervals, mode = "numeric") || min(intervals) <= 0) {
-    stop("ahr_blinded: intervals must be a vector of positive numbers.")
+  if (!is.numeric(intervals) || min(intervals) <= 0) {
+    stop("'intervals' must be a vector of positive numbers.")
   }
   if (length(intervals) != length(hr)) {
-    stop("ahr_blinded: the piecewise model specified hr and intervals are not aligned.")
+    stop("the piecewise model specified 'hr' and 'intervals' differ in lengths.")
   }
 
   # Set final element of "intervals" to Inf
@@ -111,11 +111,10 @@ ahr_blinded <- function(
   # Compute adjustment for information
   q_e <- ratio / (1 + ratio)
 
-  ans <- tibble(
+  tibble(
     event = sum(event),
     ahr = exp(-theta),
     theta = theta,
     info0 = sum(event) * (1 - q_e) * q_e
   )
-  return(ans)
 }

--- a/R/ahr_blinded.R
+++ b/R/ahr_blinded.R
@@ -91,7 +91,7 @@ ahr_blinded <- function(
     stop("'intervals' must be a vector of positive numbers.")
   }
   if (length(intervals) != length(hr)) {
-    stop("the piecewise model specified 'hr' and 'intervals' differ in lengths.")
+    stop("the piecewise model specified 'hr' and 'intervals' differ in length.")
   }
 
   # Set final element of "intervals" to Inf

--- a/R/ahr_blinded.R
+++ b/R/ahr_blinded.R
@@ -111,10 +111,11 @@ ahr_blinded <- function(
   # Compute adjustment for information
   q_e <- ratio / (1 + ratio)
 
-  tibble(
+  ans <- tibble(
     event = sum(event),
     ahr = exp(-theta),
     theta = theta,
     info0 = sum(event) * (1 - q_e) * q_e
   )
+  return(ans)
 }

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -80,26 +80,9 @@ as_gt <- function(x, ...) {
 #'   as_gt()
 as_gt.fixed_design <- function(x, title = NULL, footnote = NULL, ...) {
   # get the design method
-  if ("ahr" %in% class(x)) {
-    design_mtd <- "ahr"
-  } else if ("fh" %in% class(x)) {
-    design_mtd <- "fh"
-  } else if ("mb" %in% class(x)) {
-    design_mtd <- "mb"
-  } else if ("lf" %in% class(x)) {
-    design_mtd <- "lf"
-  } else if ("rd" %in% class(x)) {
-    design_mtd <- "rd"
-  } else if ("maxcombo" %in% class(x)) {
-    design_mtd <- "maxcombo"
-  } else if ("milestone" %in% class(x)) {
-    design_mtd <- "milestone"
-  } else if ("rmst" %in% class(x)) {
-    design_mtd <- "rmst"
-  } else if ("rd" %in% class(x)) {
-    design_mtd <- "rd"
-  }
-
+  design_mtd <- intersect(
+    c("ahr", "fh", "mb", "lf", "rd", "maxcombo", "milestone", "rmst"), class(x)
+  )[1]
 
   # set the default title
   if (is.null(title)) {

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -85,38 +85,17 @@ as_gt.fixed_design <- function(x, title = NULL, footnote = NULL, ...) {
   )[1]
 
   # set the default title
-  if (is.null(title)) {
-    title <- switch(design_mtd,
-      "ahr" = {
-        "Fixed Design under AHR Method"
-      },
-      "fh" = {
-        "Fixed Design under Fleming-Harrington Method"
-      },
-      "mb" = {
-        "Fixed Design under Magirr-Burman Method"
-      },
-      "lf" = {
-        "Fixed Design under Lachin and Foulkes Method"
-      },
-      "rd" = {
-        "Fixed Design of Risk Difference under Farrington-Manning Method"
-      },
-      "maxcombo" = {
-        "Fixed Design under MaxCombo Method"
-      },
-      "milestone" = {
-        "Fixed Design under Milestone Method"
-      },
-      "rmst" = {
-        "Fixed Design under Restricted Mean Survival Time Method"
-      },
-      "rd" = {
-        "Fixed Design of Risk Difference"
-      }
-    )
-  }
-
+  if (is.null(title)) title <- switch(
+    design_mtd,
+    "ahr" = "Fixed Design under AHR Method",
+    "fh" = "Fixed Design under Fleming-Harrington Method",
+    "mb" = "Fixed Design under Magirr-Burman Method",
+    "lf" = "Fixed Design under Lachin and Foulkes Method",
+    "rd" = "Fixed Design of Risk Difference under Farrington-Manning Method",
+    "maxcombo" = "Fixed Design under MaxCombo Method",
+    "milestone" = "Fixed Design under Milestone Method",
+    "rmst" = "Fixed Design under Restricted Mean Survival Time Method"
+  )
 
   # set the default footnote
   if (is.null(footnote)) {

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -259,33 +259,20 @@ as_gt.gs_design <- function(
 
   # Set defaults ----
   # set different default title to different methods
-  if (method == "ahr" && is.null(title)) {
-    title <- "Bound summary for AHR design"
-  }
-  if (method == "wlr" && is.null(title)) {
-    title <- "Bound summary for WLR design"
-  }
-  if (method == "combo" && is.null(title)) {
-    title <- "Bound summary for MaxCombo design"
-  }
-
-  if (method == "rd" && is.null(title)) {
-    title <- "Bound summary of Binary Endpoint"
-  }
+  if (is.null(title)) title <- paste("Bound summary", switch(
+    method,
+    "ahr" = "for AHR design", "wlr" = "for WLR design",
+    "combo" = "for MaxCombo design", "rd" = "of Binary Endpoint"
+  ))
 
   # set different default subtitle to different methods
-  if (method == "ahr" && is.null(subtitle)) {
-    subtitle <- "AHR approximations of ~HR at bound"
-  }
-  if (method == "wlr" && is.null(subtitle)) {
-    subtitle <- "WLR approximation of ~wHR at bound"
-  }
-  if (method == "combo" && is.null(subtitle)) {
-    subtitle <- "MaxCombo approximation"
-  }
-  if (method == "rd" && is.null(subtitle)) {
-    subtitle <- "measured by risk difference"
-  }
+  if (is.null(subtitle)) subtitle <- switch(
+    method,
+    "ahr" = "AHR approximations of ~HR at bound",
+    "wlr" = "WLR approximation of ~wHR at bound",
+    "combo" = "MaxCombo approximation",
+    "rd" = "measured by risk difference"
+  )
 
   # set different default columns to display
   if (is.null(display_columns)) {

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -373,34 +373,29 @@ as_gt.gs_design <- function(
   }
 
   ## if it is non-binding design
-  if (x_non_binding && (x_alpha < full_alpha)) {
-    x <- x %>%
-      gt::tab_footnote(
-        footnote = paste0(
-          "Cumulative alpha for final analysis ",
-          "(", format(x_alpha, scientific = FALSE), ") ",
-          "is less than the full alpha ",
-          "(", format(full_alpha, scientific = FALSE), ") ",
-          "when the futility bound is non-binding. ",
-          "The smaller value subtracts the probability of ",
-          "crossing a futility bound before ",
-          "crossing an efficacy bound at a later analysis ",
-          "(",
-          format(full_alpha, scientific = FALSE),
-          " - ",
-          format(full_alpha - x_alpha, scientific = FALSE),
-          " = ",
-          format(x_alpha, scientific = FALSE),
-          ") ",
-          "under the null hypothesis."
-        ),
-        locations = gt::cells_body(
-          columns = colname_spannersub[2],
-          rows = (substring(x_old$Analysis, 1, 11) == paste0("Analysis: ", max(x_k))) &
-            (x_old$Bound == display_bound[1])
-        )
-      )
-  }
+  if (x_non_binding && x_alpha < full_alpha) x <- gt::tab_footnote(
+    x,
+    footnote = footnote_non_binding(x_alpha, full_alpha),
+    locations = gt::cells_body(
+      columns = colname_spannersub[2],
+      rows = substr(x_old$Analysis, 1, 11) == paste0("Analysis: ", max(x_k)) &
+        x_old$Bound == display_bound[1]
+    )
+  )
 
-  return(x)
+  x
+}
+
+footnote_non_binding <- function(x_alpha, full_alpha) {
+  a1 <- format(x_alpha, scientific = FALSE)
+  a2 <- format(full_alpha, scientific = FALSE)
+  a3 <- format(full_alpha - x_alpha, scientific = FALSE)
+  paste0(
+    "Cumulative alpha for final analysis ",
+    "(", a1, ") ", "is less than the full alpha ", "(", a2, ") ",
+    "when the futility bound is non-binding. ",
+    "The smaller value subtracts the probability of crossing a futility bound ",
+    "before crossing an efficacy bound at a later analysis ",
+    "(", a2, " - ", a3, " = ", a1, ") ", "under the null hypothesis."
+  )
 }

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -98,53 +98,32 @@ as_gt.fixed_design <- function(x, title = NULL, footnote = NULL, ...) {
   )
 
   # set the default footnote
-  if (is.null(footnote)) {
-    footnote <- switch(design_mtd,
-      "ahr" = {
-        "Power computed with average hazard ratio method."
-      },
-      "fh" = {
-        paste0(
-          "Power for Fleming-Harrington test ",
-          substr(x$Design, 19, nchar(x$Design)),
-          " using method of Yung and Liu."
-        )
-      },
-      "mb" = {
-        paste0(
-          "Power for ",
-          x$Design,
-          " computed with method of Yung and Liu."
-        )
-      },
-      "lf" = {
-        "Power using Lachin and Foulkes method applied
-        using expected average hazard ratio (AHR) at time of planned analysis."
-      },
-      "rd" = {
-        "Risk difference power without continuity correction using method of Farrington and Manning."
-      },
-      "maxcombo" = {
-        paste0(
-          "Power for MaxCombo test with Fleming-Harrington tests",
-          substr(x$Design, 9, nchar(x$Design)), "."
-        )
-      },
-      "milestone" = {
-        paste0("Power for ", x$Design, " computed with method of Yung and Liu.")
-      },
-      "rmst" = {
-        paste0("Power for ", x$Design, " computed with method of Yung and Liu.")
-      }
-    )
-  }
+  if (is.null(footnote)) footnote <- switch(
+    design_mtd,
+    "ahr" = "Power computed with average hazard ratio method.",
+    "fh" = paste(
+      "Power for Fleming-Harrington test", substring(x$Design, 19),
+      "using method of Yung and Liu."
+    ),
+    "lf" = paste(
+      "Power using Lachin and Foulkes method applied using expected",
+      "average hazard ratio (AHR) at time of planned analysis."
+    ),
+    "rd" = paste(
+      "Risk difference power without continuity correction using method of",
+      "Farrington and Manning."
+    ),
+    "maxcombo" = paste0(
+      "Power for MaxCombo test with Fleming-Harrington tests ",
+      substring(x$Design, 9), "."
+    ),
+    # for mb, milestone, and rmst
+    paste("Power for", x$Design, "computed with method of Yung and Liu.")
+  )
 
-  ans <- x %>%
-    gt::gt() %>%
+  gt::gt(x) %>%
     gt::tab_header(title = title) %>%
     gt::tab_footnote(footnote = footnote, locations = gt::cells_title(group = "title"))
-
-  return(ans)
 }
 
 #' @rdname as_gt

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -251,9 +251,7 @@ as_gt.gs_design <- function(
 
   x_non_binding <- inherits(x, "non_binding")
 
-  x_k <- lapply(x$Analysis, function(x) {
-    return(as.numeric(substring(x, 11, 11)))
-  }) %>% unlist()
+  x_k <- as.numeric(substr(x$Analysis, 11, 11))
 
   if (!display_inf_bound) {
     x <- x %>% filter(!is.infinite(Z))

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -245,7 +245,7 @@ as_gt.gs_design <- function(
     ...) {
 
   method <- class(x)[class(x) %in% c("ahr", "wlr", "combo", "rd")]
-  full_alpha <- attributes(x)$full_alpha
+  full_alpha <- attr(x, "full_alpha")
 
   x_alpha <- max((x %>% dplyr::filter(Bound == display_bound[1]))[[colname_spannersub[2]]])
 

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -335,9 +335,7 @@ as_gt.gs_design <- function(
   )
 
   # Filter out inf bound ----
-  x <- x %>%
-    subset(!is.na(`Alternate hypothesis`)) %>%
-    subset(!is.na(`Null hypothesis`))
+  x <- subset(x, !is.na(`Alternate hypothesis`) & !is.na(`Null hypothesis`))
 
   # Add spanner ----
   names(x)[names(x) == "Alternate hypothesis"] <- colname_spannersub[1]

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -285,11 +285,10 @@ as_gt.gs_design <- function(
   if (any(i <- display_columns == "Probability"))
     display_columns <- c(display_columns[!i], "Alternate hypothesis", "Null hypothesis")
   ## check if the `display_columns` are included in `x` output
-  if (sum(!(display_columns %in% names(x))) >= 1) {
-    stop("as_gt: the variable names in display_columns is not outputted in the summary_bound object!")
-  } else {
-    x <- x %>% dplyr::select(dplyr::all_of(display_columns))
-  }
+  if (!all(display_columns %in% names(x))) stop(
+    "not all variable names in 'display_columns' are in the summary_bound object!"
+  )
+  x <- x[, display_columns]
 
   # set different default footnotes to different methods
   if (method == "ahr" && is.null(footnote)) {

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -282,10 +282,8 @@ as_gt.gs_design <- function(
   )
   # filter the columns to display as the output
   ## if `Probability` is selected to output, then transform it to `c("Alternate hypothesis", "Null hypothesis")`
-  if ("Probability" %in% display_columns) {
-    display_columns <- display_columns[!display_columns == "Probability"]
-    display_columns <- c(display_columns, "Alternate hypothesis", "Null hypothesis")
-  }
+  if (any(i <- display_columns == "Probability"))
+    display_columns <- c(display_columns[!i], "Alternate hypothesis", "Null hypothesis")
   ## check if the `display_columns` are included in `x` output
   if (sum(!(display_columns %in% names(x))) >= 1) {
     stop("as_gt: the variable names in display_columns is not outputted in the summary_bound object!")

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -338,8 +338,8 @@ as_gt.gs_design <- function(
   x <- subset(x, !is.na(`Alternate hypothesis`) & !is.na(`Null hypothesis`))
 
   # Add spanner ----
-  names(x)[names(x) == "Alternate hypothesis"] <- colname_spannersub[1]
-  names(x)[names(x) == "Null hypothesis"] <- colname_spannersub[2]
+  i <- match(c("Alternate hypothesis", "Null hypothesis"), names(x))
+  names(x)[i] <- colname_spannersub
 
   x <- x %>%
     subset(Bound %in% display_bound) %>%

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -275,29 +275,11 @@ as_gt.gs_design <- function(
   )
 
   # set different default columns to display
-  if (is.null(display_columns)) {
-    if (method == "ahr") {
-      display_columns <- c(
-        "Analysis", "Bound", "Z", "Nominal p",
-        "~HR at bound", "Alternate hypothesis", "Null hypothesis"
-      )
-    } else if (method == "wlr") {
-      display_columns <- c(
-        "Analysis", "Bound", "Z", "Nominal p",
-        "~wHR at bound", "Alternate hypothesis", "Null hypothesis"
-      )
-    } else if (method == "combo") {
-      display_columns <- c(
-        "Analysis", "Bound", "Z", "Nominal p",
-        "Alternate hypothesis", "Null hypothesis"
-      )
-    } else if (method == "rd") {
-      display_columns <- c(
-        "Analysis", "Bound", "Z", "Nominal p",
-        "~Risk difference at bound", "Alternate hypothesis", "Null hypothesis"
-      )
-    }
-  }
+  if (is.null(display_columns)) display_columns <- c(
+    "Analysis", "Bound", "Z", "Nominal p",
+    sprintf("%s at bound", switch(method, ahr = "~HR", wlr = "~wHR", rd = "~Risk difference")),
+    "Alternate hypothesis", "Null hypothesis"
+  )
   # filter the columns to display as the output
   ## if `Probability` is selected to output, then transform it to `c("Alternate hypothesis", "Null hypothesis")`
   if ("Probability" %in% display_columns) {

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -85,12 +85,12 @@ as_gt.fixed_design <- function(x, title = NULL, footnote = NULL, ...) {
   )[1]
 
   # set the default title
-  if (is.null(title)) title <- sprintf("Fixed Design under %s Method", switch(
+  if (is.null(title)) title <- sprintf("Fixed Design %s Method", switch(
     design_mtd,
-    ahr = "AHR", fh = "Fleming-Harrington", mb = "Magirr-Burman",
-    lf = "Lachin and Foulkes", maxcombo = "MaxCombo", milestone = "Milestone",
-    rd = "Fixed Design of Risk Difference under Farrington-Manning",
-    rmst = "Restricted Mean Survival Time"
+    ahr = "under AHR", fh = "under Fleming-Harrington", mb = "under Magirr-Burman",
+    lf = "under Lachin and Foulkes", maxcombo = "under MaxCombo",
+    milestone = "under Milestone", rmst = "under Restricted Mean Survival Time",
+    rd = "of Risk Difference under Farrington-Manning"
   ))
 
   # set the default footnote

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -117,9 +117,11 @@ as_gt.fixed_design <- function(x, title = NULL, footnote = NULL, ...) {
     paste("Power for", x$Design, "computed with method of Yung and Liu.")
   )
 
-  gt::gt(x) %>%
+  ans <- gt::gt(x) %>%
     gt::tab_header(title = title) %>%
     gt::tab_footnote(footnote = footnote, locations = gt::cells_title(group = "title"))
+
+  return(ans)
 }
 
 #' @rdname as_gt
@@ -379,7 +381,7 @@ as_gt.gs_design <- function(
     )
   )
 
-  x
+  return(x)
 }
 
 footnote_non_binding <- function(x_alpha, full_alpha) {

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -96,20 +96,20 @@ as_gt.fixed_design <- function(x, title = NULL, footnote = NULL, ...) {
   # set the default footnote
   if (is.null(footnote)) footnote <- switch(
     design_mtd,
-    "ahr" = "Power computed with average hazard ratio method.",
-    "fh" = paste(
+    ahr = "Power computed with average hazard ratio method.",
+    fh = paste(
       "Power for Fleming-Harrington test", substring(x$Design, 19),
       "using method of Yung and Liu."
     ),
-    "lf" = paste(
+    lf = paste(
       "Power using Lachin and Foulkes method applied using expected",
       "average hazard ratio (AHR) at time of planned analysis."
     ),
-    "rd" = paste(
+    rd = paste(
       "Risk difference power without continuity correction using method of",
       "Farrington and Manning."
     ),
-    "maxcombo" = paste0(
+    maxcombo = paste0(
       "Power for MaxCombo test with Fleming-Harrington tests ",
       substring(x$Design, 9), "."
     ),
@@ -257,17 +257,17 @@ as_gt.gs_design <- function(
   # set different default title to different methods
   if (is.null(title)) title <- paste("Bound summary", switch(
     method,
-    "ahr" = "for AHR design", "wlr" = "for WLR design",
-    "combo" = "for MaxCombo design", "rd" = "of Binary Endpoint"
+    ahr = "for AHR design", wlr = "for WLR design",
+    combo = "for MaxCombo design", rd = "of Binary Endpoint"
   ))
 
   # set different default subtitle to different methods
   if (is.null(subtitle)) subtitle <- switch(
     method,
-    "ahr" = "AHR approximations of ~HR at bound",
-    "wlr" = "WLR approximation of ~wHR at bound",
-    "combo" = "MaxCombo approximation",
-    "rd" = "measured by risk difference"
+    ahr = "AHR approximations of ~HR at bound",
+    wlr = "WLR approximation of ~wHR at bound",
+    combo = "MaxCombo approximation",
+    rd = "measured by risk difference"
   )
 
   # set different default columns to display
@@ -289,7 +289,7 @@ as_gt.gs_design <- function(
   # set different default footnotes to different methods
   if (is.null(footnote)) footnote <- switch(
     method,
-    "ahr" = list(
+    ahr = list(
       content = c(
         if (i1 <- "~HR at bound" %in% display_columns)
           "Approximate hazard ratio to cross bound.",
@@ -300,7 +300,7 @@ as_gt.gs_design <- function(
       location = c(if (i1) "~HR at bound", if (i2) "Nominal p"),
       attr = c(if (i1) "colname", if (i2) "colname")
     ),
-    "wlr" = list(
+    wlr = list(
       content = c(
         if (i1 <- "~wHR at bound" %in% display_columns)
           "Approximate hazard ratio to cross bound.",
@@ -312,7 +312,7 @@ as_gt.gs_design <- function(
       location = c(if (i1) "~wHR at bound", if (i2) "Nominal p"),
       attr = c(if (i1) "colname", if (i2) "colname", "analysis")
     ),
-    "combo" = list(
+    combo = list(
       content = c(
         if (i2 <- "Nominal p" %in% display_columns)
           "One-sided p-value for experimental vs control treatment.
@@ -321,7 +321,7 @@ as_gt.gs_design <- function(
       location = if (i2) "Nominal p",
       attr = c(if (i2) "colname", "analysis")
     ),
-    "rd" = list(
+    rd = list(
       content = if (i2 <- "Nominal p" %in% display_columns)
         "One-sided p-value for experimental vs control treatment.
         Value < 0.5 favors experimental, > 0.5 favors control.",

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -291,84 +291,48 @@ as_gt.gs_design <- function(
   x <- x[, display_columns]
 
   # set different default footnotes to different methods
-  if (method == "ahr" && is.null(footnote)) {
-    footnote <- list(
+  if (is.null(footnote)) footnote <- switch(
+    method,
+    "ahr" = list(
       content = c(
-        ifelse("~HR at bound" %in% display_columns,
-          "Approximate hazard ratio to cross bound.", NA
-        ),
-        ifelse("Nominal p" %in% display_columns,
+        if (i1 <- "~HR at bound" %in% display_columns)
+          "Approximate hazard ratio to cross bound.",
+        if (i2 <- "Nominal p" %in% display_columns)
           "One-sided p-value for experimental vs control treatment.
-          Value < 0.5 favors experimental, > 0.5 favors control.", NA
-        )
+          Value < 0.5 favors experimental, > 0.5 favors control."
       ),
-      location = c(
-        ifelse("~HR at bound" %in% display_columns, "~HR at bound", NA),
-        ifelse("Nominal p" %in% display_columns, "Nominal p", NA)
-      ),
-      attr = c(
-        ifelse("~HR at bound" %in% display_columns, "colname", NA),
-        ifelse("Nominal p" %in% display_columns, "colname", NA)
-      )
-    )
-    footnote <- lapply(footnote, function(x) x[!is.na(x)])
-  }
-  if (method == "wlr" && is.null(footnote)) {
-    footnote <- list(
+      location = c(if (i1) "~HR at bound", if (i2) "Nominal p"),
+      attr = c(if (i1) "colname", if (i2) "colname")
+    ),
+    "wlr" = list(
       content = c(
-        ifelse("~wHR at bound" %in% display_columns,
-          "Approximate hazard ratio to cross bound.", NA
-        ),
-        ifelse("Nominal p" %in% display_columns,
+        if (i1 <- "~wHR at bound" %in% display_columns)
+          "Approximate hazard ratio to cross bound.",
+        if (i2 <- "Nominal p" %in% display_columns)
           "One-sided p-value for experimental vs control treatment.
-          Value < 0.5 favors experimental, > 0.5 favors control.", NA
-        ),
+          Value < 0.5 favors experimental, > 0.5 favors control.",
         "wAHR is the weighted AHR."
       ),
-      location = c(
-        ifelse("~wHR at bound" %in% display_columns, "~wHR at bound", NA),
-        ifelse("Nominal p" %in% display_columns, "Nominal p", NA),
-        NA
-      ),
-      attr = c(
-        ifelse("~wHR at bound" %in% display_columns, "colname", NA),
-        ifelse("Nominal p" %in% display_columns, "colname", NA),
-        "analysis"
-      )
-    )
-    footnote <- lapply(footnote, function(x) x[!is.na(x)])
-  }
-  if (method == "combo" && is.null(footnote)) {
-    footnote <- list(
+      location = c(if (i1) "~wHR at bound", if (i2) "Nominal p"),
+      attr = c(if (i1) "colname", if (i2) "colname", "analysis")
+    ),
+    "combo" = list(
       content = c(
-        ifelse("Nominal p" %in% display_columns,
+        if (i2 <- "Nominal p" %in% display_columns)
           "One-sided p-value for experimental vs control treatment.
-               Value < 0.5 favors experimental, > 0.5 favors control.", NA
-        ),
-        "EF is event fraction. AHR  is under regular weighted log rank test."
-      ),
-      location = c(
-        ifelse("Nominal p" %in% display_columns, "Nominal p", NA),
-        NA
-      ),
-      attr = c(
-        ifelse("Nominal p" %in% display_columns, "colname", NA),
-        "analysis"
-      )
-    )
-    footnote <- lapply(footnote, function(x) x[!is.na(x)])
-  }
-  if (method == "rd" && is.null(footnote)) {
-    footnote <- list(
-      content = c(ifelse("Nominal p" %in% display_columns,
+          Value < 0.5 favors experimental, > 0.5 favors control.",
+        "EF is event fraction. AHR  is under regular weighted log rank test."),
+      location = if (i2) "Nominal p",
+      attr = c(if (i2) "colname", "analysis")
+    ),
+    "rd" = list(
+      content = if (i2 <- "Nominal p" %in% display_columns)
         "One-sided p-value for experimental vs control treatment.
-                         Value < 0.5 favors experimental, > 0.5 favors control.", NA
-      )),
-      location = c(ifelse("Nominal p" %in% display_columns, "Nominal p", NA)),
-      attr = c(ifelse("Nominal p" %in% display_columns, "colname", NA))
+        Value < 0.5 favors experimental, > 0.5 favors control.",
+      location = if (i2) "Nominal p",
+      attr = if (i2) "colname"
     )
-    footnote <- lapply(footnote, function(x) x[!is.na(x)])
-  }
+  )
 
   # Filter out inf bound ----
   x <- x %>%

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -244,7 +244,7 @@ as_gt.gs_design <- function(
     display_inf_bound = FALSE,
     ...) {
 
-  method <- class(x)[class(x) %in% c("ahr", "wlr", "combo", "rd")]
+  method <- intersect(class(x), c("ahr", "wlr", "combo", "rd"))[1]
   full_alpha <- attr(x, "full_alpha")
 
   x_alpha <- max((x %>% dplyr::filter(Bound == display_bound[1]))[[colname_spannersub[2]]])

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -249,7 +249,7 @@ as_gt.gs_design <- function(
 
   x_alpha <- max((x %>% dplyr::filter(Bound == display_bound[1]))[[colname_spannersub[2]]])
 
-  x_non_binding <- "non_binding" %in% class(x)
+  x_non_binding <- inherits(x, "non_binding")
 
   x_k <- lapply(x$Analysis, function(x) {
     return(as.numeric(substring(x, 11, 11)))

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -85,17 +85,13 @@ as_gt.fixed_design <- function(x, title = NULL, footnote = NULL, ...) {
   )[1]
 
   # set the default title
-  if (is.null(title)) title <- switch(
+  if (is.null(title)) title <- sprintf("Fixed Design under %s Method", switch(
     design_mtd,
-    "ahr" = "Fixed Design under AHR Method",
-    "fh" = "Fixed Design under Fleming-Harrington Method",
-    "mb" = "Fixed Design under Magirr-Burman Method",
-    "lf" = "Fixed Design under Lachin and Foulkes Method",
-    "rd" = "Fixed Design of Risk Difference under Farrington-Manning Method",
-    "maxcombo" = "Fixed Design under MaxCombo Method",
-    "milestone" = "Fixed Design under Milestone Method",
-    "rmst" = "Fixed Design under Restricted Mean Survival Time Method"
-  )
+    ahr = "AHR", fh = "Fleming-Harrington", mb = "Magirr-Burman",
+    lf = "Lachin and Foulkes", maxcombo = "MaxCombo", milestone = "Milestone",
+    rd = "Fixed Design of Risk Difference under Farrington-Manning",
+    rmst = "Restricted Mean Survival Time"
+  ))
 
   # set the default footnote
   if (is.null(footnote)) footnote <- switch(

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -353,43 +353,23 @@ as_gt.gs_design <- function(
     gt::tab_header(title = title, subtitle = subtitle)
 
   # Add footnotes ----
-  if (!is.null(footnote$content)) {
-    if (length(footnote$content) != 0) {
-      for (i in seq_along(footnote$content)) {
-        # if the footnotes is added on the colnames
-        if (footnote$attr[i] == "colname") {
-          x <- x %>%
-            gt::tab_footnote(
-              footnote = footnote$content[i],
-              locations = gt::cells_column_labels(columns = footnote$location[i])
-            )
-        }
-        # if the footnotes is added on the title/subtitle
-        if (footnote$attr[i] == "title" || footnote$attr[i] == "subtitle") {
-          x <- x %>%
-            gt::tab_footnote(
-              footnote = footnote$content[i],
-              locations = gt::cells_title(group = footnote$attr[i])
-            )
-        }
-        # if the footnotes is added on the analysis summary row, which is a grouping variable, i.e., Analysis
-        if (footnote$attr[i] == "analysis") {
-          x <- x %>%
-            gt::tab_footnote(
-              footnote = footnote$content[i],
-              locations = gt::cells_row_groups(groups = dplyr::starts_with("Analysis"))
-            )
-        }
-        # if the footnotes is added on the column spanner
-        if (footnote$attr[i] == "spanner") {
-          x <- x %>%
-            gt::tab_footnote(
-              footnote = footnote$content[i],
-              locations = gt::cells_column_spanners(spanners = colname_spanner)
-            )
-        }
-      }
+  for (i in seq_along(footnote$content)) {
+    att <- footnote$attr[i]
+    loc <- if (att == "colname") {
+      # footnotes are added on the colnames
+      gt::cells_column_labels(columns = footnote$location[i])
+    } else if (att %in% c("title", "subtitle")) {
+      # on the title/subtitle
+      gt::cells_title(group = att)
+    } else if (att == "analysis") {
+      # on the analysis summary row, which is a grouping variable, i.e., Analysis
+      gt::cells_row_groups(groups = dplyr::starts_with("Analysis"))
+    } else if (att == "spanner") {
+      # on the column spanner
+      gt::cells_column_spanners(spanners = colname_spanner)
     }
+    if (!is.null(loc))
+      x <- gt::tab_footnote(x, footnote = footnote$content[i], locations = loc)
   }
 
   ## if it is non-binding design

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -247,15 +247,13 @@ as_gt.gs_design <- function(
   method <- intersect(class(x), c("ahr", "wlr", "combo", "rd"))[1]
   full_alpha <- attr(x, "full_alpha")
 
-  x_alpha <- max((x %>% dplyr::filter(Bound == display_bound[1]))[[colname_spannersub[2]]])
+  x_alpha <- max(filter(x, Bound == display_bound[1])[[colname_spannersub[2]]])
 
   x_non_binding <- inherits(x, "non_binding")
 
   x_k <- as.numeric(substr(x$Analysis, 11, 11))
 
-  if (!display_inf_bound) {
-    x <- x %>% filter(!is.infinite(Z))
-  }
+  if (!display_inf_bound) x <- filter(x, !is.infinite(Z))
 
   x_old <- x
 

--- a/R/as_rtf.R
+++ b/R/as_rtf.R
@@ -708,30 +708,13 @@ as_rtf.gs_design <- function(
       " {^", intToUtf8(alpha_utf_int), "}"
     )
 
-    footnote_non_binding <- paste0(
+    footnote_nb <- paste0(
       "{\\super ", intToUtf8(alpha_utf_int), "} ",
-      "Cumulative alpha for final analysis ",
-      "(", format(x_alpha, scientific = FALSE), ") ",
-      "is less than the full alpha ",
-      "(", format(full_alpha, scientific = FALSE), ") ",
-      "when the futility bound is non-binding. ",
-      "The smaller value subtracts the probability of ",
-      "crossing a futility bound before ",
-      "crossing an efficacy bound at a later analysis ",
-      "(",
-      format(full_alpha, scientific = FALSE),
-      " - ",
-      format(full_alpha - x_alpha, scientific = FALSE),
-      " = ",
-      format(x_alpha, scientific = FALSE),
-      ") ",
-      "under the null hypothesis."
+      footnote_non_binding(x_alpha, full_alpha)
     )
 
-    if (!is.null(footnotes)) {
-      footnotes <- paste0(footnotes, "\\line", footnote_non_binding)
-    } else {
-      footnotes <- footnote_non_binding
+    footnotes <- if (is.null(footnotes)) footnote_nb else {
+      paste0(footnotes, "\\line", footnote_nb)
     }
   }
 

--- a/tests/testthat/_snaps/independent_as_gt.md
+++ b/tests/testthat/_snaps/independent_as_gt.md
@@ -223,7 +223,7 @@
     \end{longtable}
     \begin{minipage}{\linewidth}
     \textsuperscript{\textit{1}}One-sided p-value for experimental vs control treatment.
-                   Value < 0.5 favors experimental, > 0.5 favors control.\\
+              Value < 0.5 favors experimental, > 0.5 favors control.\\
     \textsuperscript{\textit{2}}EF is event fraction. AHR  is under regular weighted log rank test.\\
     \end{minipage}
     \endgroup
@@ -250,7 +250,7 @@
     \end{longtable}
     \begin{minipage}{\linewidth}
     \textsuperscript{\textit{1}}One-sided p-value for experimental vs control treatment.
-                             Value < 0.5 favors experimental, > 0.5 favors control.\\
+            Value < 0.5 favors experimental, > 0.5 favors control.\\
     \end{minipage}
     \endgroup
 
@@ -285,7 +285,7 @@
     \end{longtable}
     \begin{minipage}{\linewidth}
     \textsuperscript{\textit{1}}One-sided p-value for experimental vs control treatment.
-                             Value < 0.5 favors experimental, > 0.5 favors control.\\
+            Value < 0.5 favors experimental, > 0.5 favors control.\\
     \textsuperscript{\textit{2}}Cumulative alpha for final analysis (0.0238) is less than the full alpha (0.025) when the futility bound is non-binding. The smaller value subtracts the probability of crossing a futility bound before crossing an efficacy bound at a later analysis (0.025 - 0.0012 = 0.0238) under the null hypothesis.\\
     \end{minipage}
     \endgroup


### PR DESCRIPTION
I'm looking at the R scripts by alphabetical order, and reduced ~180 lines of code in `as_gt()`. Again, the changes may be easier to understand if you read the commits one by one.

In some places, I'm using my personal style (e.g., for line breaks and indentation), and happy to follow the style that other colleagues are comfortable with. In general, I tend to make the code a little compact so I can scroll less when reading the code.

I also realized `as_rtf()`'s source code is very similar to `as_gt()`, and perhaps can cut out more lines there lines after factoring out the common parts.