### PR TITLE
Let `to_integer()` always produce integer `analysis$n` and `analysis$event`

### DIFF
--- a/R/to_integer.R
+++ b/R/to_integer.R
@@ -200,13 +200,8 @@ to_integer.fixed_design <- function(x, sample_size = TRUE, ...) {
 
   # Make n and event of ans$analysis exactly integers
   if ("fixed_design" %in% class(ans)) {
-    if (almost_equal(x = ans$analysis$n, k = round(ans$analysis$n))) {
-      ans$analysis$n <- round(ans$analysis$n)
-    }
-
-    if (almost_equal(x = ans$analysis$event, k = round(ans$analysis$event))) {
-      ans$analysis$event <- round(ans$analysis$event)
-    }
+    ans$analysis$n <- round(ans$analysis$n)
+    ans$analysis$event <- round(ans$analysis$event)
   }
 
   return(ans)
@@ -431,8 +426,8 @@ to_integer.gs_design <- function(x, sample_size = TRUE, ...) {
   }
 
   # Make n and event of x_new$analysis exactly integers
-  x_new$analysis$n <- round2(x_new$analysis$n)
-  if (!is_rd) x_new$analysis$event <- round2(x_new$analysis$event)
+  x_new$analysis$n <- round(x_new$analysis$n)
+  if (!is_rd) x_new$analysis$event <- round(x_new$analysis$event)
 
   return(x_new)
 }

--- a/R/utility_wlr.R
+++ b/R/utility_wlr.R
@@ -276,11 +276,3 @@ gs_sigma2_wlr <- function(arm0,
 almost_equal <- function(x, k, tol = .Machine$double.eps^0.5) {
   abs(x - k) < tol
 }
-
-# Round a number only if it is close enough to the rounded value
-round2 <- function(x) {
-  y <- round(x)
-  i <- almost_equal(x, y)
-  x[i] <- y[i]
-  x
-}


### PR DESCRIPTION
Following the discussion at https://github.com/Merck/gsDesign2/pull/447#issuecomment-2276216039, I suggest that we round `n` and `event` without testing near equality because in theory, `n` should be nearly equal to `round(n)` (same for `event`). My understanding could be wrong, though.