### PR TITLE
Wrap long lines in Rd

### DIFF
--- a/R/gs_spending_combo.R
+++ b/R/gs_spending_combo.R
@@ -78,13 +78,16 @@
 #' gs_spending_combo(par, info = 1:3 / 3)
 #'
 #' # Truncated, trimmed and gapped spending functions
-#' par <- list(sf = gsDesign::sfTruncated, total_spend = 0.025, param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
+#' par <- list(sf = gsDesign::sfTruncated, total_spend = 0.025,
+#'   param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
 #' gs_spending_combo(par, info = 1:3 / 3)
 #'
-#' par <- list(sf = gsDesign::sfTrimmed, total_spend = 0.025, param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
+#' par <- list(sf = gsDesign::sfTrimmed, total_spend = 0.025,
+#'   param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
 #' gs_spending_combo(par, info = 1:3 / 3)
 #'
-#' par <- list(sf = gsDesign::sfGapped, total_spend = 0.025, param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
+#' par <- list(sf = gsDesign::sfGapped, total_spend = 0.025,
+#'   param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
 #' gs_spending_combo(par, info = 1:3 / 3)
 #'
 #' # Xi and Gallo conditional error spending functions

--- a/man/gs_spending_combo.Rd
+++ b/man/gs_spending_combo.Rd
@@ -80,13 +80,16 @@ par <- list(sf = gsDesign::sfPoints, total_spend = 0.025, param = c(.25, .25))
 gs_spending_combo(par, info = 1:3 / 3)
 
 # Truncated, trimmed and gapped spending functions
-par <- list(sf = gsDesign::sfTruncated, total_spend = 0.025, param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
+par <- list(sf = gsDesign::sfTruncated, total_spend = 0.025,
+  param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
 gs_spending_combo(par, info = 1:3 / 3)
 
-par <- list(sf = gsDesign::sfTrimmed, total_spend = 0.025, param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
+par <- list(sf = gsDesign::sfTrimmed, total_spend = 0.025,
+  param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
 gs_spending_combo(par, info = 1:3 / 3)
 
-par <- list(sf = gsDesign::sfGapped, total_spend = 0.025, param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
+par <- list(sf = gsDesign::sfGapped, total_spend = 0.025,
+  param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
 gs_spending_combo(par, info = 1:3 / 3)
 
 # Xi and Gallo conditional error spending functions


### PR DESCRIPTION
Otherwise we will have a `NOTE` in `R CMD check`:

```
* checking Rd line widths ... NOTE
Rd file 'gs_spending_combo.Rd':
  \examples lines wider than 100 characters:
     par <- list(sf = gsDesign::sfTruncated, total_spend = 0.025, param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
     par <- list(sf = gsDesign::sfTrimmed, total_spend = 0.025, param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
     par <- list(sf = gsDesign::sfGapped, total_spend = 0.025, param = list(trange = c(.2, .8), sf = gsDesign::sfHSD, param = 1))
These lines will be truncated in the PDF manual.
```