### PR TITLE
Remove the `full_alpha` argument from `as_rtf.gs_design()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.2.21
+Version: 1.1.2.22
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -251,7 +251,6 @@ as_gt.gs_design <- function(
     ...) {
 
   x_old <- x
-  full_alpha <- attr(x, "full_alpha")
   parts <- gsd_parts(
     x, title, subtitle, colname_spannersub, footnote,
     display_bound, display_columns, display_inf_bound
@@ -288,7 +287,7 @@ as_gt.gs_design <- function(
   }
 
   # add footnote for non-binding design
-  footnote_nb <- gsd_footnote_nb(x_old, parts$alpha, full_alpha)
+  footnote_nb <- gsd_footnote_nb(x_old, parts$alpha)
   if (!is.null(footnote_nb)) x <- gt::tab_footnote(
     x,
     footnote = footnote_nb,
@@ -348,7 +347,8 @@ gsd_footnote <- function(method, columns) {
 }
 
 # footnote for non-binding designs
-gsd_footnote_nb <- function(x, x_alpha, full_alpha) {
+gsd_footnote_nb <- function(x, x_alpha) {
+  full_alpha <- attr(x, "full_alpha")
   if (!inherits(x, "non_binding") || x_alpha >= full_alpha) return()
   a1 <- format(x_alpha, scientific = FALSE)
   a2 <- format(full_alpha, scientific = FALSE)

--- a/R/as_rtf.R
+++ b/R/as_rtf.R
@@ -171,11 +171,6 @@ check_rel_width <- function(width, n_col) {
 #' @param display_columns A vector of strings specifying the variables to be
 #'   displayed in the summary table.
 #' @param display_inf_bound Logical, whether to display the +/-inf bound.
-#' @param full_alpha The full alpha used in the design, the default is 0.025.
-#    If the cumulative alpha for final analysis is less than the `full_alpha`
-#'   when the futility bound is non-binding, a footnote will be displayed, saying
-#'   the smaller value subtracts the probability of crossing a futility bound before
-#'   crossing an efficacy bound at a later analysis under the null hypothesis.
 #' @inheritParams r2rtf::rtf_page
 #' @inheritParams r2rtf::rtf_body
 #' @param file File path for the output.
@@ -283,7 +278,6 @@ as_rtf.gs_design <- function(
     display_bound = c("Efficacy", "Futility"),
     display_columns = NULL,
     display_inf_bound = TRUE,
-    full_alpha = 0.025,
     col_rel_width = NULL,
     orientation = c("portrait", "landscape"),
     text_font_size = 9,
@@ -368,7 +362,7 @@ as_rtf.gs_design <- function(
   }
 
   # add footnote for non-binding design
-  footnote_nb <- gsd_footnote_nb(x_old, parts$alpha, full_alpha)
+  footnote_nb <- gsd_footnote_nb(x_old, parts$alpha)
   if (!is.null(footnote_nb)) {
     mkr <- marker()
     i <- gsd_footnote_row(x, display_bound[1])

--- a/man/as_rtf.Rd
+++ b/man/as_rtf.Rd
@@ -29,7 +29,6 @@ as_rtf(x, ...)
   display_bound = c("Efficacy", "Futility"),
   display_columns = NULL,
   display_inf_bound = TRUE,
-  full_alpha = 0.025,
   col_rel_width = NULL,
   orientation = c("portrait", "landscape"),
   text_font_size = 9,
@@ -76,11 +75,6 @@ The default is \code{c("Efficacy", "Futility")}.}
 displayed in the summary table.}
 
 \item{display_inf_bound}{Logical, whether to display the +/-inf bound.}
-
-\item{full_alpha}{The full alpha used in the design, the default is 0.025.
-when the futility bound is non-binding, a footnote will be displayed, saying
-the smaller value subtracts the probability of crossing a futility bound before
-crossing an efficacy bound at a later analysis under the null hypothesis.}
 }
 \value{
 \code{as_rtf()} returns the input \code{x} invisibly.


### PR DESCRIPTION
Retrieve it from `x`'s attribute instead.

cf https://github.com/Merck/gsDesign2/pull/450#discussion_r1717160414