### PR TITLE
Redirect as_gt() to simtrial when it is masked by gsDesign2::as_gt()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsDesign2
 Title: Group Sequential Design with Non-Constant Effect
-Version: 1.1.2.22
+Version: 1.1.2.23
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role = c("aut")),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(as_gt,fixed_design)
 S3method(as_gt,gs_design)
+S3method(as_gt,simtrial_gs_wlr)
 S3method(as_rtf,fixed_design)
 S3method(as_rtf,gs_design)
 S3method(summary,fixed_design)

--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -415,3 +415,11 @@ gsd_parts <- function(
     alpha = max(filter(x, Bound == bound[1])[[alpha_column]])
   )
 }
+
+# Only purpose of the method below is to fix S3 redirection when gsDesign2 is
+# loaded after simtrial, which masks the as_gt() generic from simtrial
+
+#' @export
+as_gt.simtrial_gs_wlr <- function(x, ...) {
+  simtrial:::as_gt.simtrial_gs_wlr(x, ...)
+}


### PR DESCRIPTION
Counterpart to https://github.com/Merck/simtrial/pull/287 (xref: https://github.com/Merck/simtrial/issues/284)

cc: @yihui 

Fixes the S3 redirection when gsDesign2::as_gt() masks simtrial::as_gt(), as below:

```R
library("simtrial")
library("gsDesign2")
##
## Attaching package: ‘gsDesign2’
##
## The following object is masked from ‘package:simtrial’:
##
##   as_gt
##

# Parameters for enrollment
enroll_rampup_duration <- 4 # Duration for enrollment ramp up
enroll_duration <- 16 # Total enrollment duration
enroll_rate <- define_enroll_rate(
  duration = c(
    enroll_rampup_duration, enroll_duration - enroll_rampup_duration),
  rate = c(10, 30))

# Parameters for treatment effect
delay_effect_duration <- 3 # Delay treatment effect in months
median_ctrl <- 9 # Survival median of the control arm
median_exp <- c(9, 14) # Survival median of the experimental arm
dropout_rate <- 0.001
fail_rate <- define_fail_rate(
  duration = c(delay_effect_duration, 100),
  fail_rate = log(2) / median_ctrl,
  hr = median_ctrl / median_exp,
  dropout_rate = dropout_rate)

# Other related parameters
alpha <- 0.025 # Type I error
beta <- 0.1 # Type II error
ratio <- 1 # Randomization ratio (experimental:control)

# Build a one-sided group sequential design
design <- gs_design_ahr(
  enroll_rate = enroll_rate, fail_rate = fail_rate,
  ratio = ratio, alpha = alpha, beta = beta,
  analysis_time = c(12, 24, 36),
  upper = gs_spending_bound,
  upar = list(sf = gsDesign::sfLDOF, total_spend = alpha),
  lower = gs_b,
  lpar = rep(-Inf, 3))

# Define cuttings of 2 IAs and 1 FA
ia1_cut <- create_cut(target_event_overall = ceiling(design$analysis$event[1]))
ia2_cut <- create_cut(target_event_overall = ceiling(design$analysis$event[2]))
fa_cut <- create_cut(target_event_overall = ceiling(design$analysis$event[3]))

# Run simulations
simulation <- sim_gs_n(
  n_sim = 3,
  sample_size = ceiling(design$analysis$n[3]),
  enroll_rate = design$enroll_rate,
  fail_rate = design$fail_rate,
  test = wlr,
  cut = list(ia1 = ia1_cut, ia2 = ia2_cut, fa = fa_cut),
  weight = fh(rho = 0, gamma = 0.5))

# Summarize simulation and compare with the planned design
simulation |> summary(design = design) |> as_gt()
## Error in UseMethod("as_gt", x) :
##   no applicable method for 'as_gt' applied to an object of class "c('simtrial_gs_wlr', 'data.frame')"
simulation |> summary(design = design) |> simtrial::as_gt()
```
