### PR TITLE
Link functions with roxygen2 Markdown syntax

### DIFF
--- a/R/gs_info_ahr.R
+++ b/R/gs_info_ahr.R
@@ -21,8 +21,8 @@
 #' Based on piecewise enrollment rate, failure rate, and dropout rates computes
 #' approximate information and effect size using an average hazard ratio model.
 #'
-#' @param enroll_rate Enrollment rates from \code{define_enroll_rate()}.
-#' @param fail_rate Failure and dropout rates from \code{define_fail_rate()}.
+#' @param enroll_rate Enrollment rates from [define_enroll_rate()].
+#' @param fail_rate Failure and dropout rates from [define_fail_rate()].
 #' @param ratio Experimental:Control randomization ratio.
 #' @param event Targeted minimum events at each analysis.
 #' @param analysis_time Targeted minimum study duration at each analysis.

--- a/R/gs_update_ahr.R
+++ b/R/gs_update_ahr.R
@@ -18,7 +18,7 @@
 
 #' Group sequential design using average hazard ratio under non-proportional hazards
 #'
-#' @param x A design created by either \code{gs_design_ahr} or \code{gs_power_ahr}.
+#' @param x A design created by either [gs_design_ahr()] or [gs_power_ahr()].
 #' @param alpha Type I error for the updated design.
 #' @param ustime Default is NULL in which case upper bound spending time is determined by timing.
 #' Otherwise, this should be a vector of length k (total number of analyses)

--- a/man/gs_create_arm.Rd
+++ b/man/gs_create_arm.Rd
@@ -7,9 +7,9 @@
 gs_create_arm(enroll_rate, fail_rate, ratio, total_time = 1e+06)
 }
 \arguments{
-\item{enroll_rate}{Enrollment rates from \code{define_enroll_rate()}.}
+\item{enroll_rate}{Enrollment rates from \code{\link[=define_enroll_rate]{define_enroll_rate()}}.}
 
-\item{fail_rate}{Failure and dropout rates from \code{define_fail_rate()}.}
+\item{fail_rate}{Failure and dropout rates from \code{\link[=define_fail_rate]{define_fail_rate()}}.}
 
 \item{ratio}{Experimental:Control randomization ratio.}
 

--- a/man/gs_info_ahr.Rd
+++ b/man/gs_info_ahr.Rd
@@ -15,9 +15,9 @@ gs_info_ahr(
 )
 }
 \arguments{
-\item{enroll_rate}{Enrollment rates from \code{define_enroll_rate()}.}
+\item{enroll_rate}{Enrollment rates from \code{\link[=define_enroll_rate]{define_enroll_rate()}}.}
 
-\item{fail_rate}{Failure and dropout rates from \code{define_fail_rate()}.}
+\item{fail_rate}{Failure and dropout rates from \code{\link[=define_fail_rate]{define_fail_rate()}}.}
 
 \item{ratio}{Experimental:Control randomization ratio.}
 

--- a/man/gs_update_ahr.Rd
+++ b/man/gs_update_ahr.Rd
@@ -13,7 +13,7 @@ gs_update_ahr(
 )
 }
 \arguments{
-\item{x}{A design created by either \code{gs_design_ahr} or \code{gs_power_ahr}.}
+\item{x}{A design created by either \code{\link[=gs_design_ahr]{gs_design_ahr()}} or \code{\link[=gs_power_ahr]{gs_power_ahr()}}.}
 
 \item{alpha}{Type I error for the updated design.}
 


### PR DESCRIPTION
As title suggests. The [syntax](https://roxygen2.r-lib.org/articles/markdown.html#links) for linking functions in roxygen2 markdown is: `[func()]` and `[pkg::func()]`.

(Is it okay to change these now? Or should I wait until 2025? I just wanted to make sure I respect the priority of things and not standing in the way if other changes need to happen first.)