### PR TITLE
Fix fixed_design_lf() example

### DIFF
--- a/R/fixed_design_lf.R
+++ b/R/fixed_design_lf.R
@@ -46,7 +46,7 @@
 #' x %>% summary()
 #'
 #' # Example 2: given sample size and compute power
-#' x <- fixed_design_fh(
+#' x <- fixed_design_lf(
 #'   alpha = .025,
 #'   enroll_rate = define_enroll_rate(duration = 18, rate = 20),
 #'   fail_rate = define_fail_rate(

--- a/R/globals.R
+++ b/R/globals.R
@@ -57,7 +57,7 @@ utils::globalVariables(
       # From `gs_design_wlr()`
       c(
         "IF", "time", "event", "info", "info0", "theta", "bound",
-        "z", "n", "rate"
+        "z", "n", "rate", "delta", "sigma2"
       ),
       # From `gs_info_ahr()`
       c("analysis", "time", "theta", "info", "info0"),

--- a/man/fixed_design.Rd
+++ b/man/fixed_design.Rd
@@ -232,7 +232,7 @@ x <- fixed_design_lf(
 x \%>\% summary()
 
 # Example 2: given sample size and compute power
-x <- fixed_design_fh(
+x <- fixed_design_lf(
   alpha = .025,
   enroll_rate = define_enroll_rate(duration = 18, rate = 20),
   fail_rate = define_fail_rate(


### PR DESCRIPTION
I fixed a minor typo in the example for `fixed_design_lf()` (it was calling `fixed_design_fh()`).

While checking this update, I noticed that `R CMD check` produced a NOTE about the variables `delta` and `sigma2` in `gs_design_wlr()`. I believe these were added a few weeks ago in https://github.com/Merck/gsDesign2/commit/f9aab1a217c44c3b7a58c196cfd185555513968a ( https://github.com/Merck/gsDesign2/pull/446). Given that we are preparing for a CRAN release (#480), I also fixed this.