### PR TITLE
Update the rounding of events in `to_integer()`

### DIFF
--- a/R/to_integer.R
+++ b/R/to_integer.R
@@ -282,7 +282,7 @@ to_integer.gs_design <- function(x, sample_size = TRUE, round_up_final = TRUE, .
     if (n_analysis == 1) {
       event_new <- ceiling(event)
     } else {
-      event_ia_new <- ceiling(event[1:(n_analysis - 1)])
+      event_ia_new <- round(event[1:(n_analysis - 1)])
       event_fa_new <- ifelse(round_up_final, ceiling(event[n_analysis]), floor(event[n_analysis]))
       event_new <- c(event_ia_new, event_fa_new)
     }

--- a/R/to_integer.R
+++ b/R/to_integer.R
@@ -208,7 +208,8 @@ to_integer.fixed_design <- function(x, sample_size = TRUE, ...) {
 }
 
 #' @rdname to_integer
-#'
+#' @param round_up_final Events at final analysis is rounded up if `TRUE`;
+#' otherwise, just rounded, unless it is very close to an integer.
 #' @export
 #'
 #' @examples

--- a/R/to_integer.R
+++ b/R/to_integer.R
@@ -264,7 +264,7 @@ to_integer.fixed_design <- function(x, sample_size = TRUE, ...) {
 #' x$bound$`nominal p`[1]
 #' gsDesign::sfLDOF(alpha = 0.025, t = 18 / 30)$spend
 #' }
-to_integer.gs_design <- function(x, sample_size = TRUE, ...) {
+to_integer.gs_design <- function(x, sample_size = TRUE, round_up_final = TRUE, ...) {
   is_ahr <- inherits(x, "ahr")
   is_wlr <- inherits(x, "wlr")
   is_rd  <- inherits(x, "rd")
@@ -282,7 +282,9 @@ to_integer.gs_design <- function(x, sample_size = TRUE, ...) {
     if (n_analysis == 1) {
       event_new <- ceiling(event)
     } else {
-      event_new <- c(floor(event[1:(n_analysis - 1)]), ceiling(event[n_analysis]))
+      event_ia_new <- ceiling(event[1:(n_analysis - 1)])
+      event_fa_new <- ifelse(round_up_final, ceiling(event[n_analysis]), floor(event[n_analysis]))
+      event_new <- c(event_ia_new, event_fa_new)
     }
 
     # Updated sample size to integer and enroll rates

--- a/R/to_integer.R
+++ b/R/to_integer.R
@@ -286,16 +286,17 @@ to_integer.gs_design <- function(x, sample_size = TRUE, round_up_final = TRUE, .
       # round IA events to the closest integer
       event_ia_new <- round(event[1:(n_analysis - 1)])
 
-      # ceiling the FA events as default
-      if(round_up_final) {
-        event_fa_new <- ceiling(event[n_analysis])
       # if the FA events is very close to an integer, set it as this integer
-      } else if (abs(event[n_analysis] - round(event[n_analysis])) < 1e-3) {
+      if (abs(event[n_analysis] - round(event[n_analysis])) < 0.01) {
         event_fa_new <- round(event[n_analysis])
+      # ceiling the FA events as default
+      } else if (round_up_final) {
+        event_fa_new <- ceiling(event[n_analysis])
       # otherwise, floor the FA events
-      } else {
+      } else{
         event_fa_new <- floor(event_fa_new)
       }
+
       event_new <- c(event_ia_new, event_fa_new)
     }
 

--- a/R/to_integer.R
+++ b/R/to_integer.R
@@ -282,8 +282,19 @@ to_integer.gs_design <- function(x, sample_size = TRUE, round_up_final = TRUE, .
     if (n_analysis == 1) {
       event_new <- ceiling(event)
     } else {
+      # round IA events to the closest integer
       event_ia_new <- round(event[1:(n_analysis - 1)])
-      event_fa_new <- ifelse(round_up_final, ceiling(event[n_analysis]), floor(event[n_analysis]))
+
+      # ceiling the FA events as default
+      if(round_up_final) {
+        event_fa_new <- ceiling(event[n_analysis])
+      # if the FA events is very close to an integer, set it as this integer
+      } else if (abs(event[n_analysis] - round(event[n_analysis])) < 1e-3) {
+        event_fa_new <- round(event[n_analysis])
+      # otherwise, floor the FA events
+      } else {
+        event_fa_new <- floor(event_fa_new)
+      }
       event_new <- c(event_ia_new, event_fa_new)
     }
 

--- a/man/to_integer.Rd
+++ b/man/to_integer.Rd
@@ -10,7 +10,7 @@ to_integer(x, ...)
 
 \method{to_integer}{fixed_design}(x, sample_size = TRUE, ...)
 
-\method{to_integer}{gs_design}(x, sample_size = TRUE, ...)
+\method{to_integer}{gs_design}(x, sample_size = TRUE, round_up_final = TRUE, ...)
 }
 \arguments{
 \item{x}{An object returned by fixed_design_xxx() and gs_design_xxx().}

--- a/man/to_integer.Rd
+++ b/man/to_integer.Rd
@@ -19,6 +19,9 @@ to_integer(x, ...)
 
 \item{sample_size}{Logical, indicting if ceiling
 sample size to an even integer.}
+
+\item{round_up_final}{Events at final analysis is rounded up if \code{TRUE};
+otherwise, just rounded, unless it is very close to an integer.}
 }
 \value{
 A list similar to the output of fixed_design_xxx() and gs_design_xxx(),


### PR DESCRIPTION
The current version of `to_integer()` floor the IA events and ceiling the FA events. In the PR, the IA events is rounded, and FA events is rounded up, as default. 