### PR TITLE
Use CODECOV_TOKEN to fix code coverage uploads

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -26,6 +26,8 @@ jobs:
           needs: coverage
 
       - name: Test coverage
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           covr::codecov(
             quiet = FALSE,


### PR DESCRIPTION
Our code coverage results have not been uploaded for months because we aren't using a Codecov token. We get errors like the [following](https://github.com/Merck/gsDesign2/actions/runs/11842040553/job/32999720561#step:5:1018) from our most recent run on main:

```
[1] "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 2836s."
```

We were recently provided a single repository upload token for the gsDesign2 repository by the Merck open source team. Once it is added as a repository secret named `CODECOV_TOKEN`, our workflow will start uploading coverage results again.

xref: https://github.com/r-lib/actions/issues/834