### PR TITLE
running time of `gs_design_wlr` example is > 5s

### DIFF
--- a/R/gs_design_wlr.R
+++ b/R/gs_design_wlr.R
@@ -57,6 +57,7 @@
 #'
 #' # Example 1 ----
 #' # Information fraction driven design
+#' \donttest{
 #' gs_design_wlr(
 #'   enroll_rate = enroll_rate,
 #'   fail_rate = fail_rate,
@@ -72,9 +73,11 @@
 #'   analysis_time = 36,
 #'   info_frac = 1:3/3
 #' )
+#' }
 #'
 #' # Example 2 ----
 #' # Calendar time driven design
+#' \donttest{
 #' gs_design_wlr(
 #'   enroll_rate = enroll_rate,
 #'   fail_rate = fail_rate,
@@ -90,9 +93,11 @@
 #'   analysis_time = 1:3*12,
 #'   info_frac = NULL
 #' )
+#' }
 #'
 #' # Example 3 ----
 #' # Both calendar time and information fraction driven design
+#' \donttest{
 #' gs_design_wlr(
 #'   enroll_rate = enroll_rate,
 #'   fail_rate = fail_rate,
@@ -108,6 +113,7 @@
 #'   analysis_time = 1:3*12,
 #'   info_frac = c(0.3, 0.7, 1)
 #' )
+#' }
 gs_design_wlr <- function(
     enroll_rate = define_enroll_rate(
       duration = c(2, 2, 10),

--- a/R/gs_design_wlr.R
+++ b/R/gs_design_wlr.R
@@ -57,7 +57,6 @@
 #'
 #' # Example 1 ----
 #' # Information fraction driven design
-#' \donttest{
 #' gs_design_wlr(
 #'   enroll_rate = enroll_rate,
 #'   fail_rate = fail_rate,
@@ -71,13 +70,11 @@
 #'   lower = gs_spending_bound,
 #'   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2),
 #'   analysis_time = 36,
-#'   info_frac = 1:3/3
+#'   info_frac = c(0.6, 1)
 #' )
-#' }
 #'
 #' # Example 2 ----
 #' # Calendar time driven design
-#' \donttest{
 #' gs_design_wlr(
 #'   enroll_rate = enroll_rate,
 #'   fail_rate = fail_rate,
@@ -90,14 +87,12 @@
 #'   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
 #'   lower = gs_spending_bound,
 #'   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2),
-#'   analysis_time = 1:3*12,
+#'   analysis_time = c(24, 36),
 #'   info_frac = NULL
 #' )
-#' }
 #'
 #' # Example 3 ----
 #' # Both calendar time and information fraction driven design
-#' \donttest{
 #' gs_design_wlr(
 #'   enroll_rate = enroll_rate,
 #'   fail_rate = fail_rate,
@@ -110,10 +105,9 @@
 #'   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
 #'   lower = gs_spending_bound,
 #'   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2),
-#'   analysis_time = 1:3*12,
-#'   info_frac = c(0.3, 0.7, 1)
+#'   analysis_time = c(24, 36),
+#'   info_frac = c(0.6, 1)
 #' )
-#' }
 gs_design_wlr <- function(
     enroll_rate = define_enroll_rate(
       duration = c(2, 2, 10),

--- a/man/gs_design_wlr.Rd
+++ b/man/gs_design_wlr.Rd
@@ -142,7 +142,6 @@ fail_rate <- define_fail_rate(
 
 # Example 1 ----
 # Information fraction driven design
-\donttest{
 gs_design_wlr(
   enroll_rate = enroll_rate,
   fail_rate = fail_rate,
@@ -156,13 +155,11 @@ gs_design_wlr(
   lower = gs_spending_bound,
   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2),
   analysis_time = 36,
-  info_frac = 1:3/3
+  info_frac = c(0.6, 1)
 )
-}
 
 # Example 2 ----
 # Calendar time driven design
-\donttest{
 gs_design_wlr(
   enroll_rate = enroll_rate,
   fail_rate = fail_rate,
@@ -175,14 +172,12 @@ gs_design_wlr(
   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
   lower = gs_spending_bound,
   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2),
-  analysis_time = 1:3*12,
+  analysis_time = c(24, 36),
   info_frac = NULL
 )
-}
 
 # Example 3 ----
 # Both calendar time and information fraction driven design
-\donttest{
 gs_design_wlr(
   enroll_rate = enroll_rate,
   fail_rate = fail_rate,
@@ -195,8 +190,7 @@ gs_design_wlr(
   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
   lower = gs_spending_bound,
   lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.2),
-  analysis_time = 1:3*12,
-  info_frac = c(0.3, 0.7, 1)
+  analysis_time = c(24, 36),
+  info_frac = c(0.6, 1)
 )
-}
 }

--- a/man/gs_design_wlr.Rd
+++ b/man/gs_design_wlr.Rd
@@ -142,6 +142,7 @@ fail_rate <- define_fail_rate(
 
 # Example 1 ----
 # Information fraction driven design
+\donttest{
 gs_design_wlr(
   enroll_rate = enroll_rate,
   fail_rate = fail_rate,
@@ -157,9 +158,11 @@ gs_design_wlr(
   analysis_time = 36,
   info_frac = 1:3/3
 )
+}
 
 # Example 2 ----
 # Calendar time driven design
+\donttest{
 gs_design_wlr(
   enroll_rate = enroll_rate,
   fail_rate = fail_rate,
@@ -175,9 +178,11 @@ gs_design_wlr(
   analysis_time = 1:3*12,
   info_frac = NULL
 )
+}
 
 # Example 3 ----
 # Both calendar time and information fraction driven design
+\donttest{
 gs_design_wlr(
   enroll_rate = enroll_rate,
   fail_rate = fail_rate,
@@ -193,4 +198,5 @@ gs_design_wlr(
   analysis_time = 1:3*12,
   info_frac = c(0.3, 0.7, 1)
 )
+}
 }


### PR DESCRIPTION
To solve notes listing in #490.