### PR TITLE
Fix the warning when `colname_spannersub` is used in `as_gt()`

### DIFF
--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -379,8 +379,8 @@ gsd_footnote_row <- function(x, bound) {
 # a list of information for `as_[gt|rtf].gs_design()` methods: the transformed
 # data, title, and footnote, etc.
 gsd_parts <- function(
-    x, title, subtitle, spannersub, footnote, bound, columns, inf_bound,
-    alpha_column = spannersub[2], transform = identity
+  x, title, subtitle, spannersub, footnote, bound, columns, inf_bound,
+  transform = identity
 ) {
   method <- intersect(c("ahr", "wlr", "combo", "rd"), class(x))[1]
   if (!inf_bound) x <- filter(x, !is.infinite(Z))
@@ -412,7 +412,7 @@ gsd_parts <- function(
     x = arrange(x2, Analysis),
     title = title, subtitle = subtitle,
     footnote = footnote %||% gsd_footnote(method, columns),
-    alpha = max(filter(x, Bound == bound[1])[[alpha_column]])
+    alpha = max(filter(x, Bound == bound[1])[["Null hypothesis"]])
   )
 }
 

--- a/R/as_rtf.R
+++ b/R/as_rtf.R
@@ -288,7 +288,7 @@ as_rtf.gs_design <- function(
 
   parts <- gsd_parts(
     x, title, subtitle, colname_spannersub, footnote,
-    display_bound, display_columns, display_inf_bound, "Null hypothesis",
+    display_bound, display_columns, display_inf_bound,
     function(x) {
       x2 <- data.frame(lapply(x, function(x) trimws(formatC(x, flag = "-"), "r")))
       names(x2) <- names(x)

--- a/tests/testthat/_snaps/independent_as_gt.md
+++ b/tests/testthat/_snaps/independent_as_gt.md
@@ -338,14 +338,13 @@
     \multicolumn{6}{l}{Analysis: 3 Time: 24.5 N: 108 Events: 50 AHR: 0.71 Information fraction: 1\textsuperscript{\textit{3}}} \\[2.5pt] 
     \midrule\addlinespace[2.5pt]
     Futility & -0.22 & 0.5881 & 1.0650 & 0.1002 & 0.4319 \\ 
-    Efficacy & 2.03 & 0.0212 & 0.5631 & 0.2071 & 0.0250\textsuperscript{\textit{4}} \\ 
+    Efficacy & 2.03 & 0.0212 & 0.5631 & 0.2071 & 0.0250 \\ 
     \bottomrule
     \end{tabular*}
     \begin{minipage}{\linewidth}
     \textsuperscript{\textit{1}}One-sided p-value for experimental vs control treatment. Value < 0.5 favors experimental, > 0.5 favors control.\\
     \textsuperscript{\textit{2}}Approximate hazard ratio to cross bound.\\
     \textsuperscript{\textit{3}}wAHR is the weighted AHR.\\
-    \textsuperscript{\textit{4}}Cumulative alpha for final analysis (-Inf) is less than the full alpha (0.025) when the futility bound is non-binding. The smaller value subtracts the probability of crossing a futility bound before crossing an efficacy bound at a later analysis (0.025 - Inf = -Inf) under the null hypothesis.\\
     \end{minipage}
     \end{table}
 

--- a/tests/testthat/test-independent_as_gt.R
+++ b/tests/testthat/test-independent_as_gt.R
@@ -231,8 +231,7 @@ test_that("Snapshot test for gs_power_wlr summary as_gt with colname_spanner and
     as_gt(
       colname_spanner = "Cumulative probability to cross boundaries",
       colname_spannersub = c("under H1", "under H0")
-    ) %>%
-    suppressWarnings() # Can be removed after <https://github.com/Merck/gsDesign2/issues/339> is fixed
+    )
 
   local_edition(3)
   expect_snapshot_output(gt_to_latex(output))


### PR DESCRIPTION
Fixes #339.