### PR TITLE
Do not upload coverage results to Codecov when run in a fork

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  workflow_dispatch:
 
 name: test-coverage.yaml
 
@@ -38,6 +39,7 @@ jobs:
         shell: Rscript {0}
 
       - uses: codecov/codecov-action@v4
+        if: github.event.repository.fork == false
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
When I sync my fork (eg today in https://github.com/jdblischak/gsDesign2/commit/98f123456d054e8cc9ca304dd45d5f981fd1cb8e), the test-coverage workflow [fails](https://github.com/jdblischak/gsDesign2/actions/runs/12996942372/job/36246800050#step:6:43) because I don't have `CODECOV_TOKEN` set.

```
==> Running command '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov create-commit'
/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov create-commit --git-service github -Z
info - 2025-01-27 19:45:39,664 -- ci service found: github-actions
warning - 2025-01-27 19:45:[39](https://github.com/jdblischak/gsDesign2/actions/runs/12996942372/job/36246800050#step:6:40),694 -- Branch `main` is protected but no token was provided
warning - 2025-01-27 19:45:39,694 -- For information on Codecov upload tokens, see https://docs.codecov.com/docs/codecov-tokens
info - 2025-01-27 19:45:[40](https://github.com/jdblischak/gsDesign2/actions/runs/12996942372/job/36246800050#step:6:41),169 -- Process Commit creating complete
error - 2025-01-27 19:45:40,169 -- Commit creating failed: {"message":"Token required because branch is protected"}
```

We only need coverage uploads to Codecov to run on the main repository, so this PR updates the workflow to skip the upload step when running on a fork. However, when running in a PR submitted from a fork, it still performs token-less uploads to Codecov.

xref: https://github.com/Merck/gsDesign2/pull/489, https://github.com/Merck/simtrial/pull/307, https://github.com/keaven/gsDesign/pull/179