### PR TITLE
Fix as_gt() examples

### DIFF
--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -157,6 +157,7 @@ fd_footnote <- function(x, method) {
 #' @export
 #'
 #' @examplesIf !identical(Sys.getenv("IN_PKGDOWN"), "true")
+#' \donttest{
 #' # Group sequential design examples ---
 #'
 #' library(dplyr)
@@ -242,7 +243,7 @@ fd_footnote <- function(x, method) {
 #' gs_power_wlr(lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1)) %>%
 #'   summary() %>%
 #'   as_gt(display_columns = c("Analysis", "Bound", "Nominal p", "Z", "Probability"))
-#'
+#' }
 as_gt.gs_design <- function(
     x,
     title = NULL,

--- a/man/as_gt.Rd
+++ b/man/as_gt.Rd
@@ -109,6 +109,7 @@ fixed_design_fh(
   as_gt()
 \dontshow{\}) # examplesIf}
 \dontshow{if (!identical(Sys.getenv("IN_PKGDOWN"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\donttest{
 # Group sequential design examples ---
 
 library(dplyr)
@@ -194,5 +195,6 @@ gs_power_wlr(lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1)) \%>\%
 gs_power_wlr(lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1)) \%>\%
   summary() \%>\%
   as_gt(display_columns = c("Analysis", "Bound", "Nominal p", "Z", "Probability"))
+}
 \dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
The `as_gt()` examples are skipped during `R CMD check` since they generate a lot of extraneous output (#334, #338). However, this means they are not regularly tested. While working on #497, I discovered that the examples with `gs_power_ahr()` and `gs_power_wlr()` were broken.

```R
Error in gs_power_wlr() : 
  gs_power_wlr: please input the total_spend to the futility spending function.
```

I did a `git bisect` to determine that the example broke in https://github.com/Merck/gsDesign2/commit/a6a01660a5c6f32ad859b03c2b11583017bdd0da when we updated `gs_power_ahr()` and `gs_power_wlr()` to require that users specify `total_spend` (#396, https://github.com/Merck/gsDesign2/pull/398).

I fixed the examples as was done for `as_rtf()` in #398 and also updated the examples to be run during `R CMD check` to prevent this from happening again. The downsides are that `gsDesign2.Rcheck/gsDesign2-Ex.Rout` gets bloated with all the `as_gt()` output, and the examples are also decently long-running. If CRAN complains about either of these on the next submission, then we can re-evaluate the strategy. An alternative would be to copy the examples into a test file, and then return to skipping the examples during `R CMD check`.