### PR TITLE
Avoid native pipe check note or build warning on R >= 4.5.0

### DIFF
--- a/R/expected_time.R
+++ b/R/expected_time.R
@@ -125,7 +125,7 @@ expected_time <- function(
       enroll_rate = enroll_rate, fail_rate = fail_rate,
       total_duration = res$root, ratio = ratio
     )
-    return(ans |> select(-n))
+    return(ans %>% select(-n))
   }
 }
 

--- a/R/gs_info_ahr.R
+++ b/R/gs_info_ahr.R
@@ -123,7 +123,7 @@ gs_info_ahr <- function(enroll_rate = define_enroll_rate(duration = c(2, 2, 10),
   if (!is.null(analysis_time)) {
     # calculate events given the `analysis_time`
     avehr <- ahr(enroll_rate = enroll_rate, fail_rate = fail_rate,
-                 ratio = ratio, total_duration = analysis_time) |> select(-n)
+                 ratio = ratio, total_duration = analysis_time) %>% select(-n)
     # check if the above events >= targeted events
     for (i in seq_along(event)) {
       if (avehr$event[i] < event[i]) {


### PR DESCRIPTION
This PR fixes the `R CMD check` note or `R CMD build` warning on r-devel (upcoming R 4.5.0) where `|>` is used in functions under `R/`, by replacing the native pipe with the magrittr pipe.

This check note is currently shown on all [r-devel CRAN builds](https://cran.r-project.org/web/checks/check_results_gsDesign2.html):

```text
Version: 1.1.3
Check: DESCRIPTION meta-information
Result: NOTE
    Missing dependency on R >= 4.1.0 because package code uses the pipe
    |> or function shorthand \(...) syntax added in R 4.1.0.
    File(s) using such syntax:
      ‘expected_time.R’ ‘gs_info_ahr.R’
Flavors: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc,
         r-devel-linux-x86_64-fedora-clang, r-devel-linux-x86_64-fedora-gcc,
         r-devel-macos-x86_64, r-devel-windows-x86_64
```

Without this fix, for new source tarballs built by R 4.5.0, this becomes a build warning, since `R CMD build` will auto-bump the R >= 3.5.0 requirement in `DESCRIPTION` in the tarball.