### PR TITLE
Assign the modified `df` back to `df` in `define_fail_rate()`

### DIFF
--- a/R/define.R
+++ b/R/define.R
@@ -125,7 +125,7 @@ define_fail_rate <- function(
     hr = hr
   )
 
-  check_fail_rate(df)
+  df <- check_fail_rate(df)
 
   class(df) <- c("fail_rate", class(df))
 


### PR DESCRIPTION
It seems we forgot to assign the modified `df` back.