### PR TITLE
Don't restrict specifications to PDF manual

### DIFF
--- a/R/ahr.R
+++ b/R/ahr.R
@@ -38,39 +38,30 @@
 #'   `total_duration` input.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate if input enrollment rate contains stratum column.
-#'    \item Validate if input enrollment rate contains total duration column.
-#'    \item Validate if input enrollment rate contains rate column.
-#'    \item Validate if input failure rate contains stratum column.
-#'    \item Validate if input failure rate contains duration column.
-#'    \item Validate if input failure rate contains failure rate column.
-#'    \item Validate if input failure rate contains hazard ratio column.
-#'    \item Validate if input failure rate contains dropout rate column.
-#'    \item Validate if input trial total follow-up (total duration) is a non-empty vector of positive integers.
-#'    \item Validate if strata is the same in enrollment rate and failure rate.
-#'    \item Compute the proportion in each group.
-#'    \item Compute the expected events by treatment groups, stratum and time period.
-#'    \item Calculate the expected number of events for all time points in the total
-#'     duration and for all stratification variables.
-#'    \itemize{
-#'      \item Compute the expected events in for each strata.
-#'        \itemize{
-#'          \item Combine the expected number of events of all stratification variables.
-#'          \item Recompute events, hazard ratio and information under
-#'          the given scenario of the combined data for each strata.
-#'          }
-#'        \item Combine the results for all time points by summarizing the results by adding up the number of events,
-#'       information under the null and the given scenarios.
-#'       }
-#'    \item Return a data frame of overall event count, statistical information and average hazard ratio
-#'    of each value in total_duration.
-#'    \item Calculation of \code{ahr} for different design scenarios, and the comparison to the
-#'    simulation studies are defined in vignette/AHRVignette.Rmd.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Validate if input enrollment rate contains stratum column.
+#' - Validate if input enrollment rate contains total duration column.
+#' - Validate if input enrollment rate contains rate column.
+#' - Validate if input failure rate contains stratum column.
+#' - Validate if input failure rate contains duration column.
+#' - Validate if input failure rate contains failure rate column.
+#' - Validate if input failure rate contains hazard ratio column.
+#' - Validate if input failure rate contains dropout rate column.
+#' - Validate if input trial total follow-up (total duration) is a non-empty vector of positive integers.
+#' - Validate if strata is the same in enrollment rate and failure rate.
+#' - Compute the proportion in each group.
+#' - Compute the expected events by treatment groups, stratum and time period.
+#' - Calculate the expected number of events for all time points in the total
+#'   duration and for all stratification variables.
+#'   - Compute the expected events in for each strata.
+#'     - Combine the expected number of events of all stratification variables.
+#'     - Recompute events, hazard ratio and information under
+#'       the given scenario of the combined data for each strata.
+#'   - Combine the results for all time points by summarizing the results by adding up the number of events,
+#'     information under the null and the given scenarios.
+#' - Return a data frame of overall event count, statistical information and average hazard ratio
+#'   of each value in total_duration.
+#' - Calculation of `ahr` for different design scenarios, and the comparison to the
+#'   simulation studies are defined in vignette/AHRVignette.Rmd.
 #'
 #' @export
 #'

--- a/R/ahr_blinded.R
+++ b/R/ahr_blinded.R
@@ -44,21 +44,16 @@
 #'   expected incremental drift at all analyses.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate input hr is a numeric vector.
-#'    \item Validate input hr is non-negative.
-#'    \item Validate input intervals is a numeric vector > 0.
-#'    \item Set final value in intervals to Inf
-#'    \item Validate that hr and intervals have same length.
-#'    \item For input time-to-event data, count number of events in each input interval by stratum.
-#'    \item Compute the blinded estimate of average hazard ratio.
-#'    \item Compute adjustment for information.
-#'    \item Return a tibble of the sum of events, average hazard ratio,
+#' - Validate input hr is a numeric vector.
+#' - Validate input hr is non-negative.
+#' - Validate input intervals is a numeric vector > 0.
+#' - Set final value in intervals to Inf
+#' - Validate that hr and intervals have same length.
+#' - For input time-to-event data, count number of events in each input interval by stratum.
+#' - Compute the blinded estimate of average hazard ratio.
+#' - Compute adjustment for information.
+#' - Return a tibble of the sum of events, average hazard ratio,
 #'    blinded average hazard ratio, and the information.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
 #' @export
 #'

--- a/R/check_arg.R
+++ b/R/check_arg.R
@@ -32,14 +32,9 @@
 #' will not be executed.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Check if arg is NULL.
-#'    \item Extract the type, length and dim information from arg.
-#'    \item Compare with target values and report error message if it does not match.
-#'  }
-#'  }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Check if arg is NULL.
+#' - Extract the type, length and dim information from arg.
+#' - Compare with target values and report error message if it does not match.
 #'
 #' @examples
 #' tbl <- as.data.frame(matrix(1:9, nrow = 3))

--- a/R/expected_accural.R
+++ b/R/expected_accural.R
@@ -27,22 +27,17 @@
 #' @return A vector with expected cumulative enrollment for the specified `times`.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate if input x is a vector of strictly increasing non-negative numeric elements.
-#'    \item Validate if input enrollment rate is of type data.frame.
-#'    \item Validate if input enrollment rate contains duration column.
-#'    \item Validate if input enrollment rate contains rate column.
-#'    \item Validate if rate in input enrollment rate is non-negative with at least one positive rate.
-#'    \item Convert rates to step function.
-#'    \item Add times where rates change to enrollment rates.
-#'    \item Make a tibble of the input time points x, duration, enrollment rates at points, and
+#' - Validate if input x is a vector of strictly increasing non-negative numeric elements.
+#' - Validate if input enrollment rate is of type data.frame.
+#' - Validate if input enrollment rate contains duration column.
+#' - Validate if input enrollment rate contains rate column.
+#' - Validate if rate in input enrollment rate is non-negative with at least one positive rate.
+#' - Convert rates to step function.
+#' - Add times where rates change to enrollment rates.
+#' - Make a tibble of the input time points x, duration, enrollment rates at points, and
 #'    expected accrual.
-#'    \item Extract the expected cumulative or survival enrollment.
-#'    \item Return \code{expected_accrual}
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Extract the expected cumulative or survival enrollment.
+#' - Return `expected_accrual`
 #'
 #' @export
 #'

--- a/R/expected_event.R
+++ b/R/expected_event.R
@@ -45,34 +45,30 @@
 #'   The records in the returned data frame correspond to the input data frame `fail_rate`.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate if input enrollment rate contains total duration column.
-#'    \item Validate if input enrollment rate contains rate column.
-#'    \item Validate if input failure rate contains duration column.
-#'    \item Validate if input failure rate contains failure rate column.
-#'    \item Validate if input failure rate contains dropout rate column.
-#'    \item Validate if input trial total follow-up (total duration) is a non-empty vector of positive integers.
-#'    \item Validate if input simple is logical.
-#'    \item Define a data frame with the start opening for enrollment at zero and cumulative duration.
-#'    Add the event (or failure) time corresponding to the start of the enrollment.
-#'    Finally, add the enrollment rate to the data frame
-#'    corresponding to the start and end (failure) time.
-#'    This will be recursively used to calculate the expected
-#'    number of events later. For details, see vignette/eEventsTheory.Rmd
-#'    \item Define a data frame including the cumulative duration of failure rates, the corresponding start time of
-#'    the enrollment, failure rate and dropout rates.  For details, see vignette/eEventsTheory.Rmd
-#'    \item Only consider the failure rates in the interval of the end failure rate and total duration.
-#'    \item Compute the failure rates over time using \code{stepfun} which is used
-#'     to group rows by periods defined by fail_rate.
-#'    \item Compute the dropout rate over time using \code{stepfun}.
-#'    \item Compute the enrollment rate over time using \code{stepfun}. Details are
-#'    available in vignette/eEventsTheory.Rmd.
-#'    \item Compute expected events by interval at risk using the notations and descriptions in
-#'    vignette/eEventsTheory.Rmd.
-#'    \item Return \code{expected_event}
-#'  }
-#' }
+#' - Validate if input enrollment rate contains total duration column.
+#' - Validate if input enrollment rate contains rate column.
+#' - Validate if input failure rate contains duration column.
+#' - Validate if input failure rate contains failure rate column.
+#' - Validate if input failure rate contains dropout rate column.
+#' - Validate if input trial total follow-up (total duration) is a non-empty vector of positive integers.
+#' - Validate if input simple is logical.
+#' - Define a data frame with the start opening for enrollment at zero and cumulative duration.
+#'   Add the event (or failure) time corresponding to the start of the enrollment.
+#'   Finally, add the enrollment rate to the data frame
+#'   corresponding to the start and end (failure) time.
+#'   This will be recursively used to calculate the expected
+#'   number of events later. For details, see `vignette/eEventsTheory.Rmd`
+#' - Define a data frame including the cumulative duration of failure rates, the corresponding start time of
+#'   the enrollment, failure rate and dropout rates.  For details, see `vignette/eEventsTheory.Rmd`
+#' - Only consider the failure rates in the interval of the end failure rate and total duration.
+#' - Compute the failure rates over time using `stepfun` which is used
+#'   to group rows by periods defined by fail_rate.
+#' - Compute the dropout rate over time using `stepfun`.
+#' - Compute the enrollment rate over time using `stepfun`. Details are
+#'   available in vignette/eEventsTheory.Rmd.
+#' - Compute expected events by interval at risk using the notations and descriptions in
+#'   `vignette/eEventsTheory.Rmd`.
+#' - Return `expected_event`
 #'
 #' @details
 #' More periods will generally be supplied in output than those that are input.
@@ -241,21 +237,21 @@ expected_event <- function(
 
 #' Find the "previous" values in a vector
 #'
-#' Fast replacement of \code{dplyr::lag} for the simple case of \code{n = 1L}
+#' Fast replacement of `dplyr::lag` for the simple case of `n = 1L`
 #' and always supplying a new value to insert at the beginning of the vector.
 #'
 #' Important: this function is fast because it provides minimal safety checks.
 #' It relies on the
 #' \href{https://adv-r.hadley.nz/vectors-chap.html#testing-and-coercion}{coercion
-#' rules} of \code{\link[base]{c}}. For best results, \code{x} and \code{first}
+#' rules} of \code{\link[base]{c}}. For best results, `x` and `first`
 #' should be the same type of atomic vector, though it should be fine to mix
-#' \code{numeric} and \code{integer} vectors as long as your own code also
+#' `numeric` and `integer` vectors as long as your own code also
 #' doesn't rely on this distinction. It can also work on lists if needed.
 #'
-#' @param x A vector (\code{length(x) > 0})
-#' @param first A single value (\code{length(first) == 1})
+#' @param x A vector (`length(x) > 0`)
+#' @param first A single value (`length(first) == 1`)
 #'
-#' @return a vector that begins with \code{first} and is followed by \code{x}
+#' @return a vector that begins with `first` and is followed by `x`
 #' with its final value removed
 #'
 #' @examples

--- a/R/expected_time.R
+++ b/R/expected_time.R
@@ -38,12 +38,8 @@
 #'   `total_duration` input.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Use root-finding routine with `AHR()` to find time at which targeted events accrue.
-#'    \item Return a data frame with a single row with the output from `AHR()` got the specified output.
-#'    }
-#'  }
+#' - Use root-finding routine with `AHR()` to find time at which targeted events accrue.
+#' - Return a data frame with a single row with the output from `AHR()` got the specified output.
 #'
 #' @export
 #'

--- a/R/gridpts_h1_hupdate.R
+++ b/R/gridpts_h1_hupdate.R
@@ -38,18 +38,13 @@
 #' @return A list with grid points in `z` and numerical integration weights in `w`.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Define odd numbered grid points for real line.
-#'    \item Trim points outside of $[a, b]$ and include those points.
-#'    \item If extreme, include only 1 point where density will be essentially 0.
-#'    \item Define even numbered grid points between the odd ones.
-#'    \item Compute weights for odd numbered grid points.
-#'    \item Combine odd- and even-numbered grid points with their corresponding weights.
-#'    \item Return a tibble of with grid points in z and numerical integration weights in z.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Define odd numbered grid points for real line.
+#' - Trim points outside of $[a, b]$ and include those points.
+#' - If extreme, include only 1 point where density will be essentially 0.
+#' - Define even numbered grid points between the odd ones.
+#' - Compute weights for odd numbered grid points.
+#' - Combine odd- and even-numbered grid points with their corresponding weights.
+#' - Return a tibble of with grid points in z and numerical integration weights in z.
 #'
 #' @noRd
 #'
@@ -83,15 +78,10 @@ gridpts <- function(r = 18, mu = 0, a = -Inf, b = Inf) {
 #' Mean for standard normal distribution under consideration is `mu = theta * sqrt(I)`.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Compute drift at analysis 1.
-#'    \item Compute deviation from drift.
-#'    \item Compute standard normal density, multiply by grid weight.
-#'    \item Return a tibble of z, w, and h.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Compute drift at analysis 1.
+#' - Compute deviation from drift.
+#' - Compute standard normal density, multiply by grid weight.
+#' - Return a tibble of z, w, and h.
 #'
 #' @noRd
 #'
@@ -127,15 +117,10 @@ h1 <- function(r = 18, theta = 0, info = 1, a = -Inf, b = Inf) {
 #'   and variance 1 times the weight in `h`.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Compute the square root of the change in information.
-#'    \item Compute the grid points for group sequential design numerical integration.
-#'    \item Update the integration.
-#'    \item Return a tibble of z, w, and h.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Compute the square root of the change in information.
+#' - Compute the grid points for group sequential design numerical integration.
+#' - Update the integration.
+#' - Return a tibble of z, w, and h.
 #'
 #' @noRd
 #'

--- a/R/gs_b.R
+++ b/R/gs_b.R
@@ -36,19 +36,10 @@
 #' @return Returns the vector input `par` if `k` is `NULL`, otherwise, `par[k]`.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate if the input k is null as default.
-#'    \itemize{
-#'      \item If the input k is null as default, return the whole vector of
-#'      Z-values of the boundaries.
-#'      \item If the input k is not null, return the corresponding boundary
-#'      in the vector of Z-values.
-#'      }
-#'    \item Return a vector of boundaries.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Validate if the input k is null as default.
+#'   - If the input k is null as default, return the whole vector of Z-values of the boundaries.
+#'   - If the input k is not null, return the corresponding boundary in the vector of Z-values.
+#' - Return a vector of boundaries.
 #'
 #' @export
 #'

--- a/R/gs_design_ahr.R
+++ b/R/gs_design_ahr.R
@@ -18,8 +18,8 @@
 
 #' Calculate sample size and bounds given targeted power and Type I error in group sequential design using average hazard ratio under non-proportional hazards
 #'
-#' @param enroll_rate Enrollment rates defined by \code{define_enroll_rate()}.
-#' @param fail_rate Failure and dropout rates defined by \code{define_fail_rate()}.
+#' @param enroll_rate Enrollment rates defined by `define_enroll_rate()`.
+#' @param fail_rate Failure and dropout rates defined by `define_fail_rate()`.
 #' @param ratio Experimental:Control randomization ratio.
 #' @param alpha One-sided Type I error.
 #' @param beta Type II error.
@@ -28,8 +28,8 @@
 #' @param binding Indicator of whether futility bound is binding;
 #'   default of `FALSE` is recommended.
 #' @param upper Function to compute upper bound.
-#'   - \code{gs_spending_bound()}: alpha-spending efficacy bounds.
-#'   - \code{gs_b()}: fixed efficacy bounds.
+#'   - `gs_spending_bound()`: alpha-spending efficacy bounds.
+#'   - `gs_b()`: fixed efficacy bounds.
 #' @param upar Parameters passed to `upper`.
 #'   - If `upper = gs_b`, then `upar` is a numerical vector specifying the fixed efficacy bounds per analysis.
 #'   - If `upper = gs_spending_bound`, then `upar` is a list including

--- a/R/gs_design_npe.R
+++ b/R/gs_design_npe.R
@@ -95,32 +95,25 @@
 #' will be used to ensure Type I error and other boundary properties are as specified.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate if input info is a numeric vector  or NULL, if non-NULL validate if it
-#'    is strictly increasing and positive.
-#'    \item Validate if input info0 is a numeric vector or NULL, if non-NULL validate if it
-#'     is strictly increasing and positive.
-#'    \item Validate if input info1 is a numeric vector or NULL, if non-NULL validate if it
-#'    is strictly increasing and positive.
-#'    \item Validate if input theta is a real vector and has the same length as info.
-#'    \item Validate if input theta1 is a real vector and has the same length as info.
-#'    \item Validate if input test_upper and test_lower are logical and have the same length as info.
-#'    \item Validate if input test_upper value is TRUE.
-#'    \item Validate if input alpha and beta are positive and of length one.
-#'    \item Validate if input alpha and beta are from the unit interval and alpha is smaller than beta.
-#'    \item Initialize bounds, numerical integration grids, boundary crossing probabilities.
-#'    \item Compute fixed sample size for desired power and Type I error.
-#'    \item Find an interval for information inflation to give correct power using \code{gs_power_npe()}.
-
-#'    \item
-#'    \item If there is no interim analysis, return a tibble including Analysis time, upper bound, Z-value,
-#'    Probability of crossing bound, theta, info0 and info1.
-#'    \item If the design is a group sequential design, return a tibble of Analysis,
-#'     Bound, Z, Probability,  theta, info, info0.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Validate if input info is a numeric vector  or NULL, if non-NULL validate if it
+#'   is strictly increasing and positive.
+#' - Validate if input info0 is a numeric vector or NULL, if non-NULL validate if it
+#'   is strictly increasing and positive.
+#' - Validate if input info1 is a numeric vector or NULL, if non-NULL validate if it
+#'   is strictly increasing and positive.
+#' - Validate if input theta is a real vector and has the same length as info.
+#' - Validate if input theta1 is a real vector and has the same length as info.
+#' - Validate if input test_upper and test_lower are logical and have the same length as info.
+#' - Validate if input test_upper value is TRUE.
+#' - Validate if input alpha and beta are positive and of length one.
+#' - Validate if input alpha and beta are from the unit interval and alpha is smaller than beta.
+#' - Initialize bounds, numerical integration grids, boundary crossing probabilities.
+#' - Compute fixed sample size for desired power and Type I error.
+#' - Find an interval for information inflation to give correct power using `gs_power_npe()`.
+#' - If there is no interim analysis, return a tibble including Analysis time, upper bound, Z-value,
+#'   Probability of crossing bound, theta, info0 and info1.
+#' - If the design is a group sequential design, return a tibble of Analysis,
+#'   Bound, Z, Probability,  theta, info, info0.
 #'
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #'

--- a/R/gs_design_wlr.R
+++ b/R/gs_design_wlr.R
@@ -22,18 +22,13 @@
 #' @inheritParams gs_info_wlr
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate if input analysis_time is a positive number or a positive increasing sequence.
-#'    \item Validate if input info_frac is a positive number
-#'    or positive increasing sequence on (0, 1] with final value of 1.
-#'    \item Validate if inputs info_frac and analysis_time  have the same length if both have length > 1.
-#'    \item Compute information at input analysis_time using \code{gs_info_wlr()}.
-#'    \item Compute sample size and bounds using \code{gs_design_npe()}.
-#'    \item Return a list of design enrollment, failure rates, and bounds.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Validate if input analysis_time is a positive number or a positive increasing sequence.
+#' - Validate if input info_frac is a positive number
+#'   or positive increasing sequence on (0, 1] with final value of 1.
+#' - Validate if inputs info_frac and analysis_time  have the same length if both have length > 1.
+#' - Compute information at input analysis_time using `gs_info_wlr()`.
+#' - Compute sample size and bounds using `gs_design_npe()`.
+#' - Return a list of design enrollment, failure rates, and bounds.
 #'
 #' @export
 #' @return A list with input parameters, enrollment rate, analysis, and bound.

--- a/R/gs_info_ahr.R
+++ b/R/gs_info_ahr.R
@@ -36,20 +36,13 @@
 #'   `ahr` is the expected average hazard ratio at each analysis.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate if input event is a numeric value vector or a vector with increasing values.
-#'    \item Validate if input analysis_time is a numeric value vector or a vector with increasing values.
-#'    \item Validate if inputs event and analysis_time have the same length if they are both specified.
-#'    \item Compute average hazard ratio:
-#'    \itemize{
-#'      \item If analysis_time is specified, calculate average hazard ratio using \code{ahr()}.
-#'      \item If event is specified, calculate average hazard ratio using \code{expected_time()}.
-#'    }
-#'    \item Return a data frame of Analysis, Time, AHR, Events, theta, info, info0.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Validate if input event is a numeric value vector or a vector with increasing values.
+#' - Validate if input analysis_time is a numeric value vector or a vector with increasing values.
+#' - Validate if inputs event and analysis_time have the same length if they are both specified.
+#' - Compute average hazard ratio:
+#'   - If analysis_time is specified, calculate average hazard ratio using `ahr()`.
+#'   - If event is specified, calculate average hazard ratio using `expected_time()`.
+#' - Return a data frame of Analysis, Time, AHR, Events, theta, info, info0.
 #'
 #' @details
 #' The [ahr()] function computes statistical information at targeted

--- a/R/gs_power_combo.R
+++ b/R/gs_power_combo.R
@@ -23,19 +23,14 @@
 #' @return A list with input parameters, enrollment rate, analysis, and bound.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate if lower and upper bounds have been specified.
-#'    \item Extract info, info_fh, theta_fh and corr_fh from utility.
-#'    \item Extract sample size via the maximum sample size of info.
-#'    \item Calculate information fraction either for fixed or group sequential design.
-#'    \item Compute spending function using \code{gs_bound()}.
-#'    \item Compute probability of crossing bounds under the null and alternative
-#'     hypotheses using \code{gs_prob_combo()}.
-#'    \item Export required information for boundary and crossing probability
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Validate if lower and upper bounds have been specified.
+#' - Extract info, info_fh, theta_fh and corr_fh from utility.
+#' - Extract sample size via the maximum sample size of info.
+#' - Calculate information fraction either for fixed or group sequential design.
+#' - Compute spending function using `gs_bound()`.
+#' - Compute probability of crossing bounds under the null and alternative
+#'   hypotheses using `gs_prob_combo()`.
+#' - Export required information for boundary and crossing probability
 #'
 #' @export
 #'

--- a/R/gs_power_npe.R
+++ b/R/gs_power_npe.R
@@ -83,39 +83,23 @@
 #'   information fraction, and statistical information.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Extract the length of input info as the number of interim analysis.
-#'    \item Validate if input info0 is NULL, so set it equal to info.
-#'    \item Validate if the length of inputs info and info0 are the same.
-#'    \item Validate if input theta is a scalar, so replicate
-#'    the value for all k interim analysis.
-#'    \item Validate if input theta1 is NULL and if it is a scalar.
-#'    If it is NULL, set it equal to input theta. If it is a scalar,
-#'    replicate the value for all k interim analysis.
-#'    \item Validate if input test_upper is a scalar,
-#'    so replicate the value for all k interim analysis.
-#'    \item Validate if input test_lower is a scalar,
-#'    so replicate the value for all k interim analysis.
-#'    \item Define vector a to be -Inf with
-#'    length equal to the number of interim analysis.
-#'    \item Define vector b to be Inf with
-#'    length equal to the number of interim analysis.
-#'    \item Define hgm1_0 and hgm1 to be NULL.
-#'    \item Define upper_prob and lower_prob to be
-#'    vectors of NA with length of the number of interim analysis.
-#'    \item Update lower and upper bounds using \code{gs_b()}.
-#'    \item If there are no interim analysis, compute probabilities
-#'    of crossing upper and lower bounds
-#'    using \code{h1()}.
-#'    \item Compute cross upper and lower bound probabilities
-#'    using \code{hupdate()} and \code{h1()}.
-#'    \item Return a tibble of analysis number, bound, z-values,
-#'    probability of crossing bounds,
-#'    theta, theta1, info, and info0.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Extract the length of input info as the number of interim analysis.
+#' - Validate if input info0 is NULL, so set it equal to info.
+#' - Validate if the length of inputs info and info0 are the same.
+#' - Validate if input theta is a scalar, so replicate the value for all k interim analysis.
+#' - Validate if input theta1 is NULL and if it is a scalar.
+#'   If it is NULL, set it equal to input theta. If it is a scalar,
+#'   replicate the value for all k interim analysis.
+#' - Validate if input test_upper is a scalar, so replicate the value for all k interim analysis.
+#' - Validate if input test_lower is a scalar, so replicate the value for all k interim analysis.
+#' - Define vector a to be -Inf with length equal to the number of interim analysis.
+#' - Define vector b to be Inf with length equal to the number of interim analysis.
+#' - Define hgm1_0 and hgm1 to be NULL.
+#' - Define upper_prob and lower_prob to be vectors of NA with length of the number of interim analysis.
+#' - Update lower and upper bounds using `gs_b()`.
+#' - If there are no interim analysis, compute probabilities of crossing upper and lower bounds using `h1()`.
+#' - Compute cross upper and lower bound probabilities using `hupdate()` and `h1()`.
+#' - Return a tibble of analysis number, bound, z-values, probability of crossing bounds, theta, theta1, info, and info0.
 #'
 #' @export
 #'

--- a/R/gs_power_wlr.R
+++ b/R/gs_power_wlr.R
@@ -22,15 +22,10 @@
 #' @inheritParams gs_power_ahr
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Compute information and effect size for Weighted Log-rank test using \code{gs_info_wlr()}.
-#'    \item Compute group sequential bound computation with non-constant effect using \code{gs_power_npe()}.
-#'    \item Combine information and effect size and power and return a
+#' - Compute information and effect size for Weighted Log-rank test using `gs_info_wlr()`.
+#' - Compute group sequential bound computation with non-constant effect using `gs_power_npe()`.
+#' - Combine information and effect size and power and return a
 #'    tibble  with columns Analysis, Bound, Time, Events, Z, Probability, AHR,  theta, info, and info0.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
 #'
 #' @export
 #'

--- a/R/gs_spending_bound.R
+++ b/R/gs_spending_bound.R
@@ -56,20 +56,15 @@
 #'   generates an error message.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Set the spending time at analysis.
-#'    \item Compute the cumulative spending at analysis.
-#'    \item Compute the incremental spend at each analysis.
-#'    \item Set test_bound a vector of length k > 1 if input as a single value.
-#'    \item Compute spending for current bound.
-#'    \item Iterate to convergence as in gsbound.c from gsDesign.
-#'    \item Compute subdensity for final analysis in rejection region.
-#'    \item Validate the output and return an error message in case of failure.
-#'    \item Return a numeric bound (possibly infinite).
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Set the spending time at analysis.
+#' - Compute the cumulative spending at analysis.
+#' - Compute the incremental spend at each analysis.
+#' - Set test_bound a vector of length k > 1 if input as a single value.
+#' - Compute spending for current bound.
+#' - Iterate to convergence as in gsbound.c from gsDesign.
+#' - Compute subdensity for final analysis in rejection region.
+#' - Validate the output and return an error message in case of failure.
+#' - Return a numeric bound (possibly infinite).
 #'
 #' @author Keaven Anderson \email{keaven_anderson@@merck.com}
 #'

--- a/R/pwe.R
+++ b/R/pwe.R
@@ -40,22 +40,16 @@
 #' \deqn{S(t)=\exp(-\Lambda(t)).}
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate if input enrollment rate is a strictly increasing non-negative numeric vector.
-#'    \item Validate if input failure rate is of type data.frame.
-#'    \item Validate if input failure rate contains duration column.
-#'    \item Validate if input failure rate contains rate column.
-#'    \item Validate if input lower_tail is logical.
-#'    \item Convert rates to step function.
-#'    \item Add times where rates change to enrollment rates.
-#'    \item Make a tibble of the input time points x, duration, hazard rates at points,
-#'    cumulative hazard and survival.
-#'    \item Extract the expected cumulative or survival of piecewise exponential distribution.
-#'    \item If input lower_tail is true, return the CDF, else return the survival for \code{ppwe}
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Validate if input enrollment rate is a strictly increasing non-negative numeric vector.
+#' - Validate if input failure rate is of type data.frame.
+#' - Validate if input failure rate contains duration column.
+#' - Validate if input failure rate contains rate column.
+#' - Validate if input lower_tail is logical.
+#' - Convert rates to step function.
+#' - Add times where rates change to enrollment rates.
+#' - Make a tibble of the input time points x, duration, hazard rates at points, cumulative hazard and survival.
+#' - Extract the expected cumulative or survival of piecewise exponential distribution.
+#' - If input lower_tail is true, return the CDF, else return the survival for `ppwe`
 #'
 #' @export
 #'
@@ -138,17 +132,12 @@ ppwe <- function(x, duration, rate, lower_tail = FALSE) {
 #' @return A tibble containing the duration and rate.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate if input times is increasing positive finite numbers.
-#'    \item Validate if input survival is numeric and same length as input times.
-#'    \item Validate if input survival is positive, non-increasing, less than or equal to 1 and greater than 0.
-#'    \item Create a tibble of inputs times and survival.
-#'    \item Calculate the duration, hazard and the rate.
-#'    \item Return the duration and rate by \code{s2pwe}
-#'  }
-#'  }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Validate if input times is increasing positive finite numbers.
+#' - Validate if input survival is numeric and same length as input times.
+#' - Validate if input survival is positive, non-increasing, less than or equal to 1 and greater than 0.
+#' - Create a tibble of inputs times and survival.
+#' - Calculate the duration, hazard and the rate.
+#' - Return the duration and rate by `s2pwe`
 #'
 #' @export
 #'

--- a/R/utility_combo.R
+++ b/R/utility_combo.R
@@ -24,22 +24,17 @@
 #' @param algorithm Numerical algorithms.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Define the analysis time from input fh_test.
-#'    \item Compute arm0 and arm1 using \code{gs_create_arm()}.
-#'    \item Set a unique test.
-#'    \item Compute the information fraction using \code{gs_info_combo()}.
-#'    \item Compute the correlation between tests.
-#'    \item Compute the correlation between analysis.
-#'    \item Compute the overall correlation.
-#'    \item Extract the sample size from  info.
-#'    \item Compute information restricted to actual analysis.
-#'    \item Compute the effect size.
-#'    \item Return a list of info_all = info, info = info_fh, theta = theta_fh, corr = corr_fh.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Define the analysis time from input fh_test.
+#' - Compute arm0 and arm1 using `gs_create_arm()`.
+#' - Set a unique test.
+#' - Compute the information fraction using `gs_info_combo()`.
+#' - Compute the correlation between tests.
+#' - Compute the correlation between analysis.
+#' - Compute the overall correlation.
+#' - Extract the sample size from  info.
+#' - Compute information restricted to actual analysis.
+#' - Compute the effect size.
+#' - Return a list of info_all = info, info = info_fh, theta = theta_fh, corr = corr_fh.
 #'
 #' @noRd
 gs_utility_combo <- function(enroll_rate,
@@ -397,17 +392,11 @@ gs_prob_combo <- function(upper_bound,
 #' @inheritParams pmvnorm_combo
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Create a vector of allocated alpha in each interim analysis from the cumulative allocated alpha.
-#'    \item Create a vector of allocated beta in each interim analysis from the cumulative allocated beta.
-#'    \item Extract the number of analysis.
-#'    \item Find the upper and lower bound by solving multivariate normal distribution using \code{pmvnorm_combo}
-#'    \item
-#'    \item Return a data frame of upper and lower boundaries of group sequential design.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Create a vector of allocated alpha in each interim analysis from the cumulative allocated alpha.
+#' - Create a vector of allocated beta in each interim analysis from the cumulative allocated beta.
+#' - Extract the number of analysis.
+#' - Find the upper and lower bound by solving multivariate normal distribution using `pmvnorm_combo`
+#' - Return a data frame of upper and lower boundaries of group sequential design.
 #'
 #' @examples
 #' library(gsDesign)

--- a/R/utility_wlr.R
+++ b/R/utility_wlr.R
@@ -24,28 +24,23 @@
 #' @return A list of the two arms.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Validate if there is only one stratum.
-#'    \item Calculate the accrual duration.
-#'    \item calculate the accrual intervals.
-#'    \item Calculate the accrual parameter as the proportion of enrollment rate*duration.
-#'    \item Set cure proportion to zero.
-#'    \item set survival intervals and shape.
-#'    \item Set fail rate in fail_rate to the Weibull scale parameter for the survival distribution in the arm 0.
-#'    \item Set the multiplication of hazard ratio and fail rate to the Weibull scale parameter
-#'    for the survival distribution in the arm 1.
-#'    \item Set the shape parameter to one as the exponential distribution for
-#'    shape parameter for the loss to follow-up distribution
-#'    \item Set the scale parameter to one as the scale parameter for the loss to follow-up
-#'     distribution since the exponential distribution is supported only
-#'    \item Create arm 0 using \code{npsurvSS::create_arm()} using the parameters for arm 0.
-#'    \item Create arm 1 using \code{npsurvSS::create_arm()} using the parameters for arm 1.
-#'    \item Set the class of the two arms.
-#'    \item Return a list of the two arms.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Validate if there is only one stratum.
+#' - Calculate the accrual duration.
+#' - calculate the accrual intervals.
+#' - Calculate the accrual parameter as the proportion of enrollment rate*duration.
+#' - Set cure proportion to zero.
+#' - set survival intervals and shape.
+#' - Set fail rate in fail_rate to the Weibull scale parameter for the survival distribution in the arm 0.
+#' - Set the multiplication of hazard ratio and fail rate to the Weibull scale parameter
+#'   for the survival distribution in the arm 1.
+#' - Set the shape parameter to one as the exponential distribution for
+#'   shape parameter for the loss to follow-up distribution
+#' - Set the scale parameter to one as the scale parameter for the loss to follow-up
+#'   distribution since the exponential distribution is supported only
+#' - Create arm 0 using `npsurvSS::create_arm()` using the parameters for arm 0.
+#' - Create arm 1 using `npsurvSS::create_arm()` using the parameters for arm 1.
+#' - Set the class of the two arms.
+#' - Return a list of the two arms.
 #'
 #' @export
 #'

--- a/R/wlr_weight.R
+++ b/R/wlr_weight.R
@@ -33,16 +33,11 @@
 #' @param power A scalar parameter that controls the power of the weight function.
 #'
 #' @section Specification:
-#' \if{latex}{
-#'  \itemize{
-#'    \item Compute the sample size via the sum of arm sizes.
-#'    \item Compute the proportion of size in the two arms.
-#'    \item If the input tau is specified, define time up to the cut off time tau.
-#'    \item Compute the CDF using the proportion of the size in the two arms and \code{npsruvSS::psurv()}.
-#'    \item Return the Fleming-Harrington weights for weighted Log-rank test.
-#'   }
-#' }
-#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#' - Compute the sample size via the sum of arm sizes.
+#' - Compute the proportion of size in the two arms.
+#' - If the input tau is specified, define time up to the cut off time tau.
+#' - Compute the CDF using the proportion of the size in the two arms and `npsruvSS::psurv()`.
+#' - Return the Fleming-Harrington weights for weighted Log-rank test.
 #'
 #' @name wlr_weight
 

--- a/man/ahr.Rd
+++ b/man/ahr.Rd
@@ -39,39 +39,36 @@ and enrollment pattern where the enrollment, failure and dropout rates changes o
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate if input enrollment rate contains stratum column.
-   \item Validate if input enrollment rate contains total duration column.
-   \item Validate if input enrollment rate contains rate column.
-   \item Validate if input failure rate contains stratum column.
-   \item Validate if input failure rate contains duration column.
-   \item Validate if input failure rate contains failure rate column.
-   \item Validate if input failure rate contains hazard ratio column.
-   \item Validate if input failure rate contains dropout rate column.
-   \item Validate if input trial total follow-up (total duration) is a non-empty vector of positive integers.
-   \item Validate if strata is the same in enrollment rate and failure rate.
-   \item Compute the proportion in each group.
-   \item Compute the expected events by treatment groups, stratum and time period.
-   \item Calculate the expected number of events for all time points in the total
-    duration and for all stratification variables.
-   \itemize{
-     \item Compute the expected events in for each strata.
-       \itemize{
-         \item Combine the expected number of events of all stratification variables.
-         \item Recompute events, hazard ratio and information under
-         the given scenario of the combined data for each strata.
-         }
-       \item Combine the results for all time points by summarizing the results by adding up the number of events,
-      information under the null and the given scenarios.
-      }
-   \item Return a data frame of overall event count, statistical information and average hazard ratio
-   of each value in total_duration.
-   \item Calculation of \code{ahr} for different design scenarios, and the comparison to the
-   simulation studies are defined in vignette/AHRVignette.Rmd.
-  }
+\itemize{
+\item Validate if input enrollment rate contains stratum column.
+\item Validate if input enrollment rate contains total duration column.
+\item Validate if input enrollment rate contains rate column.
+\item Validate if input failure rate contains stratum column.
+\item Validate if input failure rate contains duration column.
+\item Validate if input failure rate contains failure rate column.
+\item Validate if input failure rate contains hazard ratio column.
+\item Validate if input failure rate contains dropout rate column.
+\item Validate if input trial total follow-up (total duration) is a non-empty vector of positive integers.
+\item Validate if strata is the same in enrollment rate and failure rate.
+\item Compute the proportion in each group.
+\item Compute the expected events by treatment groups, stratum and time period.
+\item Calculate the expected number of events for all time points in the total
+duration and for all stratification variables.
+\itemize{
+\item Compute the expected events in for each strata.
+\itemize{
+\item Combine the expected number of events of all stratification variables.
+\item Recompute events, hazard ratio and information under
+the given scenario of the combined data for each strata.
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
+\item Combine the results for all time points by summarizing the results by adding up the number of events,
+information under the null and the given scenarios.
+}
+\item Return a data frame of overall event count, statistical information and average hazard ratio
+of each value in total_duration.
+\item Calculation of \code{ahr} for different design scenarios, and the comparison to the
+simulation studies are defined in vignette/AHRVignette.Rmd.
+}
 }
 
 \examples{

--- a/man/ahr_blinded.Rd
+++ b/man/ahr_blinded.Rd
@@ -47,21 +47,18 @@ specified here.
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate input hr is a numeric vector.
-   \item Validate input hr is non-negative.
-   \item Validate input intervals is a numeric vector > 0.
-   \item Set final value in intervals to Inf
-   \item Validate that hr and intervals have same length.
-   \item For input time-to-event data, count number of events in each input interval by stratum.
-   \item Compute the blinded estimate of average hazard ratio.
-   \item Compute adjustment for information.
-   \item Return a tibble of the sum of events, average hazard ratio,
-   blinded average hazard ratio, and the information.
-  }
+\itemize{
+\item Validate input hr is a numeric vector.
+\item Validate input hr is non-negative.
+\item Validate input intervals is a numeric vector > 0.
+\item Set final value in intervals to Inf
+\item Validate that hr and intervals have same length.
+\item For input time-to-event data, count number of events in each input interval by stratum.
+\item Compute the blinded estimate of average hazard ratio.
+\item Compute adjustment for information.
+\item Return a tibble of the sum of events, average hazard ratio,
+blinded average hazard ratio, and the information.
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
 }
 
 \examples{

--- a/man/expected_accrual.Rd
+++ b/man/expected_accrual.Rd
@@ -24,22 +24,19 @@ given a set of piecewise constant enrollment rates and times.
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate if input x is a vector of strictly increasing non-negative numeric elements.
-   \item Validate if input enrollment rate is of type data.frame.
-   \item Validate if input enrollment rate contains duration column.
-   \item Validate if input enrollment rate contains rate column.
-   \item Validate if rate in input enrollment rate is non-negative with at least one positive rate.
-   \item Convert rates to step function.
-   \item Add times where rates change to enrollment rates.
-   \item Make a tibble of the input time points x, duration, enrollment rates at points, and
-   expected accrual.
-   \item Extract the expected cumulative or survival enrollment.
-   \item Return \code{expected_accrual}
-  }
+\itemize{
+\item Validate if input x is a vector of strictly increasing non-negative numeric elements.
+\item Validate if input enrollment rate is of type data.frame.
+\item Validate if input enrollment rate contains duration column.
+\item Validate if input enrollment rate contains rate column.
+\item Validate if rate in input enrollment rate is non-negative with at least one positive rate.
+\item Convert rates to step function.
+\item Add times where rates change to enrollment rates.
+\item Make a tibble of the input time points x, duration, enrollment rates at points, and
+expected accrual.
+\item Extract the expected cumulative or survival enrollment.
+\item Return \code{expected_accrual}
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
 }
 
 \examples{

--- a/man/expected_event.Rd
+++ b/man/expected_event.Rd
@@ -56,33 +56,31 @@ maximize flexibility for a variety of purposes.
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate if input enrollment rate contains total duration column.
-   \item Validate if input enrollment rate contains rate column.
-   \item Validate if input failure rate contains duration column.
-   \item Validate if input failure rate contains failure rate column.
-   \item Validate if input failure rate contains dropout rate column.
-   \item Validate if input trial total follow-up (total duration) is a non-empty vector of positive integers.
-   \item Validate if input simple is logical.
-   \item Define a data frame with the start opening for enrollment at zero and cumulative duration.
-   Add the event (or failure) time corresponding to the start of the enrollment.
-   Finally, add the enrollment rate to the data frame
-   corresponding to the start and end (failure) time.
-   This will be recursively used to calculate the expected
-   number of events later. For details, see vignette/eEventsTheory.Rmd
-   \item Define a data frame including the cumulative duration of failure rates, the corresponding start time of
-   the enrollment, failure rate and dropout rates.  For details, see vignette/eEventsTheory.Rmd
-   \item Only consider the failure rates in the interval of the end failure rate and total duration.
-   \item Compute the failure rates over time using \code{stepfun} which is used
-    to group rows by periods defined by fail_rate.
-   \item Compute the dropout rate over time using \code{stepfun}.
-   \item Compute the enrollment rate over time using \code{stepfun}. Details are
-   available in vignette/eEventsTheory.Rmd.
-   \item Compute expected events by interval at risk using the notations and descriptions in
-   vignette/eEventsTheory.Rmd.
-   \item Return \code{expected_event}
- }
+\itemize{
+\item Validate if input enrollment rate contains total duration column.
+\item Validate if input enrollment rate contains rate column.
+\item Validate if input failure rate contains duration column.
+\item Validate if input failure rate contains failure rate column.
+\item Validate if input failure rate contains dropout rate column.
+\item Validate if input trial total follow-up (total duration) is a non-empty vector of positive integers.
+\item Validate if input simple is logical.
+\item Define a data frame with the start opening for enrollment at zero and cumulative duration.
+Add the event (or failure) time corresponding to the start of the enrollment.
+Finally, add the enrollment rate to the data frame
+corresponding to the start and end (failure) time.
+This will be recursively used to calculate the expected
+number of events later. For details, see \code{vignette/eEventsTheory.Rmd}
+\item Define a data frame including the cumulative duration of failure rates, the corresponding start time of
+the enrollment, failure rate and dropout rates.  For details, see \code{vignette/eEventsTheory.Rmd}
+\item Only consider the failure rates in the interval of the end failure rate and total duration.
+\item Compute the failure rates over time using \code{stepfun} which is used
+to group rows by periods defined by fail_rate.
+\item Compute the dropout rate over time using \code{stepfun}.
+\item Compute the enrollment rate over time using \code{stepfun}. Details are
+available in vignette/eEventsTheory.Rmd.
+\item Compute expected events by interval at risk using the notations and descriptions in
+\code{vignette/eEventsTheory.Rmd}.
+\item Return \code{expected_event}
 }
 }
 

--- a/man/expected_time.Rd
+++ b/man/expected_time.Rd
@@ -44,12 +44,10 @@ where the enrollment, failure and dropout rates changes over time.
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Use root-finding routine with `AHR()` to find time at which targeted events accrue.
-   \item Return a data frame with a single row with the output from `AHR()` got the specified output.
-   }
- }
+\itemize{
+\item Use root-finding routine with \code{AHR()} to find time at which targeted events accrue.
+\item Return a data frame with a single row with the output from \code{AHR()} got the specified output.
+}
 }
 
 \examples{

--- a/man/fixed_design.Rd
+++ b/man/fixed_design.Rd
@@ -110,7 +110,7 @@ and \code{1 - alpha} otherwise).}
 
 \item{study_duration}{Study duration.}
 
-\item{event}{A numerical vector specifying the targeted event at each analysis.}
+\item{event}{A numerical vector specifying the targeted events at each analysis. See details.}
 
 \item{rho}{A vector of numbers paring with gamma and tau for MaxCombo test.}
 

--- a/man/gs_b.Rd
+++ b/man/gs_b.Rd
@@ -30,19 +30,14 @@ For instance, for spending function bounds use \code{\link[=gs_spending_bound]{g
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate if the input k is null as default.
-   \itemize{
-     \item If the input k is null as default, return the whole vector of
-     Z-values of the boundaries.
-     \item If the input k is not null, return the corresponding boundary
-     in the vector of Z-values.
-     }
-   \item Return a vector of boundaries.
-  }
+\itemize{
+\item Validate if the input k is null as default.
+\itemize{
+\item If the input k is null as default, return the whole vector of Z-values of the boundaries.
+\item If the input k is not null, return the corresponding boundary in the vector of Z-values.
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
+\item Return a vector of boundaries.
+}
 }
 
 \examples{

--- a/man/gs_create_arm.Rd
+++ b/man/gs_create_arm.Rd
@@ -23,28 +23,25 @@ Create npsurvSS arm object
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate if there is only one stratum.
-   \item Calculate the accrual duration.
-   \item calculate the accrual intervals.
-   \item Calculate the accrual parameter as the proportion of enrollment rate*duration.
-   \item Set cure proportion to zero.
-   \item set survival intervals and shape.
-   \item Set fail rate in fail_rate to the Weibull scale parameter for the survival distribution in the arm 0.
-   \item Set the multiplication of hazard ratio and fail rate to the Weibull scale parameter
-   for the survival distribution in the arm 1.
-   \item Set the shape parameter to one as the exponential distribution for
-   shape parameter for the loss to follow-up distribution
-   \item Set the scale parameter to one as the scale parameter for the loss to follow-up
-    distribution since the exponential distribution is supported only
-   \item Create arm 0 using \code{npsurvSS::create_arm()} using the parameters for arm 0.
-   \item Create arm 1 using \code{npsurvSS::create_arm()} using the parameters for arm 1.
-   \item Set the class of the two arms.
-   \item Return a list of the two arms.
-  }
+\itemize{
+\item Validate if there is only one stratum.
+\item Calculate the accrual duration.
+\item calculate the accrual intervals.
+\item Calculate the accrual parameter as the proportion of enrollment rate*duration.
+\item Set cure proportion to zero.
+\item set survival intervals and shape.
+\item Set fail rate in fail_rate to the Weibull scale parameter for the survival distribution in the arm 0.
+\item Set the multiplication of hazard ratio and fail rate to the Weibull scale parameter
+for the survival distribution in the arm 1.
+\item Set the shape parameter to one as the exponential distribution for
+shape parameter for the loss to follow-up distribution
+\item Set the scale parameter to one as the scale parameter for the loss to follow-up
+distribution since the exponential distribution is supported only
+\item Create arm 0 using \code{npsurvSS::create_arm()} using the parameters for arm 0.
+\item Create arm 1 using \code{npsurvSS::create_arm()} using the parameters for arm 1.
+\item Set the class of the two arms.
+\item Return a list of the two arms.
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
 }
 
 \examples{

--- a/man/gs_design_ahr.Rd
+++ b/man/gs_design_ahr.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/gs_design_ahr.R
 \name{gs_design_ahr}
 \alias{gs_design_ahr}
-\title{Calculate sample size and bounds given the power in group sequential design using average hazard ratio under non-proportional hazards}
+\title{Calculate sample size and bounds given targeted power and Type I error in group sequential design using average hazard ratio under non-proportional hazards}
 \usage{
 gs_design_ahr(
   enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
@@ -36,9 +36,9 @@ gs_design_ahr(
 
 \item{beta}{Type II error.}
 
-\item{info_frac}{Targeted information fraction at each analysis. See details for properly set it up.}
+\item{info_frac}{Targeted information fraction for analyses. See details.}
 
-\item{analysis_time}{Targeted time of analysis. See details for properly set it up.}
+\item{analysis_time}{Targeted calendar timing of analyses. See details.}
 
 \item{ratio}{Experimental:Control randomization ratio.}
 
@@ -59,17 +59,21 @@ default of \code{FALSE} is recommended.}
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{lpar}{Parameters passed to \code{lower}, which can be set up similarly as \code{upar.}}
 
 \item{h1_spending}{Indicator that lower bound to be set by spending
 under alternate hypothesis (input \code{fail_rate})
-if spending is used for lower bound.}
+if spending is used for lower bound.
+If this is \code{FALSE}, then the lower bound spending is under the null hypothesis.
+This is for two-sided symmetric or asymmetric testing under the null hypothesis;
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{test_upper}{Indicator of which analyses should include an upper
 (efficacy) bound; single value of \code{TRUE} (default) indicates all analyses;
@@ -94,10 +98,11 @@ Jennison and Turnbull (2000); default is 18, range is 1 to 80.
 Larger values provide larger number of grid points and greater accuracy.
 Normally, \code{r} will not be changed by the user.}
 
-\item{tol}{Tolerance parameter for boundary convergence (on Z-scale).}
+\item{tol}{Tolerance parameter for boundary convergence (on Z-scale); normally not changed by the user.}
 
-\item{interval}{An interval that is presumed to include the time at which
-expected event count is equal to targeted event.}
+\item{interval}{An interval presumed to include the times at which
+expected event count is equal to targeted event.
+Normally, this can be ignored by the user as it is set to \code{c(.01, 1000)}.}
 }
 \value{
 A list with input parameters, enrollment rate, analysis, and bound.
@@ -110,19 +115,19 @@ A list with input parameters, enrollment rate, analysis, and bound.
 }
 }
 \description{
-Calculate sample size and bounds given the power in group sequential design using average hazard ratio under non-proportional hazards
+Calculate sample size and bounds given targeted power and Type I error in group sequential design using average hazard ratio under non-proportional hazards
 }
 \details{
 The parameters \code{info_frac} and \code{analysis_time} are used to determine the timing for interim and final analyses.
 \itemize{
-\item If the interim analysis is decided by targeted information fraction and the study duration is known,
+\item If the interim analysis is determined by targeted information fraction and the study duration is known,
 then \code{info_frac} is a numerical vector where each element (greater than 0 and less than or equal to 1)
 represents the information fraction for each analysis.
 The \code{analysis_time}, which defaults to 36, indicates the time for the final analysis.
-\item If the interim analysis is determined solely by the targeted analysis timing,
+\item If interim analyses are determined solely by the targeted calendar analysis timing from start of study,
 then \code{analysis_time} will be a vector specifying the time for each analysis.
-\item If both the targeted analysis time and the targeted information fraction are utilized, which arrives latter,
-then both \code{info_frac} and \code{analysis_time} should be provided as vectors.
+\item If both the targeted analysis time and the targeted information fraction are utilized for a given analysis,
+then timing will be the maximum of the two with both \code{info_frac} and \code{analysis_time} provided as vectors.
 }
 }
 \examples{

--- a/man/gs_design_combo.Rd
+++ b/man/gs_design_combo.Rd
@@ -55,11 +55,12 @@ default of \code{FALSE} is recommended.}
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{lpar}{Parameters passed to \code{lower}, which can be set up similarly as \code{upar.}}
 

--- a/man/gs_design_npe.Rd
+++ b/man/gs_design_npe.Rd
@@ -127,31 +127,27 @@ will be used to ensure Type I error and other boundary properties are as specifi
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate if input info is a numeric vector  or NULL, if non-NULL validate if it
-   is strictly increasing and positive.
-   \item Validate if input info0 is a numeric vector or NULL, if non-NULL validate if it
-    is strictly increasing and positive.
-   \item Validate if input info1 is a numeric vector or NULL, if non-NULL validate if it
-   is strictly increasing and positive.
-   \item Validate if input theta is a real vector and has the same length as info.
-   \item Validate if input theta1 is a real vector and has the same length as info.
-   \item Validate if input test_upper and test_lower are logical and have the same length as info.
-   \item Validate if input test_upper value is TRUE.
-   \item Validate if input alpha and beta are positive and of length one.
-   \item Validate if input alpha and beta are from the unit interval and alpha is smaller than beta.
-   \item Initialize bounds, numerical integration grids, boundary crossing probabilities.
-   \item Compute fixed sample size for desired power and Type I error.
-   \item Find an interval for information inflation to give correct power using \code{gs_power_npe()}.
-   \item
-   \item If there is no interim analysis, return a tibble including Analysis time, upper bound, Z-value,
-   Probability of crossing bound, theta, info0 and info1.
-   \item If the design is a group sequential design, return a tibble of Analysis,
-    Bound, Z, Probability,  theta, info, info0.
-  }
+\itemize{
+\item Validate if input info is a numeric vector  or NULL, if non-NULL validate if it
+is strictly increasing and positive.
+\item Validate if input info0 is a numeric vector or NULL, if non-NULL validate if it
+is strictly increasing and positive.
+\item Validate if input info1 is a numeric vector or NULL, if non-NULL validate if it
+is strictly increasing and positive.
+\item Validate if input theta is a real vector and has the same length as info.
+\item Validate if input theta1 is a real vector and has the same length as info.
+\item Validate if input test_upper and test_lower are logical and have the same length as info.
+\item Validate if input test_upper value is TRUE.
+\item Validate if input alpha and beta are positive and of length one.
+\item Validate if input alpha and beta are from the unit interval and alpha is smaller than beta.
+\item Initialize bounds, numerical integration grids, boundary crossing probabilities.
+\item Compute fixed sample size for desired power and Type I error.
+\item Find an interval for information inflation to give correct power using \code{gs_power_npe()}.
+\item If there is no interim analysis, return a tibble including Analysis time, upper bound, Z-value,
+Probability of crossing bound, theta, info0 and info1.
+\item If the design is a group sequential design, return a tibble of Analysis,
+Bound, Z, Probability,  theta, info, info0.
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
 }
 
 \examples{

--- a/man/gs_design_wlr.Rd
+++ b/man/gs_design_wlr.Rd
@@ -54,7 +54,7 @@ gs_design_wlr(
 
 \item{ratio}{Experimental:Control randomization ratio.}
 
-\item{info_frac}{Targeted information fraction at each analysis. See details for properly set it up.}
+\item{info_frac}{Targeted information fraction for analyses. See details.}
 
 \item{info_scale}{Information scale for calculation. Options are:
 \itemize{
@@ -63,7 +63,7 @@ gs_design_wlr(
 \item \code{"h1_info"}: variance under alternative hypothesis is used.
 }}
 
-\item{analysis_time}{Targeted time of analysis. See details for properly set it up.}
+\item{analysis_time}{Targeted calendar timing of analyses. See details.}
 
 \item{binding}{Indicator of whether futility bound is binding;
 default of \code{FALSE} is recommended.}
@@ -82,11 +82,12 @@ default of \code{FALSE} is recommended.}
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{lpar}{Parameters passed to \code{lower}, which can be set up similarly as \code{upar.}}
 
@@ -103,17 +104,21 @@ lower bound.}
 
 \item{h1_spending}{Indicator that lower bound to be set by spending
 under alternate hypothesis (input \code{fail_rate})
-if spending is used for lower bound.}
+if spending is used for lower bound.
+If this is \code{FALSE}, then the lower bound spending is under the null hypothesis.
+This is for two-sided symmetric or asymmetric testing under the null hypothesis;
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{r}{Integer value controlling grid for numerical integration as in
 Jennison and Turnbull (2000); default is 18, range is 1 to 80.
 Larger values provide larger number of grid points and greater accuracy.
 Normally, \code{r} will not be changed by the user.}
 
-\item{tol}{Tolerance parameter for boundary convergence (on Z-scale).}
+\item{tol}{Tolerance parameter for boundary convergence (on Z-scale); normally not changed by the user.}
 
-\item{interval}{An interval that is presumed to include the time at which
-expected event count is equal to targeted event.}
+\item{interval}{An interval presumed to include the times at which
+expected event count is equal to targeted event.
+Normally, this can be ignored by the user as it is set to \code{c(.01, 1000)}.}
 }
 \value{
 A list with input parameters, enrollment rate, analysis, and bound.
@@ -123,18 +128,15 @@ Group sequential design using weighted log-rank test under non-proportional haza
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate if input analysis_time is a positive number or a positive increasing sequence.
-   \item Validate if input info_frac is a positive number
-   or positive increasing sequence on (0, 1] with final value of 1.
-   \item Validate if inputs info_frac and analysis_time  have the same length if both have length > 1.
-   \item Compute information at input analysis_time using \code{gs_info_wlr()}.
-   \item Compute sample size and bounds using \code{gs_design_npe()}.
-   \item Return a list of design enrollment, failure rates, and bounds.
-  }
+\itemize{
+\item Validate if input analysis_time is a positive number or a positive increasing sequence.
+\item Validate if input info_frac is a positive number
+or positive increasing sequence on (0, 1] with final value of 1.
+\item Validate if inputs info_frac and analysis_time  have the same length if both have length > 1.
+\item Compute information at input analysis_time using \code{gs_info_wlr()}.
+\item Compute sample size and bounds using \code{gs_design_npe()}.
+\item Return a list of design enrollment, failure rates, and bounds.
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
 }
 
 \examples{

--- a/man/gs_info_ahr.Rd
+++ b/man/gs_info_ahr.Rd
@@ -46,20 +46,17 @@ average HR at targeted \code{analysis_time}.
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate if input event is a numeric value vector or a vector with increasing values.
-   \item Validate if input analysis_time is a numeric value vector or a vector with increasing values.
-   \item Validate if inputs event and analysis_time have the same length if they are both specified.
-   \item Compute average hazard ratio:
-   \itemize{
-     \item If analysis_time is specified, calculate average hazard ratio using \code{ahr()}.
-     \item If event is specified, calculate average hazard ratio using \code{expected_time()}.
-   }
-   \item Return a data frame of Analysis, Time, AHR, Events, theta, info, info0.
-  }
+\itemize{
+\item Validate if input event is a numeric value vector or a vector with increasing values.
+\item Validate if input analysis_time is a numeric value vector or a vector with increasing values.
+\item Validate if inputs event and analysis_time have the same length if they are both specified.
+\item Compute average hazard ratio:
+\itemize{
+\item If analysis_time is specified, calculate average hazard ratio using \code{ahr()}.
+\item If event is specified, calculate average hazard ratio using \code{expected_time()}.
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
+\item Return a data frame of Analysis, Time, AHR, Events, theta, info, info0.
+}
 }
 
 \examples{

--- a/man/gs_power_ahr.Rd
+++ b/man/gs_power_ahr.Rd
@@ -31,9 +31,9 @@ gs_power_ahr(
 
 \item{fail_rate}{Failure and dropout rates defined by \code{define_fail_rate()}.}
 
-\item{event}{A numerical vector specifying the targeted event at each analysis.}
+\item{event}{A numerical vector specifying the targeted events at each analysis. See details.}
 
-\item{analysis_time}{Targeted time of analysis. See details for properly set it up.}
+\item{analysis_time}{Targeted calendar timing of analyses. See details.}
 
 \item{upper}{Function to compute upper bound.
 \itemize{
@@ -49,11 +49,12 @@ gs_power_ahr(
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{lpar}{Parameters passed to \code{lower}, which can be set up similarly as \code{upar.}}
 
@@ -85,31 +86,33 @@ Jennison and Turnbull (2000); default is 18, range is 1 to 80.
 Larger values provide larger number of grid points and greater accuracy.
 Normally, \code{r} will not be changed by the user.}
 
-\item{tol}{Tolerance parameter for boundary convergence (on Z-scale).}
+\item{tol}{Tolerance parameter for boundary convergence (on Z-scale); normally not changed by the user.}
 
-\item{interval}{An interval that is presumed to include the time at which
-expected event count is equal to targeted event.}
+\item{interval}{An interval presumed to include the times at which
+expected event count is equal to targeted event.
+Normally, this can be ignored by the user as it is set to \code{c(.01, 1000)}.}
 
-\item{integer}{Logical value integer whether it is an integer design
-(i.e., integer sample size and events) or not. This argument is commonly
-used when creating integer design via \code{\link[=to_integer]{to_integer()}}.}
+\item{integer}{Indicator of whether integer sample size and events are intended. This argument is
+used when using \code{\link[=to_integer]{to_integer()}}.}
 }
 \value{
 A list with input parameters, enrollment rate, analysis, and bound.
 \itemize{
-\item The \verb{$input} is a list including \code{alpha}, \code{beta}, \code{ratio}, etc.
-\item The \verb{$enroll_rate} is a table showing the enrollment, which is the same as input.
-\item The \verb{$fail_rate} is a table showing the failure and dropout rates, which is the same as input.
-\item The \verb{$bound} is a table summarizing the efficacy and futility bound per analysis.
-\item The \code{analysis} is a table summarizing the analysis time, sample size, events, average HR, treatment effect and statistical information per analysis.
+\item \verb{$input} a list including \code{alpha}, \code{beta}, \code{ratio}, etc.
+\item \verb{$enroll_rate} a table showing the enrollment, which is the same as input.
+\item \verb{$fail_rate} a table showing the failure and dropout rates, which is the same as input.
+\item \verb{$bound} a table summarizing the efficacy and futility bound at each analysis.
+\item \code{analysis} a table summarizing the analysis time, sample size, events, average HR, treatment effect and statistical information at each analysis.
 }
 }
 \description{
-Calculate the power given the sample size in group sequential design power using average hazard ratio under
+Calculate power given the sample size in group sequential design power using average hazard ratio under
 non-proportional hazards.
 }
 \details{
-Bound satisfy input upper bound specification in
+Note that time units are arbitrary, but should be the same for all rate parameters in \code{enroll_rate}, \code{fail_rate}, and \code{analysis_time}.
+
+Computed bounds satisfy input upper bound specification in
 \code{upper}, \code{upar}, and lower bound specification in \code{lower}, \code{lpar}.
 \code{\link[=ahr]{ahr()}} computes statistical information at targeted event times.
 The \code{\link[=expected_time]{expected_time()}} function is used to get events and average HR at
@@ -117,12 +120,15 @@ targeted \code{analysis_time}.
 
 The parameters \code{event} and \code{analysis_time} are used to determine the timing for interim and final analyses.
 \itemize{
-\item If the interim analysis is decided by targeted event,
-then \code{event} is a numerical vector where each element represents the targeted events for each analysis.
-\item If the interim analysis is determined solely by the targeted analysis timing,
-then \code{analysis_time} will be a vector specifying the time for each analysis.
-\item If both the targeted analysis time and the targeted event are utilized, which arrives latter,
-then both \code{event} and \code{analysis_time} should be provided as vectors.
+\item If analysis timing is to be determined by targeted events,
+then \code{event} is a numerical vector specifying the targeted events for each analysis;
+note that this can be NULL.
+\item If interim analysis is determined by targeted calendar timing relative to start of enrollment,
+then \code{analysis_time} will be a vector specifying the calendar time from start of study for each analysis;
+note that this can be NULL.
+\item A corresponding element of \code{event} or \code{analysis_time} should be provided for each analysis.
+\item If both \code{event[i]} and \code{analysis[i]} are provided for analysis \code{i}, then the time corresponding to the
+later of these is used  for analysis \code{i}.
 }
 }
 \examples{
@@ -152,6 +158,12 @@ gs_power_ahr(
 # Example 3 ----
 # 2-sided symmetric O'Brien-Fleming spending bound, driven by event,
 # i.e., `event = c(20, 50, 70)`, `analysis_time = NULL`
+# Note that this assumes targeted final events for the design is 70 events.
+# If actual targeted final events were 65, then `timing = c(20, 50, 70) / 65`
+# would be added to `upar` and `lpar` lists.
+# NOTE: at present the computed information fraction in output `analysis` is based
+# on 70 events rather than 65 events when the `timing` argument is used in this way.
+# A vignette on this topic will be forthcoming.
 \donttest{
 gs_power_ahr(
   analysis_time = NULL,

--- a/man/gs_power_combo.Rd
+++ b/man/gs_power_combo.Rd
@@ -48,11 +48,12 @@ default of \code{FALSE} is recommended.}
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{lpar}{Parameters passed to \code{lower}, which can be set up similarly as \code{upar.}}
 
@@ -71,19 +72,16 @@ Group sequential design power using MaxCombo test under non-proportional hazards
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate if lower and upper bounds have been specified.
-   \item Extract info, info_fh, theta_fh and corr_fh from utility.
-   \item Extract sample size via the maximum sample size of info.
-   \item Calculate information fraction either for fixed or group sequential design.
-   \item Compute spending function using \code{gs_bound()}.
-   \item Compute probability of crossing bounds under the null and alternative
-    hypotheses using \code{gs_prob_combo()}.
-   \item Export required information for boundary and crossing probability
-  }
+\itemize{
+\item Validate if lower and upper bounds have been specified.
+\item Extract info, info_fh, theta_fh and corr_fh from utility.
+\item Extract sample size via the maximum sample size of info.
+\item Calculate information fraction either for fixed or group sequential design.
+\item Compute spending function using \code{gs_bound()}.
+\item Compute probability of crossing bounds under the null and alternative
+hypotheses using \code{gs_prob_combo()}.
+\item Export required information for boundary and crossing probability
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
 }
 
 \examples{

--- a/man/gs_power_npe.Rd
+++ b/man/gs_power_npe.Rd
@@ -111,39 +111,25 @@ are not supported by \code{gs_power_npe()}.
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Extract the length of input info as the number of interim analysis.
-   \item Validate if input info0 is NULL, so set it equal to info.
-   \item Validate if the length of inputs info and info0 are the same.
-   \item Validate if input theta is a scalar, so replicate
-   the value for all k interim analysis.
-   \item Validate if input theta1 is NULL and if it is a scalar.
-   If it is NULL, set it equal to input theta. If it is a scalar,
-   replicate the value for all k interim analysis.
-   \item Validate if input test_upper is a scalar,
-   so replicate the value for all k interim analysis.
-   \item Validate if input test_lower is a scalar,
-   so replicate the value for all k interim analysis.
-   \item Define vector a to be -Inf with
-   length equal to the number of interim analysis.
-   \item Define vector b to be Inf with
-   length equal to the number of interim analysis.
-   \item Define hgm1_0 and hgm1 to be NULL.
-   \item Define upper_prob and lower_prob to be
-   vectors of NA with length of the number of interim analysis.
-   \item Update lower and upper bounds using \code{gs_b()}.
-   \item If there are no interim analysis, compute probabilities
-   of crossing upper and lower bounds
-   using \code{h1()}.
-   \item Compute cross upper and lower bound probabilities
-   using \code{hupdate()} and \code{h1()}.
-   \item Return a tibble of analysis number, bound, z-values,
-   probability of crossing bounds,
-   theta, theta1, info, and info0.
-  }
+\itemize{
+\item Extract the length of input info as the number of interim analysis.
+\item Validate if input info0 is NULL, so set it equal to info.
+\item Validate if the length of inputs info and info0 are the same.
+\item Validate if input theta is a scalar, so replicate the value for all k interim analysis.
+\item Validate if input theta1 is NULL and if it is a scalar.
+If it is NULL, set it equal to input theta. If it is a scalar,
+replicate the value for all k interim analysis.
+\item Validate if input test_upper is a scalar, so replicate the value for all k interim analysis.
+\item Validate if input test_lower is a scalar, so replicate the value for all k interim analysis.
+\item Define vector a to be -Inf with length equal to the number of interim analysis.
+\item Define vector b to be Inf with length equal to the number of interim analysis.
+\item Define hgm1_0 and hgm1 to be NULL.
+\item Define upper_prob and lower_prob to be vectors of NA with length of the number of interim analysis.
+\item Update lower and upper bounds using \code{gs_b()}.
+\item If there are no interim analysis, compute probabilities of crossing upper and lower bounds using \code{h1()}.
+\item Compute cross upper and lower bound probabilities using \code{hupdate()} and \code{h1()}.
+\item Return a tibble of analysis number, bound, z-values, probability of crossing bounds, theta, theta1, info, and info0.
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
 }
 
 \examples{

--- a/man/gs_power_wlr.Rd
+++ b/man/gs_power_wlr.Rd
@@ -32,9 +32,9 @@ gs_power_wlr(
 
 \item{fail_rate}{Failure and dropout rates defined by \code{define_fail_rate()}.}
 
-\item{event}{A numerical vector specifying the targeted event at each analysis.}
+\item{event}{A numerical vector specifying the targeted events at each analysis. See details.}
 
-\item{analysis_time}{Targeted time of analysis. See details for properly set it up.}
+\item{analysis_time}{Targeted calendar timing of analyses. See details.}
 
 \item{binding}{Indicator of whether futility bound is binding;
 default of \code{FALSE} is recommended.}
@@ -45,7 +45,8 @@ default of \code{FALSE} is recommended.}
 \item \code{gs_b()}: fixed efficacy bounds.
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{upar}{Parameters passed to \code{upper}.
 \itemize{
@@ -55,7 +56,7 @@ default of \code{FALSE} is recommended.}
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
@@ -100,14 +101,14 @@ Jennison and Turnbull (2000); default is 18, range is 1 to 80.
 Larger values provide larger number of grid points and greater accuracy.
 Normally, \code{r} will not be changed by the user.}
 
-\item{tol}{Tolerance parameter for boundary convergence (on Z-scale).}
+\item{tol}{Tolerance parameter for boundary convergence (on Z-scale); normally not changed by the user.}
 
-\item{interval}{An interval that is presumed to include the time at which
-expected event count is equal to targeted event.}
+\item{interval}{An interval presumed to include the times at which
+expected event count is equal to targeted event.
+Normally, this can be ignored by the user as it is set to \code{c(.01, 1000)}.}
 
-\item{integer}{Logical value integer whether it is an integer design
-(i.e., integer sample size and events) or not. This argument is commonly
-used when creating integer design via \code{\link[=to_integer]{to_integer()}}.}
+\item{integer}{Indicator of whether integer sample size and events are intended. This argument is
+used when using \code{\link[=to_integer]{to_integer()}}.}
 }
 \value{
 A list with input parameters, enrollment rate,
@@ -118,15 +119,12 @@ Group sequential design power using weighted log rank test under non-proportiona
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Compute information and effect size for Weighted Log-rank test using \code{gs_info_wlr()}.
-   \item Compute group sequential bound computation with non-constant effect using \code{gs_power_npe()}.
-   \item Combine information and effect size and power and return a
-   tibble  with columns Analysis, Bound, Time, Events, Z, Probability, AHR,  theta, info, and info0.
-  }
+\itemize{
+\item Compute information and effect size for Weighted Log-rank test using \code{gs_info_wlr()}.
+\item Compute group sequential bound computation with non-constant effect using \code{gs_power_npe()}.
+\item Combine information and effect size and power and return a
+tibble  with columns Analysis, Bound, Time, Events, Z, Probability, AHR,  theta, info, and info0.
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
 }
 
 \examples{

--- a/man/gs_spending_bound.Rd
+++ b/man/gs_spending_bound.Rd
@@ -69,20 +69,17 @@ that in Chapter 19 of Jennison and Turnbull (2000).
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Set the spending time at analysis.
-   \item Compute the cumulative spending at analysis.
-   \item Compute the incremental spend at each analysis.
-   \item Set test_bound a vector of length k > 1 if input as a single value.
-   \item Compute spending for current bound.
-   \item Iterate to convergence as in gsbound.c from gsDesign.
-   \item Compute subdensity for final analysis in rejection region.
-   \item Validate the output and return an error message in case of failure.
-   \item Return a numeric bound (possibly infinite).
-  }
+\itemize{
+\item Set the spending time at analysis.
+\item Compute the cumulative spending at analysis.
+\item Compute the incremental spend at each analysis.
+\item Set test_bound a vector of length k > 1 if input as a single value.
+\item Compute spending for current bound.
+\item Iterate to convergence as in gsbound.c from gsDesign.
+\item Compute subdensity for final analysis in rejection region.
+\item Validate the output and return an error message in case of failure.
+\item Return a numeric bound (possibly infinite).
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
 }
 
 \examples{

--- a/man/ppwe.Rd
+++ b/man/ppwe.Rd
@@ -35,22 +35,18 @@ The survival at time \eqn{t} is then
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate if input enrollment rate is a strictly increasing non-negative numeric vector.
-   \item Validate if input failure rate is of type data.frame.
-   \item Validate if input failure rate contains duration column.
-   \item Validate if input failure rate contains rate column.
-   \item Validate if input lower_tail is logical.
-   \item Convert rates to step function.
-   \item Add times where rates change to enrollment rates.
-   \item Make a tibble of the input time points x, duration, hazard rates at points,
-   cumulative hazard and survival.
-   \item Extract the expected cumulative or survival of piecewise exponential distribution.
-   \item If input lower_tail is true, return the CDF, else return the survival for \code{ppwe}
-  }
+\itemize{
+\item Validate if input enrollment rate is a strictly increasing non-negative numeric vector.
+\item Validate if input failure rate is of type data.frame.
+\item Validate if input failure rate contains duration column.
+\item Validate if input failure rate contains rate column.
+\item Validate if input lower_tail is logical.
+\item Convert rates to step function.
+\item Add times where rates change to enrollment rates.
+\item Make a tibble of the input time points x, duration, hazard rates at points, cumulative hazard and survival.
+\item Extract the expected cumulative or survival of piecewise exponential distribution.
+\item If input lower_tail is true, return the CDF, else return the survival for \code{ppwe}
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
 }
 
 \examples{

--- a/man/s2pwe.Rd
+++ b/man/s2pwe.Rd
@@ -20,17 +20,14 @@ to a piecewise exponential approximation.
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Validate if input times is increasing positive finite numbers.
-   \item Validate if input survival is numeric and same length as input times.
-   \item Validate if input survival is positive, non-increasing, less than or equal to 1 and greater than 0.
-   \item Create a tibble of inputs times and survival.
-   \item Calculate the duration, hazard and the rate.
-   \item Return the duration and rate by \code{s2pwe}
- }
- }
-\if{html}{The contents of this section are shown in PDF user manual only.}
+\itemize{
+\item Validate if input times is increasing positive finite numbers.
+\item Validate if input survival is numeric and same length as input times.
+\item Validate if input survival is positive, non-increasing, less than or equal to 1 and greater than 0.
+\item Create a tibble of inputs times and survival.
+\item Calculate the duration, hazard and the rate.
+\item Return the duration and rate by \code{s2pwe}
+}
 }
 
 \examples{

--- a/man/wlr_weight.Rd
+++ b/man/wlr_weight.Rd
@@ -52,16 +52,13 @@ A vector of weights.
 }
 \section{Specification}{
 
-\if{latex}{
- \itemize{
-   \item Compute the sample size via the sum of arm sizes.
-   \item Compute the proportion of size in the two arms.
-   \item If the input tau is specified, define time up to the cut off time tau.
-   \item Compute the CDF using the proportion of the size in the two arms and \code{npsruvSS::psurv()}.
-   \item Return the Fleming-Harrington weights for weighted Log-rank test.
-  }
+\itemize{
+\item Compute the sample size via the sum of arm sizes.
+\item Compute the proportion of size in the two arms.
+\item If the input tau is specified, define time up to the cut off time tau.
+\item Compute the CDF using the proportion of the size in the two arms and \code{npsruvSS::psurv()}.
+\item Return the Fleming-Harrington weights for weighted Log-rank test.
 }
-\if{html}{The contents of this section are shown in PDF user manual only.}
 }
 
 \examples{


### PR DESCRIPTION
This PR is not super important. I was just wondering if there was a reason that the function specifications were hidden from the HTML help pages. If this was intentional, please feel free to close the PR.