### PR TITLE
Add back recently deleted SOP specs

### DIFF
--- a/R/gs_design_ahr.R
+++ b/R/gs_design_ahr.R
@@ -74,6 +74,36 @@
 #'   - The `$fail_rate` is a table showing the failure and dropout rates, which is the same as input.
 #'   - The `$bound` is a table summarizing the efficacy and futility bound per analysis.
 #'   - The `analysis` is a table summarizing the analysis time, sample size, events, average HR, treatment effect and statistical information per analysis.
+#'
+#' @section Specification:
+#' \if{latex}{
+#'  \itemize{
+#'    \item Validate if input analysis_time is a positive number or positive
+#'    increasing sequence.
+#'    \item Validate if input info_frac is a positive number or positive
+#'    increasing sequence
+#'    on (0, 1] with final value of 1.
+#'    \item Validate if input info_frac and analysis_time  have the same
+#'    length if both have length > 1.
+#'    \item Get information at input analysis_time
+#'    \itemize{
+#'      \item Use \code{gs_info_ahr()} to get the information and effect size
+#'      based on AHR approximation.
+#'      \item Extract the final event.
+#'      \item Check if input If needed for (any) interim analysis timing.
+#'    }
+#'    \item Add the analysis column to the information at input analysis_time.
+#'    \item Add the sample size column to the information at input analysis_time
+#'    using \code{expected_accural()}.
+#'    \item Get sample size and bounds using \code{gs_design_npe()} and
+#'    save them to bounds.
+#'    \item Add Time, Events, AHR, N that have already been calculated
+#'    to the bounds.
+#'    \item Return a list of design enrollment, failure rates, and bounds.
+#'   }
+#' }
+#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#'
 #' @export
 #'
 #' @details

--- a/R/gs_power_ahr.R
+++ b/R/gs_power_ahr.R
@@ -54,6 +54,18 @@
 #'  - If both `event[i]` and `analysis[i]` are provided for analysis `i`, then the time corresponding to the
 #'  later of these is used  for analysis `i`.
 #'
+#' @section Specification:
+#' \if{latex}{
+#'  \itemize{
+#'    \item Calculate information and effect size based on AHR approximation
+#'    using \code{gs_info_ahr()}.
+#'    \item Return a tibble of with columns Analysis, Bound, Z, Probability,
+#'    theta, Time, AHR, Events and  contains a row for each analysis
+#'    and each bound.
+#'   }
+#' }
+#' \if{html}{The contents of this section are shown in PDF user manual only.}
+#'
 #' @export
 #'
 #' @examples

--- a/man/fixed_design.Rd
+++ b/man/fixed_design.Rd
@@ -110,7 +110,7 @@ and \code{1 - alpha} otherwise).}
 
 \item{study_duration}{Study duration.}
 
-\item{event}{A numerical vector specifying the targeted event at each analysis.}
+\item{event}{A numerical vector specifying the targeted events at each analysis. See details.}
 
 \item{rho}{A vector of numbers paring with gamma and tau for MaxCombo test.}
 

--- a/man/gs_design_ahr.Rd
+++ b/man/gs_design_ahr.Rd
@@ -130,6 +130,37 @@ then \code{analysis_time} will be a vector specifying the time for each analysis
 then timing will be the maximum of the two with both \code{info_frac} and \code{analysis_time} provided as vectors.
 }
 }
+\section{Specification}{
+
+\if{latex}{
+ \itemize{
+   \item Validate if input analysis_time is a positive number or positive
+   increasing sequence.
+   \item Validate if input info_frac is a positive number or positive
+   increasing sequence
+   on (0, 1] with final value of 1.
+   \item Validate if input info_frac and analysis_time  have the same
+   length if both have length > 1.
+   \item Get information at input analysis_time
+   \itemize{
+     \item Use \code{gs_info_ahr()} to get the information and effect size
+     based on AHR approximation.
+     \item Extract the final event.
+     \item Check if input If needed for (any) interim analysis timing.
+   }
+   \item Add the analysis column to the information at input analysis_time.
+   \item Add the sample size column to the information at input analysis_time
+   using \code{expected_accural()}.
+   \item Get sample size and bounds using \code{gs_design_npe()} and
+   save them to bounds.
+   \item Add Time, Events, AHR, N that have already been calculated
+   to the bounds.
+   \item Return a list of design enrollment, failure rates, and bounds.
+  }
+}
+\if{html}{The contents of this section are shown in PDF user manual only.}
+}
+
 \examples{
 library(gsDesign)
 library(gsDesign2)

--- a/man/gs_design_ahr.Rd
+++ b/man/gs_design_ahr.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/gs_design_ahr.R
 \name{gs_design_ahr}
 \alias{gs_design_ahr}
-\title{Calculate sample size and bounds given the power in group sequential design using average hazard ratio under non-proportional hazards}
+\title{Calculate sample size and bounds given targeted power and Type I error in group sequential design using average hazard ratio under non-proportional hazards}
 \usage{
 gs_design_ahr(
   enroll_rate = define_enroll_rate(duration = c(2, 2, 10), rate = c(3, 6, 9)),
@@ -36,9 +36,9 @@ gs_design_ahr(
 
 \item{beta}{Type II error.}
 
-\item{info_frac}{Targeted information fraction at each analysis. See details for properly set it up.}
+\item{info_frac}{Targeted information fraction for analyses. See details.}
 
-\item{analysis_time}{Targeted time of analysis. See details for properly set it up.}
+\item{analysis_time}{Targeted calendar timing of analyses. See details.}
 
 \item{ratio}{Experimental:Control randomization ratio.}
 
@@ -59,17 +59,21 @@ default of \code{FALSE} is recommended.}
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{lpar}{Parameters passed to \code{lower}, which can be set up similarly as \code{upar.}}
 
 \item{h1_spending}{Indicator that lower bound to be set by spending
 under alternate hypothesis (input \code{fail_rate})
-if spending is used for lower bound.}
+if spending is used for lower bound.
+If this is \code{FALSE}, then the lower bound spending is under the null hypothesis.
+This is for two-sided symmetric or asymmetric testing under the null hypothesis;
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{test_upper}{Indicator of which analyses should include an upper
 (efficacy) bound; single value of \code{TRUE} (default) indicates all analyses;
@@ -94,10 +98,11 @@ Jennison and Turnbull (2000); default is 18, range is 1 to 80.
 Larger values provide larger number of grid points and greater accuracy.
 Normally, \code{r} will not be changed by the user.}
 
-\item{tol}{Tolerance parameter for boundary convergence (on Z-scale).}
+\item{tol}{Tolerance parameter for boundary convergence (on Z-scale); normally not changed by the user.}
 
-\item{interval}{An interval that is presumed to include the time at which
-expected event count is equal to targeted event.}
+\item{interval}{An interval presumed to include the times at which
+expected event count is equal to targeted event.
+Normally, this can be ignored by the user as it is set to \code{c(.01, 1000)}.}
 }
 \value{
 A list with input parameters, enrollment rate, analysis, and bound.
@@ -110,19 +115,19 @@ A list with input parameters, enrollment rate, analysis, and bound.
 }
 }
 \description{
-Calculate sample size and bounds given the power in group sequential design using average hazard ratio under non-proportional hazards
+Calculate sample size and bounds given targeted power and Type I error in group sequential design using average hazard ratio under non-proportional hazards
 }
 \details{
 The parameters \code{info_frac} and \code{analysis_time} are used to determine the timing for interim and final analyses.
 \itemize{
-\item If the interim analysis is decided by targeted information fraction and the study duration is known,
+\item If the interim analysis is determined by targeted information fraction and the study duration is known,
 then \code{info_frac} is a numerical vector where each element (greater than 0 and less than or equal to 1)
 represents the information fraction for each analysis.
 The \code{analysis_time}, which defaults to 36, indicates the time for the final analysis.
-\item If the interim analysis is determined solely by the targeted analysis timing,
+\item If interim analyses are determined solely by the targeted calendar analysis timing from start of study,
 then \code{analysis_time} will be a vector specifying the time for each analysis.
-\item If both the targeted analysis time and the targeted information fraction are utilized, which arrives latter,
-then both \code{info_frac} and \code{analysis_time} should be provided as vectors.
+\item If both the targeted analysis time and the targeted information fraction are utilized for a given analysis,
+then timing will be the maximum of the two with both \code{info_frac} and \code{analysis_time} provided as vectors.
 }
 }
 \examples{

--- a/man/gs_design_combo.Rd
+++ b/man/gs_design_combo.Rd
@@ -55,11 +55,12 @@ default of \code{FALSE} is recommended.}
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{lpar}{Parameters passed to \code{lower}, which can be set up similarly as \code{upar.}}
 

--- a/man/gs_design_wlr.Rd
+++ b/man/gs_design_wlr.Rd
@@ -54,7 +54,7 @@ gs_design_wlr(
 
 \item{ratio}{Experimental:Control randomization ratio.}
 
-\item{info_frac}{Targeted information fraction at each analysis. See details for properly set it up.}
+\item{info_frac}{Targeted information fraction for analyses. See details.}
 
 \item{info_scale}{Information scale for calculation. Options are:
 \itemize{
@@ -63,7 +63,7 @@ gs_design_wlr(
 \item \code{"h1_info"}: variance under alternative hypothesis is used.
 }}
 
-\item{analysis_time}{Targeted time of analysis. See details for properly set it up.}
+\item{analysis_time}{Targeted calendar timing of analyses. See details.}
 
 \item{binding}{Indicator of whether futility bound is binding;
 default of \code{FALSE} is recommended.}
@@ -82,11 +82,12 @@ default of \code{FALSE} is recommended.}
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{lpar}{Parameters passed to \code{lower}, which can be set up similarly as \code{upar.}}
 
@@ -103,17 +104,21 @@ lower bound.}
 
 \item{h1_spending}{Indicator that lower bound to be set by spending
 under alternate hypothesis (input \code{fail_rate})
-if spending is used for lower bound.}
+if spending is used for lower bound.
+If this is \code{FALSE}, then the lower bound spending is under the null hypothesis.
+This is for two-sided symmetric or asymmetric testing under the null hypothesis;
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{r}{Integer value controlling grid for numerical integration as in
 Jennison and Turnbull (2000); default is 18, range is 1 to 80.
 Larger values provide larger number of grid points and greater accuracy.
 Normally, \code{r} will not be changed by the user.}
 
-\item{tol}{Tolerance parameter for boundary convergence (on Z-scale).}
+\item{tol}{Tolerance parameter for boundary convergence (on Z-scale); normally not changed by the user.}
 
-\item{interval}{An interval that is presumed to include the time at which
-expected event count is equal to targeted event.}
+\item{interval}{An interval presumed to include the times at which
+expected event count is equal to targeted event.
+Normally, this can be ignored by the user as it is set to \code{c(.01, 1000)}.}
 }
 \value{
 A list with input parameters, enrollment rate, analysis, and bound.

--- a/man/gs_power_ahr.Rd
+++ b/man/gs_power_ahr.Rd
@@ -131,6 +131,20 @@ note that this can be NULL.
 later of these is used  for analysis \code{i}.
 }
 }
+\section{Specification}{
+
+\if{latex}{
+ \itemize{
+   \item Calculate information and effect size based on AHR approximation
+   using \code{gs_info_ahr()}.
+   \item Return a tibble of with columns Analysis, Bound, Z, Probability,
+   theta, Time, AHR, Events and  contains a row for each analysis
+   and each bound.
+  }
+}
+\if{html}{The contents of this section are shown in PDF user manual only.}
+}
+
 \examples{
 library(gsDesign2)
 library(dplyr)

--- a/man/gs_power_ahr.Rd
+++ b/man/gs_power_ahr.Rd
@@ -31,9 +31,9 @@ gs_power_ahr(
 
 \item{fail_rate}{Failure and dropout rates defined by \code{define_fail_rate()}.}
 
-\item{event}{A numerical vector specifying the targeted event at each analysis.}
+\item{event}{A numerical vector specifying the targeted events at each analysis. See details.}
 
-\item{analysis_time}{Targeted time of analysis. See details for properly set it up.}
+\item{analysis_time}{Targeted calendar timing of analyses. See details.}
 
 \item{upper}{Function to compute upper bound.
 \itemize{
@@ -49,11 +49,12 @@ gs_power_ahr(
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{lpar}{Parameters passed to \code{lower}, which can be set up similarly as \code{upar.}}
 
@@ -85,31 +86,33 @@ Jennison and Turnbull (2000); default is 18, range is 1 to 80.
 Larger values provide larger number of grid points and greater accuracy.
 Normally, \code{r} will not be changed by the user.}
 
-\item{tol}{Tolerance parameter for boundary convergence (on Z-scale).}
+\item{tol}{Tolerance parameter for boundary convergence (on Z-scale); normally not changed by the user.}
 
-\item{interval}{An interval that is presumed to include the time at which
-expected event count is equal to targeted event.}
+\item{interval}{An interval presumed to include the times at which
+expected event count is equal to targeted event.
+Normally, this can be ignored by the user as it is set to \code{c(.01, 1000)}.}
 
-\item{integer}{Logical value integer whether it is an integer design
-(i.e., integer sample size and events) or not. This argument is commonly
-used when creating integer design via \code{\link[=to_integer]{to_integer()}}.}
+\item{integer}{Indicator of whether integer sample size and events are intended. This argument is
+used when using \code{\link[=to_integer]{to_integer()}}.}
 }
 \value{
 A list with input parameters, enrollment rate, analysis, and bound.
 \itemize{
-\item The \verb{$input} is a list including \code{alpha}, \code{beta}, \code{ratio}, etc.
-\item The \verb{$enroll_rate} is a table showing the enrollment, which is the same as input.
-\item The \verb{$fail_rate} is a table showing the failure and dropout rates, which is the same as input.
-\item The \verb{$bound} is a table summarizing the efficacy and futility bound per analysis.
-\item The \code{analysis} is a table summarizing the analysis time, sample size, events, average HR, treatment effect and statistical information per analysis.
+\item \verb{$input} a list including \code{alpha}, \code{beta}, \code{ratio}, etc.
+\item \verb{$enroll_rate} a table showing the enrollment, which is the same as input.
+\item \verb{$fail_rate} a table showing the failure and dropout rates, which is the same as input.
+\item \verb{$bound} a table summarizing the efficacy and futility bound at each analysis.
+\item \code{analysis} a table summarizing the analysis time, sample size, events, average HR, treatment effect and statistical information at each analysis.
 }
 }
 \description{
-Calculate the power given the sample size in group sequential design power using average hazard ratio under
+Calculate power given the sample size in group sequential design power using average hazard ratio under
 non-proportional hazards.
 }
 \details{
-Bound satisfy input upper bound specification in
+Note that time units are arbitrary, but should be the same for all rate parameters in \code{enroll_rate}, \code{fail_rate}, and \code{analysis_time}.
+
+Computed bounds satisfy input upper bound specification in
 \code{upper}, \code{upar}, and lower bound specification in \code{lower}, \code{lpar}.
 \code{\link[=ahr]{ahr()}} computes statistical information at targeted event times.
 The \code{\link[=expected_time]{expected_time()}} function is used to get events and average HR at
@@ -117,12 +120,15 @@ targeted \code{analysis_time}.
 
 The parameters \code{event} and \code{analysis_time} are used to determine the timing for interim and final analyses.
 \itemize{
-\item If the interim analysis is decided by targeted event,
-then \code{event} is a numerical vector where each element represents the targeted events for each analysis.
-\item If the interim analysis is determined solely by the targeted analysis timing,
-then \code{analysis_time} will be a vector specifying the time for each analysis.
-\item If both the targeted analysis time and the targeted event are utilized, which arrives latter,
-then both \code{event} and \code{analysis_time} should be provided as vectors.
+\item If analysis timing is to be determined by targeted events,
+then \code{event} is a numerical vector specifying the targeted events for each analysis;
+note that this can be NULL.
+\item If interim analysis is determined by targeted calendar timing relative to start of enrollment,
+then \code{analysis_time} will be a vector specifying the calendar time from start of study for each analysis;
+note that this can be NULL.
+\item A corresponding element of \code{event} or \code{analysis_time} should be provided for each analysis.
+\item If both \code{event[i]} and \code{analysis[i]} are provided for analysis \code{i}, then the time corresponding to the
+later of these is used  for analysis \code{i}.
 }
 }
 \examples{
@@ -152,6 +158,12 @@ gs_power_ahr(
 # Example 3 ----
 # 2-sided symmetric O'Brien-Fleming spending bound, driven by event,
 # i.e., `event = c(20, 50, 70)`, `analysis_time = NULL`
+# Note that this assumes targeted final events for the design is 70 events.
+# If actual targeted final events were 65, then `timing = c(20, 50, 70) / 65`
+# would be added to `upar` and `lpar` lists.
+# NOTE: at present the computed information fraction in output `analysis` is based
+# on 70 events rather than 65 events when the `timing` argument is used in this way.
+# A vignette on this topic will be forthcoming.
 \donttest{
 gs_power_ahr(
   analysis_time = NULL,

--- a/man/gs_power_combo.Rd
+++ b/man/gs_power_combo.Rd
@@ -48,11 +48,12 @@ default of \code{FALSE} is recommended.}
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{lpar}{Parameters passed to \code{lower}, which can be set up similarly as \code{upar.}}
 

--- a/man/gs_power_wlr.Rd
+++ b/man/gs_power_wlr.Rd
@@ -32,9 +32,9 @@ gs_power_wlr(
 
 \item{fail_rate}{Failure and dropout rates defined by \code{define_fail_rate()}.}
 
-\item{event}{A numerical vector specifying the targeted event at each analysis.}
+\item{event}{A numerical vector specifying the targeted events at each analysis. See details.}
 
-\item{analysis_time}{Targeted time of analysis. See details for properly set it up.}
+\item{analysis_time}{Targeted calendar timing of analyses. See details.}
 
 \item{binding}{Indicator of whether futility bound is binding;
 default of \code{FALSE} is recommended.}
@@ -45,7 +45,8 @@ default of \code{FALSE} is recommended.}
 \item \code{gs_b()}: fixed efficacy bounds.
 }}
 
-\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}. More details can be find in \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
+\item{lower}{Function to compute lower bound, which can be set up similarly as \code{upper}.
+See \href{https://merck.github.io/gsDesign2/articles/story-seven-test-types.html}{this vignette}.}
 
 \item{upar}{Parameters passed to \code{upper}.
 \itemize{
@@ -55,7 +56,7 @@ default of \code{FALSE} is recommended.}
 \item \code{sf} for the spending function family.
 \item \code{total_spend} for total alpha spend.
 \item \code{param} for the parameter of the spending function.
-\item \code{timing} (not required for information-based spending) for the spending time if different from information-based spending.
+\item \code{timing} specifies spending time if different from information-based spending; see details.
 }
 }}
 
@@ -100,14 +101,14 @@ Jennison and Turnbull (2000); default is 18, range is 1 to 80.
 Larger values provide larger number of grid points and greater accuracy.
 Normally, \code{r} will not be changed by the user.}
 
-\item{tol}{Tolerance parameter for boundary convergence (on Z-scale).}
+\item{tol}{Tolerance parameter for boundary convergence (on Z-scale); normally not changed by the user.}
 
-\item{interval}{An interval that is presumed to include the time at which
-expected event count is equal to targeted event.}
+\item{interval}{An interval presumed to include the times at which
+expected event count is equal to targeted event.
+Normally, this can be ignored by the user as it is set to \code{c(.01, 1000)}.}
 
-\item{integer}{Logical value integer whether it is an integer design
-(i.e., integer sample size and events) or not. This argument is commonly
-used when creating integer design via \code{\link[=to_integer]{to_integer()}}.}
+\item{integer}{Indicator of whether integer sample size and events are intended. This argument is
+used when using \code{\link[=to_integer]{to_integer()}}.}
 }
 \value{
 A list with input parameters, enrollment rate,


### PR DESCRIPTION
* The SOP specs for `gs_design_ahr()` and `gs_power_ahr()` were deleted in #501 
* Turns out these specs are required "to follow organization SOP for software development life cycle requirement" (https://github.com/Merck/gsDesign2/pull/508#issuecomment-2739975217)
* We may try to develop a system to better integrate these specs into the source code while still adhering to the SOP requirements (https://github.com/Merck/gsDesign2/pull/508#issuecomment-2740903348), but for now I simply wanted to add them back
* Note that there are extra changes in the `man/` directory because of recent changes to the roxgyen2 comments