### PR TITLE
Display gt tables on function reference pages

### DIFF
--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -32,7 +32,7 @@ as_gt <- function(x, ...) {
 #'
 #' @export
 #'
-#' @examplesIf !identical(Sys.getenv("IN_PKGDOWN"), "true")
+#' @examples
 #' # Fixed design examples ----
 #'
 #' library(dplyr)
@@ -156,7 +156,7 @@ fd_footnote <- function(x, method) {
 #'
 #' @export
 #'
-#' @examplesIf !identical(Sys.getenv("IN_PKGDOWN"), "true")
+#' @examples
 #' \donttest{
 #' # Group sequential design examples ---
 #'

--- a/man/as_gt.Rd
+++ b/man/as_gt.Rd
@@ -59,7 +59,6 @@ A \code{gt_tbl} object.
 Convert summary table of a fixed or group sequential design object to a gt object
 }
 \examples{
-\dontshow{if (!identical(Sys.getenv("IN_PKGDOWN"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # Fixed design examples ----
 
 library(dplyr)
@@ -107,8 +106,6 @@ fixed_design_fh(
 ) \%>\%
   summary() \%>\%
   as_gt()
-\dontshow{\}) # examplesIf}
-\dontshow{if (!identical(Sys.getenv("IN_PKGDOWN"), "true")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 \donttest{
 # Group sequential design examples ---
 
@@ -196,5 +193,4 @@ gs_power_wlr(lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.1)) \%>\%
   summary() \%>\%
   as_gt(display_columns = c("Analysis", "Bound", "Nominal p", "Z", "Probability"))
 }
-\dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
This PR is a follow up to #502 and #338, to remove the `@examplesIf` condition for examples sections containing gt outputs.

gt tables can now be properly displayed on function reference pages directly in pkgdown >= 2.1.0, instead of being rendered as thousands lines of raw HTML (https://github.com/r-lib/pkgdown/issues/2326).