### PR TITLE
Use magrittr pipe exclusively in examples for consistency

### DIFF
--- a/R/gs_update_ahr.R
+++ b/R/gs_update_ahr.R
@@ -81,7 +81,7 @@
 #'   lower = gs_spending_bound,
 #'   lpar = list(sf = sfLDOF, total_spend = beta),
 #'   test_lower = c(TRUE, FALSE),
-#'   binding = FALSE) |> to_integer()
+#'   binding = FALSE) %>% to_integer()
 #'
 #' planned_event_ia <- x$analysis$event[1]
 #' planned_event_fa <- x$analysis$event[2]

--- a/R/to_integer.R
+++ b/R/to_integer.R
@@ -76,8 +76,8 @@ to_integer <- function(x, ...) {
 #'   ),
 #'   study_duration = 36
 #' )
-#' x |>
-#'   to_integer() |>
+#' x %>%
+#'   to_integer() %>%
 #'   summary()
 #'
 #' # FH
@@ -93,8 +93,8 @@ to_integer <- function(x, ...) {
 #'   rho = 0.5, gamma = 0.5,
 #'   study_duration = 36, ratio = 1
 #' )
-#' x |>
-#'   to_integer() |>
+#' x %>%
+#'   to_integer() %>%
 #'   summary()
 #'
 #' # MB
@@ -109,8 +109,8 @@ to_integer <- function(x, ...) {
 #'   tau = 4,
 #'   study_duration = 36, ratio = 1
 #' )
-#' x |>
-#'   to_integer() |>
+#' x %>%
+#'   to_integer() %>%
 #'   summary()
 #' }
 to_integer.fixed_design <- function(x, round_up_final = TRUE, ratio = x$input$ratio, ...) {
@@ -283,8 +283,8 @@ to_integer.fixed_design <- function(x, round_up_final = TRUE, ratio = x$input$ra
 #'   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL),
 #'   lower = gs_b,
 #'   lpar = c(-Inf, -Inf)
-#' ) |>
-#'   to_integer() |>
+#' ) %>%
+#'   to_integer() %>%
 #'   summary()
 #'
 #' gs_design_wlr(
@@ -293,8 +293,8 @@ to_integer.fixed_design <- function(x, round_up_final = TRUE, ratio = x$input$ra
 #'   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL),
 #'   lower = gs_b,
 #'   lpar = c(-Inf, -Inf)
-#' ) |>
-#'   to_integer() |>
+#' ) %>%
+#'   to_integer() %>%
 #'   summary()
 #'
 #' gs_design_rd(
@@ -307,8 +307,8 @@ to_integer.fixed_design <- function(x, round_up_final = TRUE, ratio = x$input$ra
 #'   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL),
 #'   lower = gs_b,
 #'   lpar = c(-Inf, -Inf)
-#' ) |>
-#'   to_integer() |>
+#' ) %>%
+#'   to_integer() %>%
 #'   summary()
 #'
 #' # Example 2: Calendar based spending
@@ -321,7 +321,7 @@ to_integer.fixed_design <- function(x, round_up_final = TRUE, ratio = x$input$ra
 #'   ),
 #'   lower = gs_b,
 #'   lpar = c(-Inf, -Inf)
-#' ) |> to_integer()
+#' ) %>% to_integer()
 #'
 #' # The IA nominal p-value is the same as the IA alpha spending
 #' x$bound$`nominal p`[1]

--- a/man/gs_update_ahr.Rd
+++ b/man/gs_update_ahr.Rd
@@ -82,7 +82,7 @@ x <- gs_design_ahr(
   lower = gs_spending_bound,
   lpar = list(sf = sfLDOF, total_spend = beta),
   test_lower = c(TRUE, FALSE),
-  binding = FALSE) |> to_integer()
+  binding = FALSE) \%>\% to_integer()
 
 planned_event_ia <- x$analysis$event[1]
 planned_event_fa <- x$analysis$event[2]

--- a/man/to_integer.Rd
+++ b/man/to_integer.Rd
@@ -91,8 +91,8 @@ x <- fixed_design_ahr(
   ),
   study_duration = 36
 )
-x |>
-  to_integer() |>
+x \%>\%
+  to_integer() \%>\%
   summary()
 
 # FH
@@ -108,8 +108,8 @@ x <- fixed_design_fh(
   rho = 0.5, gamma = 0.5,
   study_duration = 36, ratio = 1
 )
-x |>
-  to_integer() |>
+x \%>\%
+  to_integer() \%>\%
   summary()
 
 # MB
@@ -124,8 +124,8 @@ x <- fixed_design_mb(
   tau = 4,
   study_duration = 36, ratio = 1
 )
-x |>
-  to_integer() |>
+x \%>\%
+  to_integer() \%>\%
   summary()
 }
 \donttest{
@@ -136,8 +136,8 @@ gs_design_ahr(
   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL),
   lower = gs_b,
   lpar = c(-Inf, -Inf)
-) |>
-  to_integer() |>
+) \%>\%
+  to_integer() \%>\%
   summary()
 
 gs_design_wlr(
@@ -146,8 +146,8 @@ gs_design_wlr(
   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL),
   lower = gs_b,
   lpar = c(-Inf, -Inf)
-) |>
-  to_integer() |>
+) \%>\%
+  to_integer() \%>\%
   summary()
 
 gs_design_rd(
@@ -160,8 +160,8 @@ gs_design_rd(
   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL),
   lower = gs_b,
   lpar = c(-Inf, -Inf)
-) |>
-  to_integer() |>
+) \%>\%
+  to_integer() \%>\%
   summary()
 
 # Example 2: Calendar based spending
@@ -174,7 +174,7 @@ x <- gs_design_ahr(
   ),
   lower = gs_b,
   lpar = c(-Inf, -Inf)
-) |> to_integer()
+) \%>\% to_integer()
 
 # The IA nominal p-value is the same as the IA alpha spending
 x$bound$`nominal p`[1]


### PR DESCRIPTION
The `R CMD check` results for R-devel now include the following [warning](https://github.com/Merck/gsDesign2/actions/runs/14135791482/job/39607076060#step:6:49):

```
  NB: this package now depends on R (>= 4.1.0)
  WARNING: Added dependency on R >= 4.1.0 because package code uses the
  pipe |> or function shorthand \(...) syntax added in R 4.1.0.
  File(s) using such syntax:
    ‘gs_update_ahr.Rd’ ‘to_integer.Rd’
```

This is because we have started to use the native pipe `|>` in some of the examples, but the `DESCRIPTION` continues to only require R >=3.5:

https://github.com/Merck/gsDesign2/blob/d0a5897e244a84240a27cdd1bd51cfb5f06d2b34/DESCRIPTION#L37

Given that {gsDesign2} depends on dplyr and imports the magrittr pipe (`%>%`) into the package namespace, I think it makes sense to continue to use the magritter pipe for now: 

https://github.com/Merck/gsDesign2/blob/d0a5897e244a84240a27cdd1bd51cfb5f06d2b34/NAMESPACE#L68

At some point we'll want to migrate the entire package to use the native pipe `|>`, but at this point I don't think this is urgently needed.

**Background:**

* {simtrial} has migrated to the native pipe and requires R >= 4.1.0 (https://github.com/Merck/simtrial/pull/146). This makes more sense since it allowed us to completely drop the dependency on magrittr (since gsDesign2 depends on dplyr, magrittr will continue to be a transitive dependency whether or not we use its pipe in our code)
* The gsDesign2 README uses the native pipe (https://github.com/Merck/gsDesign2/pull/348). This is fine since this code is not run during installation and thus does not prevent the package from being built and installed with R 3.5 (and therefore `R CMD check` does not flag this code as problematic)
