### PR TITLE
Add arg `alpha` to `gs_bound_summary()` to report multiple efficacy bounds

### DIFF
--- a/R/gs_bound_summary.R
+++ b/R/gs_bound_summary.R
@@ -3,6 +3,7 @@
 #' Summarizes the efficacy and futility bounds for each analysis.
 #'
 #' @param x design object
+#' @param alpha vector of alpha values to compute additional efficacy columns
 #'
 #' @return A data frame
 #'
@@ -17,8 +18,36 @@
 #' x <- gs_design_wlr(info_frac = c(.25, .75, 1), analysis_time = c(12, 25, 36))
 #' gs_bound_summary(x)
 #'
+#' # Report multiple efficacy bounds (only supported for AHR designs)
+#' x <- gs_design_ahr(analysis_time = 1:3*12, alpha = 0.0125)
+#' gs_bound_summary(x, alpha = c(0.025, 0.05))
+#'
 #' @export
-gs_bound_summary <- function(x) {
+gs_bound_summary <- function(x, alpha = NULL) {
+  if (is.null(alpha)) return(gs_bound_summary_single(x))
+  if (!inherits(x, "ahr")) stop("The argument `alpha` is only supported for AHR design objects")
+  if (!is.numeric(alpha)) stop("The argument `alpha` must be a numeric vector")
+
+  # Support multiple alphas
+  alpha_original <- x[["input"]][["alpha"]]
+  alpha_new <- unique(sort(c(alpha, alpha_original)))
+  col_efficacy_name <- paste0("α=", alpha_new)
+  outlist <- vector("list", length = length(alpha_new))
+  for (i in seq_along(alpha_new)) {
+    if (alpha_new[i] == alpha_original) {
+      outlist[[i]] <- gs_bound_summary_single(x, col_efficacy_name[i])
+    } else {
+      x_updated <- gs_update_ahr(x, alpha = alpha_new[i])
+      x_updated_bounds <- gs_bound_summary_single(x_updated, col_efficacy_name[i])
+      outlist[[i]] <- x_updated_bounds[col_efficacy_name[i]]
+    }
+  }
+  out <- Reduce(cbind, outlist)
+  out <- out[, c("Analysis", "Value", col_efficacy_name, "Futility")]
+  return(out)
+}
+
+gs_bound_summary_single <- function(x, col_efficacy_name = "Efficacy") {
   # Input
   analysis <- x$analysis
   bound <- x$bound
@@ -79,13 +108,15 @@ gs_bound_summary <- function(x) {
     col_futility <- c(col_futility, as.numeric(row_futility))
   }
 
-  col_futility <- round(col_futility, 4)
   col_efficacy <- round(col_efficacy, 4)
+  col_futility <- round(col_futility, 4)
 
-  data.frame(
+  out <- data.frame(
     Analysis = col_analysis,
     Value = col_value,
     Efficacy = col_efficacy,
     Futility = col_futility
   )
+  colnames(out)[3] <- col_efficacy_name
+  return(out)
 }

--- a/R/gs_bound_summary.R
+++ b/R/gs_bound_summary.R
@@ -31,7 +31,7 @@ gs_bound_summary <- function(x, alpha = NULL) {
   # Support multiple alphas
   alpha_original <- x[["input"]][["alpha"]]
   alpha_new <- unique(sort(c(alpha, alpha_original)))
-  col_efficacy_name <- paste0("α=", alpha_new)
+  col_efficacy_name <- paste0("\u03b1=", alpha_new)
   outlist <- vector("list", length = length(alpha_new))
   for (i in seq_along(alpha_new)) {
     if (alpha_new[i] == alpha_original) {

--- a/man/gs_bound_summary.Rd
+++ b/man/gs_bound_summary.Rd
@@ -4,10 +4,12 @@
 \alias{gs_bound_summary}
 \title{Bound summary table}
 \usage{
-gs_bound_summary(x)
+gs_bound_summary(x, alpha = NULL)
 }
 \arguments{
 \item{x}{design object}
+
+\item{alpha}{vector of alpha values to compute additional efficacy columns}
 }
 \value{
 A data frame
@@ -23,6 +25,10 @@ gs_bound_summary(x)
 
 x <- gs_design_wlr(info_frac = c(.25, .75, 1), analysis_time = c(12, 25, 36))
 gs_bound_summary(x)
+
+# Report multiple efficacy bounds (only supported for AHR designs)
+x <- gs_design_ahr(analysis_time = 1:3*12, alpha = 0.0125)
+gs_bound_summary(x, alpha = c(0.025, 0.05))
 
 }
 \seealso{


### PR DESCRIPTION
Closes #522

xref: #468, #515

Still some open questions:
- [x] Only supported for AHR design objects? (https://github.com/Merck/gsDesign2/issues/522#issuecomment-2824907077)
    * Confirmed. The initial implementation will only support AHR design objects. Support for WLR design objects will be added after `gs_update_wlr()` has been added (https://github.com/Merck/gsDesign2/pull/535#issuecomment-2836186975)
- [x] How to properly support design objects created by `gs_power_ahr()`? Currently I don't treat them any different that design objects created by `gs_design_ahr()` (https://github.com/Merck/gsDesign2/issues/522#issuecomment-2828026719)
    * Confirmed. It is ok to use `x[["input"]][["alpha"]]` for objects created by either function (https://github.com/Merck/gsDesign2/pull/535#issuecomment-2836188185)

```R
library("gsDesign2")

x <- gs_design_ahr(analysis_time = 1:3*12, alpha = 0.0125)
gs_bound_summary(x, alpha = c(0.025, 0.05))
##       Analysis               Value α=0.0125 α=0.025 α=0.05 Futility
## 1    IA 1: 31%                   Z   4.3506  3.8728 3.3437  -1.6192
## 2       N: 509         p (1-sided)   0.0000  0.0001 0.0004   0.9473
## 3  Events: 115        ~HR at bound   0.4449  0.4863 0.5366   1.3518
## 4    Month: 12    P(Cross) if HR=1   0.0000  0.0001 0.0004   0.0527
## 5              P(Cross) if AHR=0.8   0.0007  0.0032 0.0139   0.0032
## 6    IA 2: 74%                   Z   2.6778  2.3579 2.0022   1.1590
## 7       N: 611         p (1-sided)   0.0037  0.0092 0.0226   0.1232
## 8  Events: 278        ~HR at bound   0.7251  0.7535 0.7863   0.8701
## 9    Month: 24    P(Cross) if HR=1   0.0037  0.0092 0.0228   0.8768
## 10             P(Cross) if AHR=0.7   0.5336  0.6571 0.7770   0.0556
## 11       Final                   Z   2.2781  2.0096 1.7134   2.2775
## 12      N: 611         p (1-sided)   0.0114  0.0222 0.0433   0.0114
## 13 Events: 375        ~HR at bound   0.7903  0.8125 0.8378   0.7903
## 14   Month: 36    P(Cross) if HR=1   0.0122  0.0237 0.0445   0.9878
## 15             P(Cross) if AHR=0.7   0.9000  0.9252 0.9390   0.1001
```