### PR TITLE
Allow bound functions to be specified as character strings for `gs_power_ahr()`

### DIFF
--- a/R/gs_power_ahr.R
+++ b/R/gs_power_ahr.R
@@ -164,6 +164,9 @@ gs_power_ahr <- function(
   # Get the info_scale
   info_scale <- match.arg(info_scale)
 
+  upper <- match.fun(upper)
+  lower <- match.fun(lower)
+
   # Check if it is two-sided design or not
   if ((identical(lower, gs_b) && (!is.list(lpar))) || all(!test_lower)) {
     if (all(test_lower == FALSE)) {


### PR DESCRIPTION
This is a very simple PR similar to #509, and needed for the Shiny app (for power calculation). It will be great to get it merged relatively soon. Thanks!