### PR TITLE
Add Merck ROR ID to package metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Authors@R: c(
     person("Yalin", "Zhu", email = "yalin.zhu@outlook.com", role = c("ctb")),
     person("John", "Blischak", email = "jdblischak@gmail.com", role = c("ctb")),
     person("Dickson", "Wanjau", email = "dickson.wanjau@merck.com", role = c("ctb")),
-    person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = "cph")
+    person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = "cph",
+           comment = c(ROR = "02891sr49"))
     )
 Description: The goal of 'gsDesign2' is to enable fixed or group sequential
     design under non-proportional hazards. To enable highly flexible enrollment,

--- a/man/gsDesign2-package.Rd
+++ b/man/gsDesign2-package.Rd
@@ -43,7 +43,7 @@ Other contributors:
   \item Yalin Zhu \email{yalin.zhu@outlook.com} [contributor]
   \item John Blischak \email{jdblischak@gmail.com} [contributor]
   \item Dickson Wanjau \email{dickson.wanjau@merck.com} [contributor]
-  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates [copyright holder]
+  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates (02891sr49) [copyright holder]
 }
 
 }


### PR DESCRIPTION
CRAN and {pkgdown} [2.1.2](https://github.com/r-lib/pkgdown/releases/tag/v2.1.2) now support linking to an organization's ROR ID: https://ror.org/02891sr49