### PR TITLE
Remove column "Futility" from bound table of a one-sided design

### DIFF
--- a/R/gs_bound_summary.R
+++ b/R/gs_bound_summary.R
@@ -43,7 +43,11 @@ gs_bound_summary <- function(x, alpha = NULL) {
     }
   }
   out <- Reduce(cbind, outlist)
-  out <- out[, c("Analysis", "Value", col_efficacy_name, "Futility")]
+  # Use of union() allows placement of column "Futility" at the far right, but
+  # only if it is returned by gs_bound_summary_single(). This is because
+  # one-sided designs do not produce a Futility column.
+  column_order <- union(c("Analysis", "Value", col_efficacy_name), colnames(out))
+  out <- out[, column_order]
   return(out)
 }
 
@@ -118,5 +122,9 @@ gs_bound_summary_single <- function(x, col_efficacy_name = "Efficacy") {
     Futility = col_futility
   )
   colnames(out)[3] <- col_efficacy_name
+
+  # One-sided design should not include Futility column
+  if (all(is.na(out[["Futility"]]))) out[["Futility"]] <- NULL
+
   return(out)
 }

--- a/tests/testthat/test-developer-gs_bound_summary.R
+++ b/tests/testthat/test-developer-gs_bound_summary.R
@@ -114,3 +114,14 @@ test_that("Edge case: when arg `alpha` matches original alpha", {
   expect_equal(colnames(x_bound_same)[3], "α=0.0125")
   expect_equal(unname(x_bound_same), unname(x_bound))
 })
+
+test_that("One-sided design should not have column Futility", {
+  x <- gs_design_ahr(info_frac = 1:3/3, lower = gs_b, lpar = rep(-Inf, 3))
+  x_bound <- gs_bound_summary(x)
+
+  expect_false("Futility" %in% colnames(x_bound))
+
+  x_bound_alpha <- gs_bound_summary(x, alpha = c(0.025, 0.05))
+
+  expect_false("Futility" %in% colnames(x_bound_alpha))
+})


### PR DESCRIPTION
xref: https://github.com/Merck/gsDesign2/issues/537#issuecomment-2887612108, https://github.com/Merck/gsDesign2/issues/537#issuecomment-2898853025

```R
library("gsDesign2")

# one-sided design
x <- gs_design_ahr(info_frac = 1:3/3, lower = gs_b, lpar = rep(-Inf, 3))
head(gs_bound_summary(x), 3)
##      Analysis        Value Efficacy
## 1   IA 1: 33%            Z   3.7103
## 2      N: 430  p (1-sided)   0.0001
## 3 Events: 100 ~HR at bound   0.4764
head(gs_bound_summary(x, alpha = c(0.025, 0.05)), 3)
##      Analysis        Value α=0.025 α=0.05
## 1   IA 1: 33%            Z  3.7103 3.2001
## 2      N: 430  p (1-sided)  0.0001 0.0007
## 3 Events: 100 ~HR at bound  0.4764 0.5275
```