### PR TITLE
Add formatting args to gs_bound_summary()

### DIFF
--- a/R/gs_bound_summary.R
+++ b/R/gs_bound_summary.R
@@ -2,8 +2,9 @@
 #'
 #' Summarizes the efficacy and futility bounds for each analysis.
 #'
-#' @param x design object
-#' @param alpha vector of alpha values to compute additional efficacy columns
+#' @param x Design object.
+#' @param alpha Vector of alpha values to compute additional efficacy columns.
+#' @inheritParams gsDesign::gsBoundSummary
 #'
 #' @return A data frame
 #'
@@ -23,8 +24,12 @@
 #' gs_bound_summary(x, alpha = c(0.025, 0.05))
 #'
 #' @export
-gs_bound_summary <- function(x, alpha = NULL) {
-  if (is.null(alpha)) return(gs_bound_summary_single(x))
+gs_bound_summary <- function(x, digits = 4, ddigits = 2, tdigits = 0, timename = "Month", alpha = NULL) {
+  if (is.null(alpha)) {
+    out <- gs_bound_summary_single(x, digits = digits, ddigits = ddigits,
+                                   tdigits = tdigits, timename = timename)
+    return(out)
+  }
   if (!inherits(x, "ahr")) stop("The argument `alpha` is only supported for AHR design objects")
   if (!is.numeric(alpha)) stop("The argument `alpha` must be a numeric vector")
 
@@ -35,10 +40,14 @@ gs_bound_summary <- function(x, alpha = NULL) {
   outlist <- vector("list", length = length(alpha_new))
   for (i in seq_along(alpha_new)) {
     if (alpha_new[i] == alpha_original) {
-      outlist[[i]] <- gs_bound_summary_single(x, col_efficacy_name[i])
+      outlist[[i]] <- gs_bound_summary_single(x, col_efficacy_name[i],
+                                              digits = digits, ddigits = ddigits,
+                                              tdigits = tdigits, timename = timename)
     } else {
       x_updated <- gs_update_ahr(x, alpha = alpha_new[i])
-      x_updated_bounds <- gs_bound_summary_single(x_updated, col_efficacy_name[i])
+      x_updated_bounds <- gs_bound_summary_single(x_updated, col_efficacy_name[i],
+                                                  digits = digits, ddigits = ddigits,
+                                                  tdigits = tdigits, timename = timename)
       outlist[[i]] <- x_updated_bounds[col_efficacy_name[i]]
     }
   }
@@ -51,7 +60,8 @@ gs_bound_summary <- function(x, alpha = NULL) {
   return(out)
 }
 
-gs_bound_summary_single <- function(x, col_efficacy_name = "Efficacy") {
+gs_bound_summary_single <- function(x, col_efficacy_name = "Efficacy", digits,
+                                    ddigits, tdigits, timename) {
   # Input
   analysis <- x$analysis
   bound <- x$bound
@@ -72,20 +82,22 @@ gs_bound_summary_single <- function(x, col_efficacy_name = "Efficacy") {
     info <- paste0(info, "%")
     n <- round(analysis$n[i])
     events <- round(analysis$event[i])
-    month <- analysis$time[i]
+    time_value <- round(analysis$time[i], tdigits)
+    # If the value is an integer, force it to have the correct number of decimal places
+    time_value <- format(time_value, nsmall = tdigits)
 
     col_analysis <- c(
       col_analysis,
       if (i == final) "Final" else paste(label, info),
       paste("N:", n),
       paste("Events:", events),
-      paste("Month:", month),
+      paste0(timename, ": ", time_value),
       ""
     )
 
     # Value column
     hr <- analysis[analysis$analysis == i, "ahr"]
-    hr <- round(hr, 1)
+    hr <- round(hr, ddigits)
     hr_label <- "HR"
     # logrank test (gs_xxx_ahr): HR -> AHR
     if (inherits(x, "ahr")) hr_label <- "AHR"
@@ -112,8 +124,8 @@ gs_bound_summary_single <- function(x, col_efficacy_name = "Efficacy") {
     col_futility <- c(col_futility, as.numeric(row_futility))
   }
 
-  col_efficacy <- round(col_efficacy, 4)
-  col_futility <- round(col_futility, 4)
+  col_efficacy <- round(col_efficacy, digits)
+  col_futility <- round(col_futility, digits)
 
   out <- data.frame(
     Analysis = col_analysis,

--- a/man/gs_bound_summary.Rd
+++ b/man/gs_bound_summary.Rd
@@ -4,12 +4,30 @@
 \alias{gs_bound_summary}
 \title{Bound summary table}
 \usage{
-gs_bound_summary(x, alpha = NULL)
+gs_bound_summary(
+  x,
+  digits = 4,
+  ddigits = 2,
+  tdigits = 0,
+  timename = "Month",
+  alpha = NULL
+)
 }
 \arguments{
-\item{x}{design object}
+\item{x}{Design object.}
 
-\item{alpha}{vector of alpha values to compute additional efficacy columns}
+\item{digits}{Number of digits past the decimal to be printed in the body of
+the table.}
+
+\item{ddigits}{Number of digits past the decimal to be printed for the
+natural parameter delta.}
+
+\item{tdigits}{Number of digits past the decimal point to be shown for
+estimated timing of each analysis.}
+
+\item{timename}{Text string indicating time unit.}
+
+\item{alpha}{Vector of alpha values to compute additional efficacy columns.}
 }
 \value{
 A data frame

--- a/tests/testthat/test-developer-gs_bound_summary.R
+++ b/tests/testthat/test-developer-gs_bound_summary.R
@@ -18,11 +18,11 @@ test_that("gs_bound_summary() uses correct HR label", {
 
   x_ahr <- gs_design_ahr(info_frac = c(.25, .75, 1), analysis_time = c(12, 25, 36))
   x_ahr_bound <- gs_bound_summary(x_ahr)
-  expect_identical(x_ahr_bound$Value[5], "P(Cross) if AHR=0.8")
+  expect_identical(x_ahr_bound$Value[5], "P(Cross) if AHR=0.81")
 
   x_wlr <- gs_design_wlr(info_frac = c(.25, .75, 1), analysis_time = c(12, 25, 36))
   x_wlr_bound <- gs_bound_summary(x_wlr)
-  expect_identical(x_wlr_bound$Value[5], "P(Cross) if wAHR=0.8")
+  expect_identical(x_wlr_bound$Value[5], "P(Cross) if wAHR=0.81")
 
 })
 
@@ -124,4 +124,60 @@ test_that("One-sided design should not have column Futility", {
   x_bound_alpha <- gs_bound_summary(x, alpha = c(0.025, 0.05))
 
   expect_false("Futility" %in% colnames(x_bound_alpha))
+})
+
+test_that("Arg `digits` controls number of digits in table body", {
+  x <- gs_design_ahr(info_frac = c(.25, .75, 1), analysis_time = c(12, 25, 36))
+  x_bound_5 <- gs_bound_summary(x, digits = 5)
+  x_bound_1 <- gs_bound_summary(x, digits = 1)
+
+  efficacy_5 <- nchar(format(x_bound_5$Efficacy))
+  efficacy_1 <- nchar(format(x_bound_1$Efficacy))
+  expect_equal(unique(efficacy_5 - efficacy_1), 5 - 1)
+
+  futility_5 <- nchar(format(x_bound_5$Futility))
+  futility_1 <- nchar(format(x_bound_1$Futility))
+  expect_equal(unique(futility_5 - futility_1), 5 - 1)
+})
+
+test_that("Arg `ddigits` controls number of digits for delta value", {
+  x <- gs_design_ahr(info_frac = 1:3 / 3)
+
+  x_bound_1 <- gs_bound_summary(x, ddigits = 1)
+  expect_identical(
+    x_bound_1$Value[c(5, 10, 15)],
+    c("P(Cross) if AHR=0.8", "P(Cross) if AHR=0.7", "P(Cross) if AHR=0.7")
+  )
+
+  x_bound_2 <- gs_bound_summary(x, ddigits = 2)
+  expect_identical(
+    x_bound_2$Value[c(5, 10, 15)],
+    c("P(Cross) if AHR=0.81", "P(Cross) if AHR=0.73", "P(Cross) if AHR=0.68")
+  )
+
+  x_bound_3 <- gs_bound_summary(x, ddigits = 3)
+  expect_identical(
+    x_bound_3$Value[c(5, 10, 15)],
+    c("P(Cross) if AHR=0.806", "P(Cross) if AHR=0.729", "P(Cross) if AHR=0.683")
+  )
+})
+
+test_that("Arg `tdigits` controls number of digits for estimated timing", {
+  x <- gs_design_ahr(info_frac = 1:3 / 3)
+  x_bound <- gs_bound_summary(x, tdigits = 2)
+
+  expect_identical(
+    x_bound$Analysis[c(4, 9, 14)],
+    c("Month: 12.53", "Month: 21.29", "Month: 36.00")
+  )
+})
+
+test_that("Arg `timename` controls time unit label", {
+  x <- gs_design_ahr(info_frac = c(.25, .75, 1), analysis_time = c(12, 25, 36))
+  x_bound <- gs_bound_summary(x, timename = "Fortnight")
+
+  expect_identical(
+    x_bound$Analysis[c(4, 9, 14)],
+    c("Fortnight: 12", "Fortnight: 25", "Fortnight: 36")
+  )
 })


### PR DESCRIPTION
Closes #537 

I added formatting arguments to `gs_bound_summary()`. The names and default values match that of `gsDesign::gsBoundSummary()`. For the documentation of the new arguments, I inherited from `gsDesign::gsBoundSummary()`.

```R
formals(gsDesign::gsBoundSummary)[c("digits", "ddigits", "tdigits", "timename")]
## $digits
## [1] 4
##
## $ddigits
## [1] 2
##
## $tdigits
## [1] 0
##
## $timename
## [1] "Month"
```

Here is an example:

```R
library("gsDesign2")

x <- gs_design_ahr(analysis_time = 1:3*12, alpha = 0.0125)
gs_bound_summary(x, digits = 2, ddigits = 3, tdigits = 2, timename = "Time",
                 alpha = c(0.025, 0.05))
##       Analysis                 Value α=0.0125 α=0.025 α=0.05 Futility
## 1    IA 1: 31%                     Z     4.35    3.87   3.34    -1.62
## 2       N: 509           p (1-sided)     0.00    0.00   0.00     0.95
## 3  Events: 115          ~HR at bound     0.44    0.49   0.54     1.35
## 4  Time: 12.00      P(Cross) if HR=1     0.00    0.00   0.00     0.05
## 5              P(Cross) if AHR=0.811     0.00    0.00   0.01     0.00
## 6    IA 2: 74%                     Z     2.68    2.36   2.00     1.16
## 7       N: 611           p (1-sided)     0.00    0.01   0.02     0.12
## 8  Events: 278          ~HR at bound     0.73    0.75   0.79     0.87
## 9  Time: 24.00      P(Cross) if HR=1     0.00    0.01   0.02     0.88
## 10             P(Cross) if AHR=0.715     0.53    0.66   0.78     0.06
## 11       Final                     Z     2.28    2.01   1.71     2.28
## 12      N: 611           p (1-sided)     0.01    0.02   0.04     0.01
## 13 Events: 375          ~HR at bound     0.79    0.81   0.84     0.79
## 14 Time: 36.00      P(Cross) if HR=1     0.01    0.02   0.04     0.99
## 15             P(Cross) if AHR=0.683     0.90    0.93   0.94     0.10
```
