### PR TITLE
Temporarily remove ROR ID to avoid `R CMD check` NOTE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,8 +20,7 @@ Authors@R: c(
     person("Yalin", "Zhu", email = "yalin.zhu@outlook.com", role = c("ctb")),
     person("Shiyu", "Zhang", email = "shiyu.zhang@merck.com", role = c("ctb")),
     person("Dickson", "Wanjau", email = "dickson.wanjau@merck.com", role = c("ctb")),
-    person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = "cph",
-           comment = c(ROR = "02891sr49"))
+    person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = "cph")
     )
 Description: The goal of 'gsDesign2' is to enable fixed or group sequential
     design under non-proportional hazards. To enable highly flexible enrollment,

--- a/man/gsDesign2-package.Rd
+++ b/man/gsDesign2-package.Rd
@@ -45,7 +45,7 @@ Other contributors:
   \item Yalin Zhu \email{yalin.zhu@outlook.com} [contributor]
   \item Shiyu Zhang \email{shiyu.zhang@merck.com} [contributor]
   \item Dickson Wanjau \email{dickson.wanjau@merck.com} [contributor]
-  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates (02891sr49) [copyright holder]
+  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates [copyright holder]
 }
 
 }


### PR DESCRIPTION
Revert "Add Merck ROR ID to package metadata"
This reverts commit 8c57f32ca487cf1c4f67a6d72da69b48d90f534b.

This is really strange. I added the ROR ID to {gsDesign2} (https://github.com/Merck/gsDesign2/pull/544) in exactly the same way as {gsDesign} (https://github.com/keaven/gsDesign/pull/201), and {gsDesign} was recently accepted to CRAN (and the nicely formatted ROR ID is displayed on its CRAN page). Furthermore, our GitHub Actions workflow with [R-devel on ubuntu-latest](https://github.com/Merck/gsDesign2/blob/218ee4f2090e3a0642de109ecd2884aa07ecc1e4/.github/workflows/R-CMD-check.yaml#L24) does not produce this NOTE. Unfortunately, the incoming CRAN checks on both Windows and Debian both produce the following NOTE:

```
* checking DESCRIPTION meta-information ... NOTE
Author field differs from that derived from Authors@R
  Author:    'Keaven Anderson [aut], Yujie Zhao [aut, cre], Yilong Zhang [aut], John Blischak [aut], Yihui Xie [aut], Nan Xiao [aut], Jianxiao Yang [aut], Amin Shirazi [ctb], Ruixue Wang [ctb], Yi Cui [ctb], Ping Yang [ctb], Xin Tong Li [ctb], Chenxiang Li [ctb], Hiroaki Fukuda [ctb], Hongtao Zhang [ctb], Yalin Zhu [ctb], Shiyu Zhang [ctb], Dickson Wanjau [ctb], Merck & Co., Inc., Rahway, NJ, USA and its affiliates [cph] (02891sr49)'
  Authors@R: 'Keaven Anderson [aut], Yujie Zhao [aut, cre], Yilong Zhang [aut], John Blischak [aut], Yihui Xie [aut], Nan Xiao [aut], Jianxiao Yang [aut], Amin Shirazi [ctb], Ruixue Wang [ctb], Yi Cui [ctb], Ping Yang [ctb], Xin Tong Li [ctb], Chenxiang Li [ctb], Hiroaki Fukuda [ctb], Hongtao Zhang [ctb], Yalin Zhu [ctb], Shiyu Zhang [ctb], Dickson Wanjau [ctb], Merck & Co., Inc., Rahway, NJ, USA and its affiliates [cph] (ROR: <https://ror.org/02891sr49>)'
```

The only difference is the ending in how the ROR ID is formatted:

```diff
- Merck & Co., Inc., Rahway, NJ, USA and its affiliates [cph] (02891sr49)
+ Merck & Co., Inc., Rahway, NJ, USA and its affiliates [cph] (ROR: <https://ror.org/02891sr49>)
```

I couldn't find anything in [R-devel NEWS](https://stat.ethz.ch/R-manual/R-devel/doc/html/NEWS.html), the recent [R changelog](https://github.com/wch/r-source/compare/tags/R-4-5-0...trunk), or the [r-package-devel mailing list archives](https://stat.ethz.ch/pipermail/r-package-devel/) to indicate that there has been any recent update.

I tried various things, but the only way I was able to avoid the NOTE entirely was to remove the ROR comment. While this is a nice to have, I don't think we want it to block our next release. I'll create an Issue to remind us to add back, when hopefully this feature is more stable.