### PR TITLE
Remove native pipe from package code to avoid R >= 4.1.0 requirement

### DIFF
--- a/R/utility_wlr.R
+++ b/R/utility_wlr.R
@@ -302,8 +302,8 @@ gs_sigma2_wlr <- function(arm0,
   # ----------------------- #
   # get enroll duration and relative rate
   # ----------------------- #
-  enroll_duration <- arm0$accr_interval |> diff()
-  enroll_total_duration <- arm0$accr_interval |> max()
+  enroll_duration <- arm0$accr_interval %>% diff()
+  enroll_total_duration <- arm0$accr_interval %>% max()
   n_enroll_piece <- length(enroll_duration)
   enroll_relative_rate <- rep(-10, n_enroll_piece)
   for (s in 1:n_enroll_piece) {
@@ -345,7 +345,7 @@ gs_sigma2_wlr <- function(arm0,
       arm0$accr_time <- tmax
       arm1$accr_time <- tmax
       # truncate the accrual interval to be stop at the time of analysis
-      arm0$accr_interval <- c(tmax, arm0$accr_interval)[which(c(tmax, arm0$accr_interval) <= tmax)] |> sort()
+      arm0$accr_interval <- c(tmax, arm0$accr_interval)[which(c(tmax, arm0$accr_interval) <= tmax)] %>% sort()
       arm1$accr_interval <- arm0$accr_interval
       truncated_enroll_duration <- diff(arm0$accr_interval)
       # adjust the accrual probability per interval by the truncated interval


### PR DESCRIPTION
Follow-up to https://github.com/Merck/gsDesign2/pull/563

We currently have the following [warning](https://github.com/Merck/gsDesign2/actions/runs/17273245622/job/49023338062#step:6:49) in CI when building the package:

```
  NB: this package now depends on R (>= 4.1.0)
  WARNING: Added dependency on R >= 4.1.0 because package code uses the
  pipe |> or function shorthand \(...) syntax added in R 4.1.0.
  File(s) using such syntax:
    ‘utility_wlr.R’
```

Since the native pipe was only used 3 times, I decided to replace it with the magrittr pipe for now. In the future we can migrate completely from the magrittr pipe to the native pipe and require R >= 4.1.0 at that time.
