### PR TITLE
Update text_summary() to support fixed designs from gs_design_ahr()

### DIFF
--- a/man/text_summary.Rd
+++ b/man/text_summary.Rd
@@ -59,4 +59,13 @@ gs_design_ahr(
                                fail_rate = log(2) / 10, dropout_rate = 0.001),
   info_frac = 1:3/3, test_lower = FALSE) |>
   text_summary()
+
+# Text summary of a fixed design created with gs_design_ahr()
+x <- gs_design_ahr(
+  upper = gs_b,
+  lower = gs_b,
+  upar = qnorm(1 - 0.025),
+  lpar = -Inf
+)
+x |> text_summary()
 }


### PR DESCRIPTION
When a fixed design is selected in the [app](https://rinpharma.shinyapps.io/gsdesign2/), the following error appears below the summary table:

```R
Error: $ operator is invalid for atomic vectors
```

This is because `text_summary()` is expecting a function when determining the upper bound.

https://github.com/Merck/gsDesign2/blob/5103d9c21bba96a45d43be6545a4e65db30747b2/R/text_summary.R#L192

A fixed design has no upper bound, so I fixed this by conditioning on `n_analysis > 1`.

Now the text summary for a fixed design works as below:

> One-sided group sequential design with 1 analyses, time-to-event outcome with sample size 1124 and 865 events,  percent (1-sided) Type I error. Enrollment and total study durations are assumed to be 24 and 30 months, respectively. With hazard ratio of 1 during the first 3 months and 0.7 thereafter, the power is 90 percent.

```R
library(gsDesign)
library(gsDesign2)

# Enrollment
enroll_rate <- define_enroll_rate(duration = c(2, 2, 2, 18), rate = c(1, 2, 3, 4), stratum = "All")

# Failure rates
duration <- diff(c(0, 3, 103))
control_rate <- log(2)/c(6, 6)
fail_rate <- define_fail_rate(duration, fail_rate = control_rate, dropout_rate = c(0.001, 0.001), hr = c(1, 0.7), stratum = "All")

x <- gs_design_ahr(
  enroll_rate = enroll_rate,
  fail_rate = fail_rate,
  alpha = 0.025,
  beta = 0.1,
  analysis_time = 30,
  ratio = 1,
  binding = FALSE,
  upper = "gs_b",
  upar = qnorm(1 - 0.025),
  lower = "gs_b",
  lpar = -Inf,
  h1_spending = TRUE,
  test_lower = FALSE,
  info_scale = "h0_info"
) |>
  to_integer()

text_summary(x)
## [1] "One-sided group sequential design with 1 analyses, time-to-event outcome with sample size 1124 and 865 events,  percent (1-sided) Type I error. Enrollment and total study durations are assumed to be 24 and 30 months, respectively. With hazard ratio of 1 during the first 3 months and 0.7 thereafter, the power is 90 percent."
```