### PR TITLE
Fix NOTE about undefined global variable `t.1` in `pw_info()`

### DIFF
--- a/R/pw_info.R
+++ b/R/pw_info.R
@@ -175,7 +175,6 @@ pw_info <- function(
 
   # pool strata together for each time period
   tbl_event <- tbl_event[, .(
-    t = min(t),
     event = sum(event),
     info0 = sum(info0),
     info = sum(info)
@@ -186,7 +185,6 @@ pw_info <- function(
   # -------------------------------------- #
   # merge 2 tables tbl_n and tbl_event, where they share the same time, t, stratum
   ans <- tbl_event[tbl_n, on = c("time", "stratum", "t")]
-  ans[, t.1 := NULL]
 
   # filter out the rows with 0 events and unneeded columns
   ans <- ans[!almost_equal(event, 0L), .(time, stratum, t, hr, n, event, info, info0)]


### PR DESCRIPTION
This is a follow-up to PR #579. It introduced the following [NOTE](https://github.com/Merck/gsDesign2/actions/runs/17618847779/job/50059048636?pr=579#step:6:95) from `R CMD check`:

```
* checking R code for possible problems ... [15s/10s] NOTE
pw_info: no visible binding for global variable ‘t.1’
  (/home/runner/work/gsDesign2/gsDesign2/check/gsDesign2.Rcheck/00_pkg_src/gsDesign2/R/pw_info.R:189)
Undefined global functions or variables:
  t.1
```

This is caused by the following line, which uses the non-standard evaluation feature of {data.table} to update the table by reference:

https://github.com/Merck/gsDesign2/blob/5103d9c21bba96a45d43be6545a4e65db30747b2/R/pw_info.R#L189

There are various workarounds to fix this:

* Add `t.1 <- NULL` just above the line. This is sufficient to satisfy `R CMD check`, but clutters the code with another line related to an unimportant intermediate variable
* Replace `ans[, t.1 := NULL]` with `ans[["t.1"]] <- NULL`. I confirmed via `data.table::address()` that the latter makes a copy of the data table, but for such a small object, this will have a negligible effect on performance

However, I was concerned why `t.1` was introduced in the first place. I realized it came from this step, where `t` is both calculated and used as a grouping variable. Since `t` is in `by`, there is by definition only a single value, and thus no need to run `min(t)`.

https://github.com/Merck/gsDesign2/blob/5103d9c21bba96a45d43be6545a4e65db30747b2/R/pw_info.R#L176-L182

After I removed `t = min(t)`, the column `t.1` was no longer created because `tbl_event` only had a single column `t`. The NOTE is removed, and the tests all pass. I also ran the code examples below and confirmed the results were identical before and after my change:


```R
pw_info()
##   time stratum t  hr  n    event     info    info0
## 1   30     All 0 0.9 12 21.24782 5.300180 5.311956
## 2   30     All 3 0.6 96 37.24314 9.027063 9.310786

pw_info(
  enroll_rate = define_enroll_rate(
    duration = 12,
    rate = 20
  ),
  fail_rate = define_fail_rate(
    duration = c(9, Inf),
    fail_rate = log(2) / c(10, 20),
    hr = c(0.72, 0.72),
    dropout_rate = 0.001
  ),
  total_duration = 50,
  ratio = 1
)
##   time stratum t   hr   n    event     info    info0
## 1   50     All 0 0.72 180 98.70948 24.29858 24.67737
## 2   50     All 9 0.72  60 87.45497 21.86273 21.86374
```
