### PR TITLE
Migrate documentation to roxygen2 7.3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,4 +68,4 @@ VignetteBuilder:
 LinkingTo:
     Rcpp
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/gridpts_h1_hupdate.R
+++ b/R/gridpts_h1_hupdate.R
@@ -119,7 +119,7 @@ h1 <- function(r = 18, theta = 0, info = 1, a = -Inf, b = Inf) {
 #' @param b Upper limit of integration (scalar `> a`).
 #' @param thetam1 Drift parameter for previous analysis.
 #' @param im1 Information at previous analysis.
-#' @param gm1 Numerical integration grid from [h1()] or previous run of [hupdate()].
+#' @param gm1 Numerical integration grid from `h1()` or previous run of `hupdate()`.
 #'
 #' @return A list with grid points in `z`,
 #'   numerical integration weights in `w`,

--- a/man/gsDesign2-package.Rd
+++ b/man/gsDesign2-package.Rd
@@ -45,7 +45,7 @@ Other contributors:
   \item Yalin Zhu \email{yalin.zhu@outlook.com} [contributor]
   \item Shiyu Zhang \email{shiyu.zhang@merck.com} [contributor]
   \item Dickson Wanjau \email{dickson.wanjau@merck.com} [contributor]
-  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates (02891sr49) [copyright holder]
+  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates (\href{https://ror.org/02891sr49}{ROR}) [copyright holder]
 }
 
 }


### PR DESCRIPTION
**tl;dr** This PR makes minor edits to the documentation of the non-exported function `hupdate()` to unblock migration to roxgyen2 7.3.3

xref: https://github.com/Merck/simtrial/pull/351

## Background

When I update to roxygen2 [7.3.3](https://github.com/r-lib/roxygen2/releases/tag/v7.3.3) and document the package, I receive the following messages:

```R
==> Rcpp::compileAttributes()

* Updated R/RcppExports.R

==> devtools::document(roclets = c('rd', 'collate', 'namespace'))

ℹ Updating gsDesign2 documentation
ℹ Loading gsDesign2
✖ gridpts_h1_hupdate.R:122: @param Could not resolve link to topic "h1" in the
  dependencies or base packages.
ℹ If you haven't documented "h1" yet, or just changed its name, this is
  normal. Once "h1" is documented, this warning goes away.
ℹ Make sure that the name of the topic is spelled correctly.
ℹ Always list the linked package as a dependency.
ℹ Alternatively, you can fully qualify the link with a package name.
✖ gridpts_h1_hupdate.R:122: @param Could not resolve link to topic "hupdate"
  in the dependencies or base packages.
ℹ If you haven't documented "hupdate" yet, or just changed its name, this is
  normal. Once "hupdate" is documented, this warning goes away.
ℹ Make sure that the name of the topic is spelled correctly.
ℹ Always list the linked package as a dependency.
ℹ Alternatively, you can fully qualify the link with a package name.
Documentation completed
```

I'm not certain exactly what caused this change between roxygen2 [7.3.3 and 7.3.2](https://github.com/r-lib/roxygen2/compare/v7.3.2...v7.3.3), but my guess is that it was PR https://github.com/r-lib/roxygen2/pull/1633 to "Resolve markdown links to external packages". It isn't worth investigating further because these messages are about the documentation for the internal function `hupdate()` which has the tag `@noRd`. Thus I fixed it by converting the links to code syntax.

## Alternative considered

Since both `h1()` and `hupdate()` already have nice documentation written for them, my initial plan was to simply remove the `@noRd` tags. This didn't work though because they are not exported to `NAMESPACE`, and thus their examples fail. From `R CMD check`:

```R
E  checking examples ... [109s] ERROR (1m 52s)
   Running examples in 'gsDesign2-Ex.R' failed
   The error most likely occurred in:

   > base::assign(".ptime", proc.time(), pos = "CheckExEnv")
   > ### Name: h1
   > ### Title: Initialize numerical integration for group sequential design
   > ### Aliases: h1
   >
   > ### ** Examples
   >
   > # Replicate variance of 1, mean of 35
   > g <- h1(theta = 5, info = 49)
   Error in h1(theta = 5, info = 49) : could not find function "h1"
   Execution halted
E  checking examples with --run-donttest ... [267s] ERROR (4m 28.7s)
   Running examples in 'gsDesign2-Ex.R' failed
   The error most likely occurred in:

   > base::assign(".ptime", proc.time(), pos = "CheckExEnv")
   > ### Name: h1
   > ### Title: Initialize numerical integration for group sequential design
   > ### Aliases: h1
   >
   > ### ** Examples
   >
   > # Replicate variance of 1, mean of 35
   > g <- h1(theta = 5, info = 49)
   Error in h1(theta = 5, info = 49) : could not find function "h1"
   Execution halted
```

The next consideration would be to export them, but they were explicitly un-exported for {gsDesign2} 1.1.0 (https://github.com/Merck/gsDesign2/issues/253, https://github.com/Merck/gsDesign2/pull/261), so I abandoned this approach.

https://github.com/Merck/gsDesign2/blob/fe4d2dc07c8ce3ba0ce179e5b3c762d4512b7c76/NEWS.md?plain=1#L207
