### PR TITLE
Optimize return object preparation from gs_power_npe()

### DIFF
--- a/R/gs_power_npe.R
+++ b/R/gs_power_npe.R
@@ -384,7 +384,7 @@ gs_power_npe <- function(theta = .1, theta0 = 0, theta1 = theta, # 3 theta
     }
   }
 
-  ans <- tibble(
+  ans <- data.frame(
     analysis = rep(1:n_analysis, 2),
     bound = c(rep("upper", n_analysis), rep("lower", n_analysis)),
     z = c(b, a),
@@ -392,14 +392,10 @@ gs_power_npe <- function(theta = .1, theta0 = 0, theta1 = theta, # 3 theta
     theta = rep(theta, 2),
     theta1 = rep(theta1, 2),
     info_frac = rep(info / max(info), 2),
-    info = rep(info, 2)
-  ) |>
-    mutate(
-      info0 = rep(info0, 2),
-      info1 = rep(info1, 2)
-    ) |>
-    # filter(abs(Z) < Inf) |>
-    arrange(desc(bound), analysis)
+    info = rep(info, 2),
+    info0 = rep(info0, 2),
+    info1 = rep(info1, 2)
+  )
 
   return(ans)
 }

--- a/tests/testthat/test-developer-gs_design_npe.R
+++ b/tests/testthat/test-developer-gs_design_npe.R
@@ -90,7 +90,7 @@ test_that("fixed design with 3 equal info", {
     dplyr::mutate(bound = tolower(bound)) |>
     dplyr::select(-c(theta1, info1)) |>
     dplyr::arrange(analysis, bound)
-  expect_equal(x1_c, x2)
+  expect_equal(x1_c, as.data.frame(x2))
 })
 
 test_that("fixed design with 3 unequal info", {
@@ -128,7 +128,7 @@ test_that("fixed design with 3 unequal info", {
     dplyr::mutate(bound = tolower(bound)) |>
     dplyr::select(-c(theta1, info1)) |>
     dplyr::arrange(analysis, bound)
-  expect_equal(x1_c, x2)
+  expect_equal(x1_c, as.data.frame(x2))
 })
 
 test_that("futility at IA1; efficacy only at IA2 +FA", {
@@ -170,7 +170,7 @@ test_that("futility at IA1; efficacy only at IA2 +FA", {
     dplyr::mutate(bound = tolower(bound)) |>
     dplyr::select(-c(theta1, info1)) |>
     dplyr::arrange(analysis, bound)
-  expect_equal(x1_c, x2)
+  expect_equal(x1_c, as.data.frame(x2))
 })
 
 test_that("spending bounds", {
@@ -216,7 +216,7 @@ test_that("spending bounds", {
     dplyr::mutate(bound = tolower(bound)) |>
     dplyr::select(analysis, bound, z, probability, theta, info, info0, info1) |>
     dplyr::arrange(analysis, bound)
-  expect_equal(x1_c, x2)
+  expect_equal(x1_c, as.data.frame(x2))
 })
 
 test_that("2-sided symmetric spend", {
@@ -266,5 +266,5 @@ test_that("2-sided symmetric spend", {
     dplyr::mutate(bound = tolower(bound)) |>
     dplyr::select(analysis, bound, z, probability, theta, info, info0, info1) |>
     dplyr::arrange(analysis, bound)
-  expect_equal(x1_c, x2)
+  expect_equal(x1_c, as.data.frame(x2))
 })

--- a/tests/testthat/test-developer-gs_power_npe.R
+++ b/tests/testthat/test-developer-gs_power_npe.R
@@ -6,7 +6,7 @@ test_that("The default of `gs_power_npe` is a single analysis with type I error 
     dplyr::filter(Bound == "Upper") |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  expect_equal(x1, x2)
+  expect_equal(x1, as.data.frame(x2))
 })
 
 test_that("fixed bound", {
@@ -29,7 +29,7 @@ test_that("fixed bound", {
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  expect_equal(x1, x2)
+  expect_equal(x1, as.data.frame(x2))
 })
 
 test_that("Same fixed efficacy bounds, no futility bound (i.e., non-binding bound), null hypothesis", {
@@ -48,7 +48,7 @@ test_that("Same fixed efficacy bounds, no futility bound (i.e., non-binding boun
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  expect_equal(x1, x2)
+  expect_equal(x1, as.data.frame(x2))
 })
 
 test_that("Fixed bound with futility only at analysis 1; efficacy only at analyses 2, 3", {
@@ -71,7 +71,7 @@ test_that("Fixed bound with futility only at analysis 1; efficacy only at analys
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  expect_equal(x1, x2)
+  expect_equal(x1, as.data.frame(x2))
 })
 
 test_that("Spending function bounds - Lower spending based on non-zero effect", {
@@ -94,7 +94,7 @@ test_that("Spending function bounds - Lower spending based on non-zero effect", 
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  expect_equal(x1, x2)
+  expect_equal(x1, as.data.frame(x2))
 })
 
 test_that("Same bounds, but power under different theta", {
@@ -117,7 +117,7 @@ test_that("Same bounds, but power under different theta", {
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  expect_equal(x1, x2)
+  expect_equal(x1, as.data.frame(x2))
 })
 
 test_that("Two-sided symmetric spend, O'Brien-Fleming spending", {
@@ -142,7 +142,7 @@ test_that("Two-sided symmetric spend, O'Brien-Fleming spending", {
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  expect_equal(x1, x2)
+  expect_equal(x1, as.data.frame(x2))
 })
 
 test_that("Re-use these bounds under alternate hypothesis - Always use binding = TRUE for power calculations", {
@@ -173,7 +173,7 @@ test_that("Re-use these bounds under alternate hypothesis - Always use binding =
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  expect_equal(x1, x2)
+  expect_equal(x1, as.data.frame(x2))
 })
 
 test_that("info != info0 != info1 - If one inputs info in upar", {
@@ -206,7 +206,7 @@ test_that("info != info0 != info1 - If one inputs info in upar", {
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  expect_equal(x1_c, x2)
+  expect_equal(x1_c, as.data.frame(x2))
 })
 
 test_that("Developer Tests 1-sided test", {
@@ -238,7 +238,7 @@ test_that("Developer Tests 1-sided test", {
     n.I = (1:3) * 400,
     b = gsDesign::gsDesign(k = 3, test.type = 1, sfu = gsDesign::sfLDOF)$upper$bound, a = rep(-20, 3), r = r
   )
-  expect_equal(x, y)
+  expect_equal(x, as.data.frame(y))
   expect_equal(x$z[x$bound == "upper"], z$upper$bound)
   expect_equal(x$probability[x$bound == "upper"], cumsum(z$upper$prob))
 })


### PR DESCRIPTION
As discussed in group meeting, this PR optimizes the preparation of the return object by `gs_power_npe()`.

Sorry @yihui. I had prepared this yesterday afternoon, but didn't have time to submit the PR. Could we review/merge this targeted PR first, and then rebase your more comprehensive PR on top?

xref: #623 