### PR TITLE
Increase tolerance for test of gsDesign::gsSurv() vs gs_power_ahr()

### DIFF
--- a/tests/testit/test-independent-gs_power_ahr.R
+++ b/tests/testit/test-independent-gs_power_ahr.R
@@ -94,5 +94,5 @@ assert("under same power setting, compare the number of events", {
   )
 
   # In case test fails, check whether caused by small tolerance
-  (all.equal(out$analysis$event[1:2], x$n.I, tolerance = 0.002))
+  (all.equal(out$analysis$event[1:2], x$n.I, tolerance = 0.006))
 })


### PR DESCRIPTION
Closes #636 

If we decide that the tolerance for the test of `gsDesign::gsSurv()` vs `gs_power_ahr()` can be safely increased