### PR TITLE
Group all GitHub Actions updates into single Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "quarterly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add `groups` config to `.github/dependabot.yml`
- All GitHub Actions updates now batched into single PR instead of separate PRs per workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)