### PR TITLE
Ask CRAN to not test examples with running time > 5s

### DIFF
--- a/R/text_summary.R
+++ b/R/text_summary.R
@@ -30,6 +30,7 @@
 #' x <- gs_design_ahr(info_frac = 1:3/3, test_lower = FALSE) |> to_integer()
 #' x |> text_summary()
 #'
+#' \donttest{
 #' # Text summary of a 2-sided symmetric design
 #' x <- gs_design_ahr(info_frac = 1:3/3,
 #'                    upper = gs_spending_bound, lower = gs_spending_bound,
@@ -72,6 +73,7 @@
 #'   lpar = -Inf
 #' )
 #' x |> text_summary()
+#' }
 text_summary <- function(x, information = FALSE, time_unit = "months") {
 
   n_analysis <- nrow(x$analysis)

--- a/man/text_summary.Rd
+++ b/man/text_summary.Rd
@@ -26,6 +26,7 @@ library(gsDesign)
 x <- gs_design_ahr(info_frac = 1:3/3, test_lower = FALSE) |> to_integer()
 x |> text_summary()
 
+\donttest{
 # Text summary of a 2-sided symmetric design
 x <- gs_design_ahr(info_frac = 1:3/3,
                    upper = gs_spending_bound, lower = gs_spending_bound,
@@ -68,4 +69,5 @@ x <- gs_design_ahr(
   lpar = -Inf
 )
 x |> text_summary()
+}
 }


### PR DESCRIPTION
This PR is to fix the NOTE from CRAN when we submit gsDesign2 v1.2.0:
```
* checking examples ... [29s/25s] NOTE
Examples with CPU (user + system) or elapsed time > 5s
              user system elapsed
text_summary 5.241  0.036   3.576
```