### PR TITLE
Update gs_cp_npe1.R

### DIFF
--- a/R/gs_cp_npe1.R
+++ b/R/gs_cp_npe1.R
@@ -35,7 +35,7 @@
 #' @param info A vector of length two, which specifies the statistical information under the treatment effect `theta`.
 #' @param zi Numeric scalar z-value observed at analysis \eqn{i}.
 #' @param zj Numeric scalar at the future analysis \eqn{j}.
-#' @return A scalar with the conditional power \eqn{P(Z_j > z_i \mid Z_i = z_i)}.
+#' @return A scalar with the conditional power \eqn{P(Z_j > z_j \mid Z_i = z_i)}.
 #' @noRd
 #'
 #' @examples


### PR DESCRIPTION
Found a typo in the return value. The function returns P(Z_j > z_j | Z_i = z_i). This should avoid future confusion. The purpose of the function is unchanged, the return value documentation is just updated to reflect the what the function does.

This addresses #665. 