### PR TITLE
Assign a unique class to the output of gs_design/power_npe()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Development
+
+- The objects returned by `gs_design_npe()` and `gs_power_npe()` are now assigned a unique class.
+
 # gsDesign2 1.2.0
 
 ## Major changes

--- a/R/gs_design_npe.R
+++ b/R/gs_design_npe.R
@@ -302,6 +302,7 @@ gs_design_npe <- function(
           )
       )
       ans <- ans |> select(analysis, bound, z, probability, probability0, theta, info_frac, info, info0, info1)
+      class(ans) <- c("gs_design_npe", class(ans))
       return(ans)
     }
 
@@ -311,6 +312,7 @@ gs_design_npe <- function(
       info = info * min_x, info0 = info0 * min_x, info1 = info1 * min_x,
       info_frac = info / max(info)
     )
+    class(ans) <- c("gs_design_npe", class(ans))
     return(ans)
   }
 
@@ -444,5 +446,11 @@ gs_design_npe <- function(
   ans <- ans[order(ans$analysis, ans$bound != "upper"), c("analysis", "bound", "z", "probability", "probability0", "theta", "info_frac", "info", "info0", "info1")]
   rownames(ans) <- NULL
 
-  return(tibble::as_tibble(ans))
+  ans <- tibble::as_tibble(ans)
+  # Add class for dispatch with potential S3 methods. The output is too
+  # dissimilar to the other functions like gs_design_ahr() to use the class
+  # "gs_design"
+  class(ans) <- c("gs_design_npe", class(ans))
+
+  return(ans)
 }

--- a/R/gs_power_npe.R
+++ b/R/gs_power_npe.R
@@ -106,7 +106,11 @@
 #'   Normally, `r` will not be changed by the user.
 #' @param tol Tolerance parameter for boundary convergence (on Z-scale); normally not changed by the user.
 #'
-#' @return A tibble with columns of
+#' @return
+#'   `gs_design_npe()` returns a tibble with the class `"gs_design_npe"`.
+#'   `gs_power_npe()` returns a data frame with the class `"gs_power_npe"`.
+#'   The columns are described below:
+#'
 #'   - `analysis`: analysis index.
 #'   - `bound`: one of value `"upper"`, `"lower"`, or `"harm"`, indicating the upper, lower, and harm bound.
 #'   - `z`: the Z-score bounds.
@@ -294,7 +298,7 @@ gs_power_npe <- function(theta = .1, theta0 = 0, theta1 = theta, # 3 theta
   if (n_analysis == 1 && test_harm) {
     stop("gs_power_npe() harm bound cannot be tested if there is only one analysis.")
   }
-  
+
   theta  <- check_theta(theta,  n_analysis)
   theta0 <- check_theta(theta0, n_analysis)
   theta1 <- check_theta(theta1, n_analysis)
@@ -506,6 +510,11 @@ gs_power_npe <- function(theta = .1, theta0 = 0, theta1 = theta, # 3 theta
       info1 = rep(info1, 3)
     )
   }
+
+  # Add class for dispatch with potential S3 methods. The output is too
+  # dissimilar to the other functions like gs_power_ahr() to use the class
+  # "gs_design"
+  class(ans) <- c("gs_power_npe", class(ans))
 
   return(ans)
 }

--- a/man/gs_power_design_npe.Rd
+++ b/man/gs_power_design_npe.Rd
@@ -152,7 +152,9 @@ Normally, \code{r} will not be changed by the user.}
 \item{tol}{Tolerance parameter for boundary convergence (on Z-scale); normally not changed by the user.}
 }
 \value{
-A tibble with columns of
+\code{gs_design_npe()} returns a tibble with the class \code{"gs_design_npe"}.
+\code{gs_power_npe()} returns a data frame with the class \code{"gs_power_npe"}.
+The columns are described below:
 \itemize{
 \item \code{analysis}: analysis index.
 \item \code{bound}: one of value \code{"upper"}, \code{"lower"}, or \code{"harm"}, indicating the upper, lower, and harm bound.

--- a/tests/testit/test-developer-gs_design_npe.R
+++ b/tests/testit/test-developer-gs_design_npe.R
@@ -52,7 +52,7 @@ assert("examples in spec - Lachin book p71", {
   x2 <- gs_design_npe_(theta = pe - pc, info = info, info0 = info0) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (all.equal(x1_c, x2, check.attributes = FALSE))
+  (unclass(x1_c) %==% unclass(x2))
 })
 
 assert("fixed design with 3 equal info", {

--- a/tests/testit/test-developer-gs_design_npe.R
+++ b/tests/testit/test-developer-gs_design_npe.R
@@ -52,7 +52,7 @@ assert("examples in spec - Lachin book p71", {
   x2 <- gs_design_npe_(theta = pe - pc, info = info, info0 = info0) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (x1_c %==% x2)
+  (all.equal(x1_c, x2, check.attributes = FALSE))
 })
 
 assert("fixed design with 3 equal info", {
@@ -389,4 +389,22 @@ assert("Comparison with gsDesign when test.type = 3", {
       scale = 1
     ))
 
+})
+
+assert("gs_design_npe() output object is assigned a unique class", {
+  # fixed design
+  (inherits(gs_design_npe(), "gs_design_npe"))
+
+  # group sequential design
+  x <- gs_design_npe(
+    alpha = 0.0125,
+    theta = c(.1, .2, .3),
+    info = (1:3) * 80,
+    info0 = (1:3) * 80,
+    upper = gs_b,
+    upar = gsDesign::gsDesign(k = 3, sfu = gsDesign::sfLDOF, alpha = 0.0125)$upper$bound,
+    lower = gs_b,
+    lpar = c(-1, 0, 0)
+  )
+  (inherits(x, "gs_design_npe"))
 })

--- a/tests/testit/test-developer-gs_power_npe.R
+++ b/tests/testit/test-developer-gs_power_npe.R
@@ -6,7 +6,7 @@ assert("The default of `gs_power_npe` is a single analysis with type I error con
     dplyr::filter(Bound == "Upper") |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (all.equal(x1, x2, check.attributes = FALSE))
+  (unclass(x1) %==% unclass(x2))
 })
 
 assert("fixed bound", {
@@ -29,7 +29,7 @@ assert("fixed bound", {
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (all.equal(x1, x2, check.attributes = FALSE))
+  (unclass(x1) %==% unclass(x2))
 })
 
 assert("Same fixed efficacy bounds, no futility bound (i.e., non-binding bound), null hypothesis", {
@@ -48,7 +48,7 @@ assert("Same fixed efficacy bounds, no futility bound (i.e., non-binding bound),
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (all.equal(x1, x2, check.attributes = FALSE))
+  (unclass(x1) %==% unclass(x2))
 })
 
 assert("Fixed bound with futility only at analysis 1; efficacy only at analyses 2, 3", {
@@ -71,7 +71,7 @@ assert("Fixed bound with futility only at analysis 1; efficacy only at analyses 
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (all.equal(x1, x2, check.attributes = FALSE))
+  (unclass(x1) %==% unclass(x2))
 })
 
 assert("Spending function bounds - Lower spending based on non-zero effect", {
@@ -95,7 +95,7 @@ assert("Spending function bounds - Lower spending based on non-zero effect", {
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
   legacy_rows <- x1$analysis < 3 | x1$bound != "lower"
-  (all.equal(x1[legacy_rows, ], x2[legacy_rows, ], check.attributes = FALSE))
+  (unclass(x1[legacy_rows, ]) %==% unclass(x2[legacy_rows, ]))
   (x1$z[x1$analysis == 3 & x1$bound == "lower"] ==
     x1$z[x1$analysis == 3 & x1$bound == "upper"])
 })
@@ -121,7 +121,7 @@ assert("Same bounds, but power under different theta", {
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
   legacy_rows <- x1$analysis < 3 | x1$bound != "lower"
-  (all.equal(x1[legacy_rows, ], x2[legacy_rows, ], check.attributes = FALSE))
+  (unclass(x1[legacy_rows, ]) %==% unclass(x2[legacy_rows, ]))
   (x1$z[x1$analysis == 3 & x1$bound == "lower"] ==
     x1$z[x1$analysis == 3 & x1$bound == "upper"])
 })
@@ -148,7 +148,7 @@ assert("Two-sided symmetric spend, O'Brien-Fleming spending", {
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (all.equal(x1, x2, check.attributes = FALSE))
+  (unclass(x1) %==% unclass(x2))
 })
 
 assert("Re-use these bounds under alternate hypothesis - Always use binding = TRUE for power calculations", {
@@ -179,7 +179,7 @@ assert("Re-use these bounds under alternate hypothesis - Always use binding = TR
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (all.equal(x1, x2, check.attributes = FALSE))
+  (unclass(x1) %==% unclass(x2))
 })
 
 assert("info != info0 != info1 - If one inputs info in upar", {
@@ -212,7 +212,7 @@ assert("info != info0 != info1 - If one inputs info in upar", {
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (all.equal(x1_c, x2, check.attributes = FALSE))
+  (unclass(x1_c) %==% unclass(x2))
 })
 
 assert("Developer Tests 1-sided test", {
@@ -244,7 +244,7 @@ assert("Developer Tests 1-sided test", {
     n.I = (1:3) * 400,
     b = gsDesign::gsDesign(k = 3, test.type = 1, sfu = gsDesign::sfLDOF)$upper$bound, a = rep(-20, 3), r = r
   )
-  (all.equal(x, y, check.attributes = FALSE))
+  (unclass(x) %==% unclass(y))
   (x$z[x$bound == "upper"] %==% z$upper$bound)
   (all.equal(x$probability[x$bound == "upper"], cumsum(z$upper$prob), tolerance = 3e-8))
 })

--- a/tests/testit/test-developer-gs_power_npe.R
+++ b/tests/testit/test-developer-gs_power_npe.R
@@ -6,7 +6,7 @@ assert("The default of `gs_power_npe` is a single analysis with type I error con
     dplyr::filter(Bound == "Upper") |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (x1 %==% as.data.frame(x2))
+  (all.equal(x1, x2, check.attributes = FALSE))
 })
 
 assert("fixed bound", {
@@ -29,7 +29,7 @@ assert("fixed bound", {
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (x1 %==% as.data.frame(x2))
+  (all.equal(x1, x2, check.attributes = FALSE))
 })
 
 assert("Same fixed efficacy bounds, no futility bound (i.e., non-binding bound), null hypothesis", {
@@ -48,7 +48,7 @@ assert("Same fixed efficacy bounds, no futility bound (i.e., non-binding bound),
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (x1 %==% as.data.frame(x2))
+  (all.equal(x1, x2, check.attributes = FALSE))
 })
 
 assert("Fixed bound with futility only at analysis 1; efficacy only at analyses 2, 3", {
@@ -71,7 +71,7 @@ assert("Fixed bound with futility only at analysis 1; efficacy only at analyses 
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (x1 %==% as.data.frame(x2))
+  (all.equal(x1, x2, check.attributes = FALSE))
 })
 
 assert("Spending function bounds - Lower spending based on non-zero effect", {
@@ -95,7 +95,7 @@ assert("Spending function bounds - Lower spending based on non-zero effect", {
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
   legacy_rows <- x1$analysis < 3 | x1$bound != "lower"
-  (x1[legacy_rows, ] %==% as.data.frame(x2[legacy_rows, ]))
+  (all.equal(x1[legacy_rows, ], x2[legacy_rows, ], check.attributes = FALSE))
   (x1$z[x1$analysis == 3 & x1$bound == "lower"] ==
     x1$z[x1$analysis == 3 & x1$bound == "upper"])
 })
@@ -121,7 +121,7 @@ assert("Same bounds, but power under different theta", {
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
   legacy_rows <- x1$analysis < 3 | x1$bound != "lower"
-  (x1[legacy_rows, ] %==% as.data.frame(x2[legacy_rows, ]))
+  (all.equal(x1[legacy_rows, ], x2[legacy_rows, ], check.attributes = FALSE))
   (x1$z[x1$analysis == 3 & x1$bound == "lower"] ==
     x1$z[x1$analysis == 3 & x1$bound == "upper"])
 })
@@ -148,7 +148,7 @@ assert("Two-sided symmetric spend, O'Brien-Fleming spending", {
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (x1 %==% as.data.frame(x2))
+  (all.equal(x1, x2, check.attributes = FALSE))
 })
 
 assert("Re-use these bounds under alternate hypothesis - Always use binding = TRUE for power calculations", {
@@ -179,7 +179,7 @@ assert("Re-use these bounds under alternate hypothesis - Always use binding = TR
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (x1 %==% as.data.frame(x2))
+  (all.equal(x1, x2, check.attributes = FALSE))
 })
 
 assert("info != info0 != info1 - If one inputs info in upar", {
@@ -212,7 +212,7 @@ assert("info != info0 != info1 - If one inputs info in upar", {
   ) |>
     dplyr::rename(analysis = Analysis, bound = Bound, z = Z, probability = Probability) |>
     dplyr::mutate(bound = tolower(bound))
-  (x1_c %==% as.data.frame(x2))
+  (all.equal(x1_c, x2, check.attributes = FALSE))
 })
 
 assert("Developer Tests 1-sided test", {
@@ -244,7 +244,7 @@ assert("Developer Tests 1-sided test", {
     n.I = (1:3) * 400,
     b = gsDesign::gsDesign(k = 3, test.type = 1, sfu = gsDesign::sfLDOF)$upper$bound, a = rep(-20, 3), r = r
   )
-  (x %==% as.data.frame(y))
+  (all.equal(x, y, check.attributes = FALSE))
   (x$z[x$bound == "upper"] %==% z$upper$bound)
   (all.equal(x$probability[x$bound == "upper"], cumsum(z$upper$prob), tolerance = 3e-8))
 })
@@ -371,4 +371,8 @@ assert("Harm bound - Cap harm bound at futility bound", {
   futility_bound <- x |> dplyr::filter(bound == "lower", analysis %in% harm_analysis) |> dplyr::pull(z)
   (harm_bound <= futility_bound)
   (harm_analysis %==% 1:2)
+})
+
+assert("gs_power_npe() output object is assigned a unique class", {
+  (inherits(gs_power_npe(), "gs_power_npe"))
 })


### PR DESCRIPTION
Close #657 

As discussed in group meeting, the output of `gs_design_npe()` and `gs_power_npe()` is too dissimilar to the output of the other group sequential design functions (eg `gs_design_ahr()`) to be assigned the existing class "gs_design", so I assigned them each a unique class to facilitate downstream S3 method dispatch.

Note that the existing documentation does not document the columns `probability0` returned by `gs_design_npe()`

```R
colnames(gs_design_npe())
## [1] "analysis"     "bound"        "z"            "probability"  "probability0" "theta"       
## [7] "info"         "info0"        "info1"        "info_frac"   
colnames(gs_power_npe())
## [1] "analysis"    "bound"       "z"           "probability" "theta"       "theta1"      "info_frac"  
## [8] "info"        "info0"       "info1"      
```

xref: motivating Issue (https://github.com/keaven/gsDesignBroom/issues/2), abandoned attempt to reuse class `"gs_design"` (https://github.com/jdblischak/gsDesign2/commit/62ffdf7fb32237390863eaa9257596cba23ce6dd)